### PR TITLE
  Fix CI on fork PRs by switching to pull_request_target                                                                                                           

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,10 +1,35 @@
 name: Pylint
 
+# Triggers and label gating for fork PRs:
+#   - push to master                          → always runs.
+#   - PR from databrickslabs/* (same repo)    → always runs (synchronize, opened, etc.).
+#   - PR from a fork                          → runs only when a maintainer
+#                                               adds the `safe-to-test` label,
+#                                               and only on that label event.
+#                                               A subsequent fork push (synchronize)
+#                                               intentionally does NOT re-run; the
+#                                               maintainer must remove and re-add
+#                                               the label after reviewing the new
+#                                               commits. This blocks the
+#                                               "approval extends to attacker's
+#                                               next push" attack on
+#                                               pull_request_target.
 on:
   push:
     branches: [master]
-  pull_request:
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - 'requirements/**'
+      - '.github/workflows/pylint.yml'
+  pull_request_target:
     branches: [master]
+    types: [labeled, synchronize, opened, reopened]
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - 'requirements/**'
+      - '.github/workflows/pylint.yml'
 
 permissions:
   contents: read
@@ -12,6 +37,10 @@ permissions:
 
 jobs:
   build:
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test')
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
@@ -20,6 +49,11 @@ jobs:
         python-version: ["3.10"]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        # pull_request_target defaults to checking out the base ref; we want
+        # to lint the PR's actual code. For push/same-repo events the empty
+        # fallback resolves to the workflow ref.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,19 +1,15 @@
 name: Pylint
 
-# Triggers and label gating for fork PRs:
-#   - push to master                          → always runs.
-#   - PR from databrickslabs/* (same repo)    → always runs (synchronize, opened, etc.).
-#   - PR from a fork                          → runs only when a maintainer
-#                                               adds the `safe-to-test` label,
-#                                               and only on that label event.
-#                                               A subsequent fork push (synchronize)
-#                                               intentionally does NOT re-run; the
-#                                               maintainer must remove and re-add
-#                                               the label after reviewing the new
-#                                               commits. This blocks the
-#                                               "approval extends to attacker's
-#                                               next push" attack on
-#                                               pull_request_target.
+# pull_request_target (instead of pull_request) is required so fork-PR
+# runs receive the OIDC token that configure-jfrog-pypi exchanges for a
+# JFrog Artifactory access token. With pull_request the fork's run gets
+# no OIDC, and the action fails with ACTIONS_ID_TOKEN_REQUEST_TOKEN
+# unbound.
+#
+# Untrusted code from fork PRs is gated by the repo's "Require approval
+# for outside collaborators" setting — fork-PR workflow runs are pending
+# until a maintainer explicitly approves them. The explicit head-SHA
+# checkout below is what actually exercises the PR's code.
 on:
   push:
     branches: [master]
@@ -24,7 +20,6 @@ on:
       - '.github/workflows/pylint.yml'
   pull_request_target:
     branches: [master]
-    types: [labeled, synchronize, opened, reopened]
     paths:
       - '**/*.py'
       - 'pyproject.toml'
@@ -37,10 +32,6 @@ permissions:
 
 jobs:
   build:
-    if: |
-      github.event_name == 'push' ||
-      github.event.pull_request.head.repo.full_name == github.repository ||
-      (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test')
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,11 @@
 name: Tests
 
-# Triggers: see fork-PR label-gating note in .github/workflows/pylint.yml.
+# Triggers: see pull_request_target rationale in .github/workflows/pylint.yml.
 on:
   push:
     branches: [master]
   pull_request_target:
     branches: [master]
-    types: [labeled, synchronize, opened, reopened]
 
 permissions:
   contents: read
@@ -15,10 +14,6 @@ permissions:
 jobs:
   # Detect which paths changed
   changes:
-    if: |
-      github.event_name == 'push' ||
-      github.event.pull_request.head.repo.full_name == github.repository ||
-      (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test')
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,12 @@
 name: Tests
 
+# Triggers: see fork-PR label-gating note in .github/workflows/pylint.yml.
 on:
   push:
     branches: [master]
-  pull_request:
+  pull_request_target:
     branches: [master]
+    types: [labeled, synchronize, opened, reopened]
 
 permissions:
   contents: read
@@ -13,6 +15,10 @@ permissions:
 jobs:
   # Detect which paths changed
   changes:
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test')
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
@@ -28,10 +34,11 @@ jobs:
       # - uses: dorny/paths-filter@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Check changed paths
         id: check
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
             BASE_SHA="${{ github.event.pull_request.base.sha }}"
             HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           else
@@ -151,6 +158,8 @@ jobs:
         python-version: ["3.10"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
@@ -182,6 +191,8 @@ jobs:
         python-version: ["3.10"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
@@ -213,6 +224,8 @@ jobs:
         python-version: ["3.10"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
@@ -244,6 +257,8 @@ jobs:
         python-version: ["3.10"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
@@ -277,6 +292,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python 3.10
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:

--- a/.github/workflows/verify-locks.yml
+++ b/.github/workflows/verify-locks.yml
@@ -4,8 +4,10 @@ name: Verify Dependency Locks
 # from a fresh regeneration. Enforces the internal guidance's "strongly
 # recommended" assertion that running uv pip compile produces no diff.
 
+# Triggers: see fork-PR label-gating note in .github/workflows/pylint.yml.
 on:
-  pull_request:
+  pull_request_target:
+    types: [labeled, synchronize, opened, reopened]
     paths:
       - 'pyproject.toml'
       - 'tools/community_connector/pyproject.toml'
@@ -28,11 +30,17 @@ permissions:
 
 jobs:
   verify:
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test')
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup uv
         uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3

--- a/.github/workflows/verify-locks.yml
+++ b/.github/workflows/verify-locks.yml
@@ -4,10 +4,9 @@ name: Verify Dependency Locks
 # from a fresh regeneration. Enforces the internal guidance's "strongly
 # recommended" assertion that running uv pip compile produces no diff.
 
-# Triggers: see fork-PR label-gating note in .github/workflows/pylint.yml.
+# Triggers: see pull_request_target rationale in .github/workflows/pylint.yml.
 on:
   pull_request_target:
-    types: [labeled, synchronize, opened, reopened]
     paths:
       - 'pyproject.toml'
       - 'tools/community_connector/pyproject.toml'
@@ -30,10 +29,6 @@ permissions:
 
 jobs:
   verify:
-    if: |
-      github.event_name == 'push' ||
-      github.event.pull_request.head.repo.full_name == github.repository ||
-      (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test')
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,11 @@
 We happily welcome contributions to Lakeflow-Community-Connectors. We use GitHub Issues to track community reported issues and GitHub Pull Requests for accepting changes.
+
+## CI on pull requests from forks
+
+CI for this repo runs on hardened runners that exchange a per-job OIDC token for a JFrog Artifactory access token. GitHub does not issue OIDC tokens to `pull_request` events from forks, so PRs opened from a fork need an explicit maintainer approval to run CI:
+
+1. A maintainer reviews the PR's diff (including any change under `requirements/` or `pyproject.toml`).
+2. The maintainer adds the `safe-to-test` label. CI runs against the labeled commit.
+3. If the contributor pushes new commits, CI does **not** auto-rerun. The maintainer reviews the new commits, removes `safe-to-test`, then re-adds it to retrigger CI.
+
+This explicit toggle is intentional: it ensures every set of commits that runs against the privileged runner is reviewed by a maintainer first. Internal contributors pushing branches inside `databrickslabs/lakeflow-community-connectors` are not affected — their PRs run CI automatically on every push.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,8 @@ We happily welcome contributions to Lakeflow-Community-Connectors. We use GitHub
 
 ## CI on pull requests from forks
 
-CI for this repo runs on hardened runners that exchange a per-job OIDC token for a JFrog Artifactory access token. GitHub does not issue OIDC tokens to `pull_request` events from forks, so PRs opened from a fork need an explicit maintainer approval to run CI:
+CI for this repo runs on hardened runners that exchange a per-job OIDC token for a JFrog Artifactory access token. To make this work for fork PRs, the workflows are triggered with `pull_request_target` and explicitly check out the PR's head commit.
 
-1. A maintainer reviews the PR's diff (including any change under `requirements/` or `pyproject.toml`).
-2. The maintainer adds the `safe-to-test` label. CI runs against the labeled commit.
-3. If the contributor pushes new commits, CI does **not** auto-rerun. The maintainer reviews the new commits, removes `safe-to-test`, then re-adds it to retrigger CI.
+Workflow runs from outside collaborators are held pending until a maintainer approves them ("Require approval for outside collaborators" is enabled in the repo settings). Maintainers should review the diff — including any change under `requirements/`, `pyproject.toml`, or workflow files — before approving, since approved runs execute the PR's code with secrets available.
 
-This explicit toggle is intentional: it ensures every set of commits that runs against the privileged runner is reviewed by a maintainer first. Internal contributors pushing branches inside `databrickslabs/lakeflow-community-connectors` are not affected — their PRs run CI automatically on every push.
+Internal contributors pushing branches inside `databrickslabs/lakeflow-community-connectors` are not affected — their PRs run CI automatically on every push.


### PR DESCRIPTION
 ## Summary                                                

  Fork PRs currently fail at `configure-jfrog-pypi` with `ACTIONS_ID_TOKEN_REQUEST_TOKEN: unbound variable` because GitHub does not issue OIDC tokens to `pull_request` events from forks. This blocks any external contribution from getting CI feedback.

Switch the affected workflows from `pull_request` to `pull_request_target`, which runs in base-repo context and receives the OIDC token. Add an explicit head-SHA checkout to each job so we still test the PR's actual code (otherwise `pull_request_target` checks out base).
                                                                                                                                                                   
Untrusted fork code is gated by the repo's existing "Require approval for outside collaborators" setting — fork-PR workflow runs are pending until a maintainer approves.
                                                                                                                                                                   
  ## Changes                                                

  - **`.github/workflows/pylint.yml`**, **`.github/workflows/tests.yml`**, **`.github/workflows/verify-locks.yml`** — `pull_request` → `pull_request_target`; `ref:${{ github.event.pull_request.head.sha }}` added to every `actions/checkout` step.
  - **`pylint.yml`** also gains path filters (`**/*.py`, `pyproject.toml`, `requirements/**`, the workflow itself) so doc-only PRs no longer trigger it. The other two workflows already had appropriate path filters.                                                                                                              
  - **`CONTRIBUTING.md`** — brief section explaining the fork-PR approval flow.