### PR TITLE
Fix workflow startup_failure introduced by #192

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -3,27 +3,27 @@ name: Pylint
 # Trigger model. CI needs the GitHub OIDC token because the protected
 # runner group's only egress to PyPI is the JFrog proxy
 # (.github/actions/configure-jfrog-pypi), and the proxy authenticates by
-# exchanging an OIDC ID token for a JFrog access token. Fork-PR runs on
-# plain `pull_request` don't receive OIDC, so configure-jfrog-pypi fails
-# with `ACTIONS_ID_TOKEN_REQUEST_TOKEN: unbound variable`.
+# exchanging an OIDC ID token for a JFrog access token. Plain
+# `pull_request` events from forks don't receive OIDC, so we can't use
+# that trigger for fork PRs at all.
 #
-# Naively switching all PR runs to `pull_request_target` to get OIDC is
-# the classic "pwn request" footgun (GitHub Security Lab) — it runs
-# fork-controlled code in base-repo context with secrets/OIDC in scope.
-# H1 report #3730634 (PR #188) exploited exactly that.
+# Naively using `pull_request_target` for every PR event would give
+# fork-controlled code the OIDC token — the classic "pwn request"
+# footgun (GitHub Security Lab). H1 #3730634 (PR #188) exploited that.
 #
-# The compromise:
+# So: a single `pull_request_target` trigger for all PR events, with a
+# job-level `if` that decides what actually runs:
 #
-#   * push / same-repo pull_request → run normally. These already have
-#     OIDC; nothing fork-controlled is checked out.
-#   * Fork PR pull_request          → workflow fires but `build` is
-#     skipped by the job's `if` (cannot pass OIDC anyway).
-#   * Fork PR pull_request_target   → wired *only* to `types: [labeled]`
-#     and gated on `label.name == 'safe-to-test'`. The label add is the
-#     reviewer's explicit "I have read this diff; it's safe to execute"
-#     signal. The label is auto-stripped on every subsequent push
-#     (.github/workflows/strip-safe-to-test.yml) so each new commit
-#     re-requires approval.
+#   * push to master           — always runs.
+#   * same-repo PR (any event) — runs.
+#   * fork PR opened/sync/etc. — skipped (no fork code executes).
+#   * fork PR labeled          — runs *only* if the added label is
+#                                `safe-to-test`. That label is the
+#                                reviewer's "I read this diff; it's safe
+#                                to execute on the runner" signal. The
+#                                label auto-strips on every subsequent
+#                                push (strip-safe-to-test.yml) so each
+#                                new commit re-requires approval.
 #
 # The explicit head-SHA checkout is the SHA the reviewer just labeled —
 # i.e. the version they signed off on.
@@ -35,16 +35,9 @@ on:
       - 'pyproject.toml'
       - 'requirements/**'
       - '.github/workflows/pylint.yml'
-  pull_request:
-    branches: [master]
-    paths:
-      - '**/*.py'
-      - 'pyproject.toml'
-      - 'requirements/**'
-      - '.github/workflows/pylint.yml'
   pull_request_target:
     branches: [master]
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - '**/*.py'
       - 'pyproject.toml'
@@ -58,10 +51,7 @@ permissions:
 jobs:
   build:
     # Gate fork PRs behind the `safe-to-test` label. See trigger model above.
-    if: >-
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-test' && github.event.pull_request.head.repo.full_name != github.repository)
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test') }}
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
@@ -73,8 +63,9 @@ jobs:
       with:
         # pull_request_target defaults to checking out the base ref; we want
         # to lint the PR's actual code (specifically: the SHA the reviewer
-        # just labeled `safe-to-test`). For push/same-repo events the variable
-        # is empty and checkout falls back to the workflow ref.
+        # just labeled `safe-to-test`, or the head SHA for same-repo PRs).
+        # For push events the variable is empty and checkout falls back to
+        # the workflow ref.
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,27 +1,24 @@
 name: Tests
 
-# Trigger model (full rationale in .github/workflows/pylint.yml):
+# Trigger model (full rationale in .github/workflows/pylint.yml).
 #
-#   * push to master            — internal/trusted; OIDC available.
-#   * pull_request (same-repo)  — internal-branch PRs only; OIDC available.
-#                                 Fork-PR pull_request events also fire here
-#                                 (we can't filter at trigger level), but
-#                                 the `changes` job's `if` skips them.
-#   * pull_request_target       — *only* on label add. A maintainer adding
-#     types: [labeled]            the `safe-to-test` label is the explicit
-#                                 approval signal that this fork commit is
-#                                 safe to execute with secrets in scope.
-#                                 The label is auto-stripped on every push
-#                                 (.github/workflows/strip-safe-to-test.yml)
-#                                 so each new commit re-requires approval.
+# All PR events route through a single `pull_request_target` trigger
+# (base-repo context, OIDC available). The job-level `if` decides whether
+# a given event actually runs CI:
+#
+#   * push to master           — always runs.
+#   * same-repo PR (any event) — runs.
+#   * fork PR opened/sync/etc. — skipped.
+#   * fork PR labeled          — runs *only* if the added label is
+#                                `safe-to-test`. The label auto-strips on
+#                                every push (strip-safe-to-test.yml) so
+#                                each new commit re-requires approval.
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
   pull_request_target:
     branches: [master]
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
@@ -31,10 +28,7 @@ jobs:
   # Detect which paths changed
   changes:
     # Gate fork PRs behind the `safe-to-test` label. See trigger model above.
-    if: >-
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-test' && github.event.pull_request.head.repo.full_name != github.repository)
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test') }}
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
@@ -58,7 +52,7 @@ jobs:
             BASE_SHA="${{ github.event.before }}"
             HEAD_SHA="${{ github.event.after }}"
           else
-            # pull_request (same-repo) or pull_request_target (labeled fork)
+            # pull_request_target (same-repo any event, or fork labeled safe-to-test)
             BASE_SHA="${{ github.event.pull_request.base.sha }}"
             HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           fi

--- a/.github/workflows/verify-locks.yml
+++ b/.github/workflows/verify-locks.yml
@@ -14,18 +14,9 @@ on:
       - 'src/databricks/labs/community_connector/sources/**/pyproject.toml'
       - 'requirements/**'
       - 'tools/scripts/regenerate-locks.sh'
-  pull_request:
-    branches: [master]
-    paths:
-      - 'pyproject.toml'
-      - 'tools/community_connector/pyproject.toml'
-      - 'src/databricks/labs/community_connector/sources/**/pyproject.toml'
-      - 'requirements/**'
-      - 'tools/scripts/regenerate-locks.sh'
-      - '.github/workflows/verify-locks.yml'
   pull_request_target:
     branches: [master]
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - 'pyproject.toml'
       - 'tools/community_connector/pyproject.toml'
@@ -41,10 +32,7 @@ permissions:
 jobs:
   verify:
     # Gate fork PRs behind the `safe-to-test` label. See trigger model in pylint.yml.
-    if: >-
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-test' && github.event.pull_request.head.repo.full_name != github.repository)
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test') }}
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest


### PR DESCRIPTION
## Context

Every workflow run since #192 merged has been `startup_failure` — including the master `push` post-merge, and every event on open fork PRs (#191). The GitHub API exposes only a generic "workflow file issue" conclusion (no annotations, no logs), so the exact validator complaint is opaque, but two structural changes from #192 are the only differences from the previously-working shape:

1. Three concurrent triggers (`push` + `pull_request` + `pull_request_target`) on the same workflow.
2. Job-level `if:` as a multi-line `>-` folded scalar with `&&`/`||`.

This PR backs both off.

## What changes

- **`tests.yml`**, **`pylint.yml`**, **`verify-locks.yml`** — drop the `pull_request` trigger; keep only `push` + `pull_request_target` (with `types: [opened, synchronize, reopened, labeled]` so label-add events fire). Job-level `if:` becomes a single-line `${{ ... }}` expression.

## New if-gate semantics

| Event | Result |
|---|---|
| `push` to master | run |
| Same-repo PR (any event) | run |
| Fork PR `opened` / `synchronize` / `reopened` | skip |
| Fork PR `labeled` with `safe-to-test` | run |
| Fork PR `labeled` with any other label | skip |
| Fork PR `unlabeled` (not in trigger types) | doesn't fire |

Same security guarantee as #192: fork PRs only execute on the protected runner after a maintainer applies `safe-to-test`. Auto-strip on synchronize (unchanged) forces re-approval per commit.

## Test plan

- [ ] Watch CI on this PR — should pass via same-repo branch path.
- [ ] After merge, watch the master `push` event to confirm it runs (no startup_failure).
- [ ] Re-test on PR #191: applying `safe-to-test` should trigger Tests + Pylint + Verify Dependency Locks against the labeled head SHA.

## Why we don't yet know the exact root cause

GitHub's REST API doesn't surface workflow-validator errors — they only appear as a red annotation on the run page in the UI. I tried `runs/{id}/annotations`, `check-suites/{id}/check-runs`, `runs/{id}/attempts/1/logs` — all empty/404. If this PR fixes things and a future change re-introduces one of the two suspects (multi-trigger or multi-line `if`), we'll learn which one was actually the trigger.

This pull request and its description were written by Isaac.