### PR TITLE
Fix workflow branch triggers (pylint scope, generate-merged push branch)    

### DIFF
--- a/.github/workflows/generate-merged-source-file.yml
+++ b/.github/workflows/generate-merged-source-file.yml
@@ -11,7 +11,7 @@ on:
       - '!src/databricks/labs/community_connector/sources/**/test/**'
   push:
     branches:
-      - main
+      - master
     paths:
       - 'src/databricks/labs/community_connector/sources/**/*.py'
       - 'src/databricks/labs/community_connector/libs/utils.py'

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,10 @@
 name: Pylint
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 permissions:
   contents: read


### PR DESCRIPTION
Summary                                                                                                                                                                                                                                                                  
                                                            
  - pylint.yml — on: [push] (any branch) → push/pull_request scoped to master, matching tests.yml. Effect: external fork PRs are now linted (previously they weren't, since fork pushes don't trigger upstream workflows), and unrelated topic-branch pushes no longer     
  trigger redundant pylint runs.
  - generate-merged-source-file.yml — push: branches: [main] → branches: [master]. The push-side check on the default branch was silently dead because the trigger pointed at a non-existent branch; now it runs on merge into master.                                     
                                                                                                                                                                                                                                                                           
  No behavior change beyond trigger scope; permissions and runner config unchanged.

Co-authored-by: Isaac