### PR TITLE
Emit tableName from _community_tables for consistency

### DIFF
--- a/src/databricks/labs/community_connector/interface/README.md
+++ b/src/databricks/labs/community_connector/interface/README.md
@@ -48,7 +48,7 @@ spark.read.format("lakeflow_connect")
 # API to list tables in one namespace
 # Schema:
 #   namespace ARRAY<STRING>,
-#   table_name STRING
+#   tableName STRING
 # For connectors that implement SupportsNamespaces, the `namespace` option is required.
 # Use "[]" for root-level tables. Walk the tree via _community_namespaces to find namespaces.
 # Flat connectors (no SupportsNamespaces) ignore the option and return every table with an empty namespace.

--- a/src/databricks/labs/community_connector/sources/appsflyer/_generated_appsflyer_python_source.py
+++ b/src/databricks/labs/community_connector/sources/appsflyer/_generated_appsflyer_python_source.py
@@ -1491,7 +1491,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -1504,7 +1504,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -1556,7 +1556,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/azure_devops/_generated_azure_devops_python_source.py
+++ b/src/databricks/labs/community_connector/sources/azure_devops/_generated_azure_devops_python_source.py
@@ -2568,7 +2568,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -2581,7 +2581,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -2633,7 +2633,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/dicomweb/_generated_dicomweb_python_source.py
+++ b/src/databricks/labs/community_connector/sources/dicomweb/_generated_dicomweb_python_source.py
@@ -2141,7 +2141,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -2154,7 +2154,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -2206,7 +2206,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/example/_generated_example_python_source.py
+++ b/src/databricks/labs/community_connector/sources/example/_generated_example_python_source.py
@@ -1318,7 +1318,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -1331,7 +1331,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -1383,7 +1383,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/fhir/_generated_fhir_python_source.py
+++ b/src/databricks/labs/community_connector/sources/fhir/_generated_fhir_python_source.py
@@ -2849,7 +2849,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -2862,7 +2862,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -2914,7 +2914,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/github/_generated_github_python_source.py
+++ b/src/databricks/labs/community_connector/sources/github/_generated_github_python_source.py
@@ -2341,7 +2341,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -2354,7 +2354,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -2406,7 +2406,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
+++ b/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
@@ -2034,7 +2034,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -2047,7 +2047,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -2099,7 +2099,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/google_analytics_aggregated/_generated_google_analytics_aggregated_python_source.py
+++ b/src/databricks/labs/community_connector/sources/google_analytics_aggregated/_generated_google_analytics_aggregated_python_source.py
@@ -1759,7 +1759,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -1772,7 +1772,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -1824,7 +1824,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/google_sheets_docs/_generated_google_sheets_docs_python_source.py
+++ b/src/databricks/labs/community_connector/sources/google_sheets_docs/_generated_google_sheets_docs_python_source.py
@@ -1475,7 +1475,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -1488,7 +1488,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -1540,7 +1540,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
+++ b/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
@@ -1564,7 +1564,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -1577,7 +1577,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -1629,7 +1629,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/microsoft_teams/_generated_microsoft_teams_python_source.py
+++ b/src/databricks/labs/community_connector/sources/microsoft_teams/_generated_microsoft_teams_python_source.py
@@ -2259,7 +2259,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -2272,7 +2272,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -2324,7 +2324,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/mixpanel/_generated_mixpanel_python_source.py
+++ b/src/databricks/labs/community_connector/sources/mixpanel/_generated_mixpanel_python_source.py
@@ -1531,7 +1531,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -1544,7 +1544,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -1596,7 +1596,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/osipi/_generated_osipi_python_source.py
+++ b/src/databricks/labs/community_connector/sources/osipi/_generated_osipi_python_source.py
@@ -4382,7 +4382,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -4395,7 +4395,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -4447,7 +4447,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/qualtrics/_generated_qualtrics_python_source.py
+++ b/src/databricks/labs/community_connector/sources/qualtrics/_generated_qualtrics_python_source.py
@@ -2579,7 +2579,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -2592,7 +2592,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -2644,7 +2644,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/sap_successfactors/_generated_sap_successfactors_python_source.py
+++ b/src/databricks/labs/community_connector/sources/sap_successfactors/_generated_sap_successfactors_python_source.py
@@ -8122,7 +8122,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -8135,7 +8135,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -8187,7 +8187,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/shopify/_generated_shopify_python_source.py
+++ b/src/databricks/labs/community_connector/sources/shopify/_generated_shopify_python_source.py
@@ -1836,7 +1836,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -1849,7 +1849,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -1901,7 +1901,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/surveymonkey/_generated_surveymonkey_python_source.py
+++ b/src/databricks/labs/community_connector/sources/surveymonkey/_generated_surveymonkey_python_source.py
@@ -2301,7 +2301,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -2314,7 +2314,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -2366,7 +2366,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/zendesk/_generated_zendesk_python_source.py
+++ b/src/databricks/labs/community_connector/sources/zendesk/_generated_zendesk_python_source.py
@@ -1361,7 +1361,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -1374,7 +1374,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -1426,7 +1426,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sources/zoho_crm/_generated_zoho_crm_python_source.py
+++ b/src/databricks/labs/community_connector/sources/zoho_crm/_generated_zoho_crm_python_source.py
@@ -2397,7 +2397,7 @@ def register_lakeflow_source(spark):
                 )
                 tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
                 return [
-                    {"namespace": namespace, "table_name": tn}
+                    {"namespace": namespace, TABLE_NAME: tn}
                     for tn in sorted(tables)
                 ]
             # Flat connector path. Reject a stray `namespace` option — the
@@ -2410,7 +2410,7 @@ def register_lakeflow_source(spark):
                     f"or use a namespace-aware connector."
                 )
             return [
-                {"namespace": [], "table_name": tn}
+                {"namespace": [], TABLE_NAME: tn}
                 for tn in sorted(self.lakeflow_connect.list_tables())
             ]
 
@@ -2462,7 +2462,7 @@ def register_lakeflow_source(spark):
                 return StructType(
                     [
                         StructField("namespace", ArrayType(StringType()), False),
-                        StructField("table_name", StringType(), False),
+                        StructField(TABLE_NAME, StringType(), False),
                     ]
                 )
             return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/src/databricks/labs/community_connector/sparkpds/lakeflow_datasource.py
+++ b/src/databricks/labs/community_connector/sparkpds/lakeflow_datasource.py
@@ -294,7 +294,7 @@ class LakeflowBatchReader(DataSourceReader):
             )
             tables = self.lakeflow_connect.list_tables_in_namespace(namespace)
             return [
-                {"namespace": namespace, "table_name": tn}
+                {"namespace": namespace, TABLE_NAME: tn}
                 for tn in sorted(tables)
             ]
         # Flat connector path. Reject a stray `namespace` option — the
@@ -307,7 +307,7 @@ class LakeflowBatchReader(DataSourceReader):
                 f"or use a namespace-aware connector."
             )
         return [
-            {"namespace": [], "table_name": tn}
+            {"namespace": [], TABLE_NAME: tn}
             for tn in sorted(self.lakeflow_connect.list_tables())
         ]
 
@@ -359,7 +359,7 @@ class LakeflowSource(DataSource):
             return StructType(
                 [
                     StructField("namespace", ArrayType(StringType()), False),
-                    StructField("table_name", StringType(), False),
+                    StructField(TABLE_NAME, StringType(), False),
                 ]
             )
         return self.lakeflow_connect.get_table_schema(table, self.options)

--- a/tests/unit/test_sparkpds_virtual_tables.py
+++ b/tests/unit/test_sparkpds_virtual_tables.py
@@ -122,7 +122,7 @@ def test_community_tables_schema():
     assert schema == StructType(
         [
             StructField("namespace", ArrayType(StringType()), False),
-            StructField("table_name", StringType(), False),
+            StructField("tableName", StringType(), False),
         ]
     )
 
@@ -162,8 +162,8 @@ def test_tables_flat_connector_uses_list_tables_with_empty_namespace():
     """Flat connectors ignore the `namespace` option and report every table at root."""
     reader = _reader(_FlatConnector({}), TABLES_TABLE)
     assert reader._read_tables() == [
-        {"namespace": [], "table_name": "t1"},
-        {"namespace": [], "table_name": "t2"},
+        {"namespace": [], "tableName": "t1"},
+        {"namespace": [], "tableName": "t2"},
     ]
 
 
@@ -182,7 +182,7 @@ def test_tables_namespaced_root_only_with_empty_namespace():
         **{NAMESPACE: json.dumps([])},
     )
     assert reader._read_tables() == [
-        {"namespace": [], "table_name": "global_settings"},
+        {"namespace": [], "tableName": "global_settings"},
     ]
 
 
@@ -193,7 +193,7 @@ def test_tables_namespaced_specific_namespace():
         **{NAMESPACE: json.dumps(["orgA", "repo1"])},
     )
     assert reader._read_tables() == [
-        {"namespace": ["orgA", "repo1"], "table_name": "issues"},
+        {"namespace": ["orgA", "repo1"], "tableName": "issues"},
     ]
 
 
@@ -215,8 +215,8 @@ def test_tables_namespaced_sorts_table_names():
     )
     # Fixture returns ["users", "settings"]; framework sorts → ["settings", "users"].
     assert reader._read_tables() == [
-        {"namespace": ["orgB"], "table_name": "settings"},
-        {"namespace": ["orgB"], "table_name": "users"},
+        {"namespace": ["orgB"], "tableName": "settings"},
+        {"namespace": ["orgB"], "tableName": "users"},
     ]
 
 


### PR DESCRIPTION
## Summary

- The two framework virtual tables previously disagreed on the casing of their identifier column: `_community_table_metadata` emitted `tableName` (camelCase) while `_community_tables` emitted `table_name` (snake_case). Callers had to remember which convention applies per table, and a typo only surfaces as a runtime `IllegalArgumentException("Field tableName does not exist")` — no compile error.
- Renames the `_community_tables` identifier column to `tableName` via the shared `TABLE_NAME` constant, so the two virtual tables stay aligned. Doc and tests updated accordingly.
- Scope is intentionally minimal: the snake_case fields inside `_community_table_metadata` (`primary_keys`, `cursor_field`, `ingestion_type`) are left as-is. They produce a camel/snake mix inside that one schema — worth a follow-up, but a larger break that would touch `ingestion_pipeline.py` and the Scala caller.

## Compatibility

Breaking for any consumer that reads `_community_tables` and selects the old `table_name` column by name. The in-tree `ingestion_pipeline.py` does not consume `_community_tables`, so no internal callers are affected. External Scala integration code that reads this virtual table will need a coordinated update.

## Test plan

- [x] `pytest tests/unit/test_sparkpds_virtual_tables.py` — 21/21 pass
- [x] `pytest tests/unit/sparkpds_registry_test.py` — 6/6 pass
- [ ] Sync with the downstream Scala caller before merging

This pull request and its description were written by Isaac.