### PR TITLE
Add least-privilege permissions to workflows and disable publish-test…

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -19,6 +19,10 @@ permissions:
 
 jobs:
   release-build:
+    # Disabled: release/publish workflows are not permitted per the workflow
+    # security policy. Retained for future restoration pending a decision on
+    # how non-eng releases will be performed.
+    if: false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   # Detect which paths changed
   changes:


### PR DESCRIPTION
update workflow permission

- pylint.yml, tests.yml: declare `permissions: contents: read` at workflow level per least-privilege policy.
- publish-testpypi.yml: guard release-build job with `if: false`; release/publish workflows are not currently permitted. File retained for future restoration.

Co-authored-by: Isaac