### PR TITLE
Add column-coverage invariant to LakeflowConnectTests harness

### DIFF
--- a/src/databricks/labs/community_connector/source_simulator/specs/sap_successfactors/corpus/Attachment.json
+++ b/src/databricks/labs/community_connector/source_simulator/specs/sap_successfactors/corpus/Attachment.json
@@ -9,7 +9,7 @@
     "documentEntityId": "delta-755",
     "documentEntityType": "yankee-781",
     "documentType": "uniform-334",
-    "fileContent": null,
+    "fileContent": "aGVsbG8gd29ybGQ=",
     "fileExtension": "india-997",
     "fileName": "victor-476",
     "fileSize": 66696,

--- a/src/databricks/labs/community_connector/source_simulator/specs/sap_successfactors/corpus/Photo.json
+++ b/src/databricks/labs/community_connector/source_simulator/specs/sap_successfactors/corpus/Photo.json
@@ -7,7 +7,7 @@
     "lastModified": "oscar-525",
     "lastModifiedDateTime": "lima-606",
     "mimeType": "foxtrot-804",
-    "photo": null,
+    "photo": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
     "photoName": "kilo-572",
     "width": 19694
   },

--- a/tests/unit/sources/sap_successfactors/test_sap_successfactors_lakeflow_connect.py
+++ b/tests/unit/sources/sap_successfactors/test_sap_successfactors_lakeflow_connect.py
@@ -29,6 +29,17 @@ class TestSapSuccessFactorsConnector(LakeflowConnectTests):
         "password": "simulator-fake-password",
     }
 
+    # ``password`` is declared in these schemas for write-back / round-trip
+    # compatibility, but the SuccessFactors OData API never returns it in
+    # read responses (security-sensitive field). No corpus record can ever
+    # exercise the column, so it is exempt from the column-coverage check.
+    allow_null_columns = {
+        "Candidate": {"password"},
+        "CandidateLight": {"password"},
+        "ExternalUser": {"password"},
+        "User": {"password"},
+    }
+
     def test_read_table(self):
         """Same as the harness contract, but skips the snake_case shadow tables
         whose schemas are incompatible with their PascalCase siblings."""
@@ -43,6 +54,22 @@ class TestSapSuccessFactorsConnector(LakeflowConnectTests):
             err = self._validate_read(
                 table, self.connector.read_table, "read_table", is_read_table=True
             )
+            if err:
+                errors.append(err)
+        if errors:
+            pytest.fail("\n\n".join(errors))
+
+    def test_every_column_populated_by_at_least_one_record(self):
+        """Same as the harness contract, but skips the incompatible shadow tables."""
+        tables = [
+            t for t in self._non_partitioned_tables()
+            if t not in _INCOMPATIBLE_SHADOW_TABLES
+        ]
+        if not tables:
+            pytest.skip("All tables use partitioned reads")
+        errors = []
+        for table in tables:
+            err = self._validate_column_population(table)
             if err:
                 errors.append(err)
         if errors:

--- a/tests/unit/sources/test_partition_suite.py
+++ b/tests/unit/sources/test_partition_suite.py
@@ -23,6 +23,9 @@ from databricks.labs.community_connector.interface.supports_partition import (
     SupportsPartitionedStream,
 )
 from databricks.labs.community_connector.libs.utils import parse_value
+from databricks.labs.community_connector.source_simulator import MODE_SIMULATE
+
+from tests.unit.sources.test_suite import _resolve_env_mode_for_simulator
 
 
 class SupportsPartitionTests:
@@ -219,6 +222,85 @@ class SupportsPartitionTests:
             )
 
         return None
+
+    # ------------------------------------------------------------------
+    # test_every_column_populated_by_at_least_one_partition_record
+    # ------------------------------------------------------------------
+
+    def test_every_column_populated_by_at_least_one_partition_record(self):
+        """Partition-side mirror of
+        ``LakeflowConnectTests.test_every_column_populated_by_at_least_one_record``.
+
+        For every column the connector advertises in ``get_table_schema``,
+        at least one record returned across ``read_partition`` calls must
+        be non-null. Honors ``allow_null_columns`` on the host test class.
+        Simulate mode only — see the non-partitioned twin for the rationale.
+        """
+        tables = self._partitioned_tables()
+        if not tables:
+            pytest.skip("No partitioned tables")
+        if _resolve_env_mode_for_simulator(self.simulator_source) != MODE_SIMULATE:
+            pytest.skip("Column-coverage invariant only enforced in simulate mode")
+        errors = []
+        for table in tables:
+            err = self._validate_column_population_partitioned(table)
+            if err:
+                errors.append(err)
+        if errors:
+            pytest.fail("\n\n".join(errors))
+
+    def _validate_column_population_partitioned(self, table: str) -> Optional[str]:
+        """Returns error string or None.
+
+        Mirrors ``_validate_column_population`` on the non-partitioned path
+        but consumes records from ``get_partitions`` + ``read_partition``,
+        capped at ``sample_records`` total across all partitions. Top-level
+        columns only.
+        """
+        try:
+            schema = self.connector.get_table_schema(table, self._opts(table))
+        except Exception:
+            # test_get_table_schema will surface the underlying error.
+            return None
+
+        try:
+            partitions = self.connector.get_partitions(table, self._opts(table))
+        except Exception:
+            # test_get_partitions will surface the underlying error.
+            return None
+        if not partitions:
+            # test_read_partition reports the empty-partitions case.
+            return None
+
+        records: List[dict] = []
+        budget = self.sample_records
+        for partition in partitions:
+            if budget <= 0:
+                break
+            try:
+                iterator = self.connector.read_partition(
+                    table, partition, self._opts(table)
+                )
+            except Exception:
+                return None
+            if not hasattr(iterator, "__iter__"):
+                return None
+            try:
+                for rec in iterator:
+                    if not isinstance(rec, dict):
+                        continue
+                    records.append(rec)
+                    if len(records) >= self.sample_records:
+                        break
+            except Exception:
+                return None
+            budget = self.sample_records - len(records)
+
+        if not records:
+            # test_read_partition reports the zero-records case.
+            return None
+
+        return self._check_column_population(table, schema, records)
 
     def _validate_partition_records(
         self, table: str, partition_idx: int, records: list, schema: StructType

--- a/tests/unit/sources/test_suite.py
+++ b/tests/unit/sources/test_suite.py
@@ -133,6 +133,16 @@ class LakeflowConnectTests:
     # mismatch is a known fixture limitation, not a connector bug.
     allow_empty_first_read: frozenset = frozenset()
 
+    # Per-table allow-list of declared columns that are exempt from
+    # ``test_every_column_populated_by_at_least_one_record``. Use only for
+    # columns the source API genuinely never returns (e.g. password / secret
+    # fields suppressed for security), where no corpus record can ever
+    # exercise them. Document the reason in a comment alongside each entry.
+    # Prefer expanding the corpus or trimming the schema over adding to this
+    # list — the goal of the invariant is to surface schema/corpus drift.
+    # Format: {"table_name": {"column_a", "column_b"}}.
+    allow_null_columns: Dict[str, set] = {}
+
     # ------------------------------------------------------------------
     # Setup
     # ------------------------------------------------------------------
@@ -722,6 +732,101 @@ class LakeflowConnectTests:
             "  Fix: read_table() must eventually return the same offset it "
             "was given. Trigger.AvailableNow termination depends on this."
         )
+
+    # ------------------------------------------------------------------
+    # test_every_column_populated_by_at_least_one_record  (per-table, collected)
+    # ------------------------------------------------------------------
+
+    def test_every_column_populated_by_at_least_one_record(self):
+        """Every declared column is non-null in at least one sampled record.
+
+        Catches schema/flatten/corpus drift where the connector advertises a
+        column but the read path never produces a non-null value for it. The
+        existing per-record ``_all_null`` check only fires when *every* column
+        on a single record is null; this catches the partial form where base
+        / metadata columns populate but typed / flattened columns don't —
+        e.g. corpus records are shaped for a different schema version than
+        the connector's flatten layer expects.
+
+        Simulate mode only: in live mode, a real source may legitimately
+        return records with all-null columns in a small sample, and the
+        invariant becomes flaky. The simulator corpus is fixed, so failure
+        here is a real bug to fix in the connector or the corpus.
+        """
+        tables = self._non_partitioned_tables()
+        if not tables:
+            pytest.skip("All tables use partitioned reads")
+        if _resolve_env_mode_for_simulator(self.simulator_source) != MODE_SIMULATE:
+            pytest.skip("Column-coverage invariant only enforced in simulate mode")
+        errors = []
+        for table in tables:
+            err = self._validate_column_population(table)
+            if err:
+                errors.append(err)
+        if errors:
+            pytest.fail("\n\n".join(errors))
+
+    def _validate_column_population(self, table: str) -> Optional[str]:
+        """Returns error string or None.
+
+        Top-level columns only — nested struct sub-fields are intentionally
+        not recursed into, to avoid false positives where nested fields are
+        legitimately sparse across a small sample.
+        """
+        try:
+            schema = self.connector.get_table_schema(table, self._opts(table))
+        except Exception as e:
+            return f"[{table}] get_table_schema raised during column-population check: {e}"
+
+        try:
+            result = self.connector.read_table(table, {}, self._opts(table))
+        except Exception:
+            # test_read_table will surface the underlying error; don't
+            # double-report it from this check.
+            return None
+        if not isinstance(result, tuple) or len(result) != 2:
+            return None
+        iterator, _ = result
+        if not hasattr(iterator, "__iter__"):
+            return None
+
+        try:
+            records = self._consume(iterator)
+        except Exception:
+            return None
+
+        if not records:
+            # Empty first read is already validated by test_read_table.
+            return None
+
+        populated: set = set()
+        for rec in records:
+            if not isinstance(rec, dict):
+                continue
+            for field in schema.fields:
+                if field.name in populated:
+                    continue
+                if rec.get(field.name) is not None:
+                    populated.add(field.name)
+
+        allowed = set(self.allow_null_columns.get(table, ()))
+        missing = [
+            f.name for f in schema.fields
+            if f.name not in populated and f.name not in allowed
+        ]
+        if missing:
+            return (
+                f"[{table}] Columns null in every sampled record "
+                f"(checked {len(records)} record(s)): {missing}\n"
+                "  Fix: the connector advertises these columns but the read "
+                "path produces no record where they are non-null. Likely causes:\n"
+                "    - corpus records have a different shape than the schema "
+                "(wrong kind, wrong API version)\n"
+                "    - flatten / projection logic looks up wrong field names\n"
+                "    - corpus simply lacks coverage for these columns "
+                "(add a record that populates them)"
+            )
+        return None
 
     # ------------------------------------------------------------------
     # Shared read-validation helper

--- a/tests/unit/sources/test_suite.py
+++ b/tests/unit/sources/test_suite.py
@@ -799,6 +799,17 @@ class LakeflowConnectTests:
             # Empty first read is already validated by test_read_table.
             return None
 
+        return self._check_column_population(table, schema, records)
+
+    def _check_column_population(
+        self, table: str, schema: StructType, records: List[dict]
+    ) -> Optional[str]:
+        """Pure check: given a collected records list, report missing columns.
+
+        Shared between the non-partitioned ``read_table`` path and the
+        partitioned ``read_partition`` path (the partition mixin imports
+        this method off the host class via ``self``).
+        """
         populated: set = set()
         for rec in records:
             if not isinstance(rec, dict):


### PR DESCRIPTION
## Summary

Adds a column-coverage invariant to the connector test harness: for every column declared in `get_table_schema()`, at least one record returned by the read path in simulate mode must have that column non-null. Implemented as two parallel tests, one on each read path:

- `LakeflowConnectTests.test_every_column_populated_by_at_least_one_record` — covers `read_table` for non-partitioned tables.
- `SupportsPartitionTests.test_every_column_populated_by_at_least_one_partition_record` — covers `get_partitions` + `read_partition` for partitioned tables.

Both share a `_check_column_population(table, schema, records)` helper on `LakeflowConnectTests` so the missing-column computation, error formatting, and `allow_null_columns` handling live in one place.

Catches a class of bug the existing per-record `_all_null` check misses: when typed / flattened columns are uniformly null but base / metadata columns populate, no single record is "all null" and the existing check doesn't fire. Concrete example on an in-flight ADME PR — the simulator corpus declared records of one OSDU `kind` while the connector's flatten layer projected fields from a different `kind`; every typed column came out null, all 22 existing tests still passed.

## Allow-list

New per-class `allow_null_columns: dict[str, set[str]]` attribute for columns the source API genuinely never returns (e.g. `password` fields suppressed for security). Pre-populated for the four `SapSuccessFactorsLakeflowConnect` tables that declare `password`. **Use only for "API physically cannot return this field" cases** — corpus gaps and state-conditional columns should be addressed by expanding the corpus or trimming the schema, not by allow-listing.

## SAP SuccessFactors corpus fix

Two records in `corpus/Attachment.json` and `corpus/Photo.json` had `fileContent` / `photo` declared as keys with literal `null` values across every record. The API does return these fields in detail responses, so allow-listing was the wrong call. Seeded one record per file with a base64 placeholder (1-byte `"hello world"` / 1×1 transparent PNG). Brings SAP back to passing under strict gating.

## Known failures (follow-up work per source owner)

7 source suites still fail the new checks under strict gating. Each represents either a real bug or a corpus gap a source owner should address:

| Source | Path | Failing tables | Notes |
|---|---|---|---|
| dicomweb | partition | `studies` | 5 DICOM tags missing from corpus (`accession_number`, `study_description`, `modalities_in_study`, `number_of_study_related_series`, `number_of_study_related_instances`) |
| fhir | non-partitioned | `Patient` | 11 cols — corpus has no deceased / active variants |
| github | non-partitioned | `repositories` | 8 cols — corpus needs a mirror repo, a template repo, and merge-policy fields |
| gmail | non-partitioned | `labels` | 3 cols — corpus needs a user-created label with color |
| hubspot | non-partitioned | `contacts` | `properties` always null — likely a real bug (whole payload missing) |
| qualtrics | non-partitioned | `mailing_lists` | `creation_date`, `last_modified_date` missing from corpus |
| shopify | non-partitioned | `customers`, `products`, `orders` | corpus lacks cancelled order, order with addresses, custom-template product |

Source suites that pass: appsflyer, azure_devops, google_analytics_aggregated, google_sheets_docs, microsoft_teams, mixpanel, osipi, sap_successfactors, surveymonkey, zendesk, zoho_crm. The `TestDICOMwebConnectorMocked` class skips both new tests because it uses fixture JSON rather than the simulator framework.

## Test plan

- [x] `pytest tests/unit/sources -k test_every_column_populated` → 12 pass, 7 fail (matches table above), 3 skip
- [x] `pytest tests/unit/sources` → 669 pass, 49 skip, 7 fail (only the two new tests fail; no regressions in existing tests)