### PR TITLE
v2: move auth gate to first-step shell check (fix startup_failure)

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -50,8 +50,6 @@ permissions:
 
 jobs:
   build:
-    # Gate fork PRs behind the `safe-to-test` label. See trigger model above.
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test') }}
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
@@ -59,6 +57,27 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
+    - name: Authorize
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        BASE_REPO: ${{ github.repository }}
+        HAS_SAFE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+      run: |
+        if [ "$EVENT_NAME" = "push" ]; then
+          echo "OK: push to master."
+          exit 0
+        fi
+        if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+          echo "OK: same-repo PR ($HEAD_REPO)."
+          exit 0
+        fi
+        if [ "$HAS_SAFE_LABEL" = "true" ]; then
+          echo "OK: fork PR with safe-to-test label."
+          exit 0
+        fi
+        echo "::error title=Fork PR not authorized::Apply the 'safe-to-test' label to run CI against this commit. See CONTRIBUTING.md."
+        exit 1
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         # pull_request_target defaults to checking out the base ref; we want

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,16 +3,22 @@ name: Tests
 # Trigger model (full rationale in .github/workflows/pylint.yml).
 #
 # All PR events route through a single `pull_request_target` trigger
-# (base-repo context, OIDC available). The job-level `if` decides whether
-# a given event actually runs CI:
+# (base-repo context, OIDC available). The `Authorize` step at the top
+# of each gated job decides whether the rest runs:
 #
 #   * push to master           — always runs.
 #   * same-repo PR (any event) — runs.
-#   * fork PR opened/sync/etc. — skipped.
-#   * fork PR labeled          — runs *only* if the added label is
-#                                `safe-to-test`. The label auto-strips on
+#   * fork PR opened/sync/etc. — Authorize fails the job (red X on PR).
+#   * fork PR labeled          — runs *only* if `safe-to-test` is on the
+#                                PR's labels. The label auto-strips on
 #                                every push (strip-safe-to-test.yml) so
 #                                each new commit re-requires approval.
+#
+# We use a step-level shell gate instead of a job-level `if:` because
+# GitHub's workflow validator rejected the latter form (PR #193 chased
+# this; symptom was `startup_failure` for every event). The step-level
+# gate runs *before* `actions/checkout`, so no fork code touches the
+# runner unless authorized.
 on:
   push:
     branches: [master]
@@ -27,8 +33,6 @@ permissions:
 jobs:
   # Detect which paths changed
   changes:
-    # Gate fork PRs behind the `safe-to-test` label. See trigger model above.
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test') }}
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
@@ -39,6 +43,27 @@ jobs:
       community_connector: ${{ steps.check.outputs.community_connector }}
       sources: ${{ steps.check.outputs.sources }}
     steps:
+      - name: Authorize
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          HAS_SAFE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ]; then
+            echo "OK: push to master."
+            exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "OK: same-repo PR ($HEAD_REPO)."
+            exit 0
+          fi
+          if [ "$HAS_SAFE_LABEL" = "true" ]; then
+            echo "OK: fork PR with safe-to-test label."
+            exit 0
+          fi
+          echo "::error title=Fork PR not authorized::Apply the 'safe-to-test' label to run CI against this commit. See CONTRIBUTING.md."
+          exit 1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       # cannot use dorny because of ip allowlisting
       # - uses: dorny/paths-filter@v3

--- a/.github/workflows/verify-locks.yml
+++ b/.github/workflows/verify-locks.yml
@@ -31,12 +31,31 @@ permissions:
 
 jobs:
   verify:
-    # Gate fork PRs behind the `safe-to-test` label. See trigger model in pylint.yml.
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test') }}
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
     steps:
+      - name: Authorize
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          HAS_SAFE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ]; then
+            echo "OK: push to master."
+            exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "OK: same-repo PR ($HEAD_REPO)."
+            exit 0
+          fi
+          if [ "$HAS_SAFE_LABEL" = "true" ]; then
+            echo "OK: fork PR with safe-to-test label."
+            exit 0
+          fi
+          echo "::error title=Fork PR not authorized::Apply the 'safe-to-test' label to run CI against this commit. See CONTRIBUTING.md."
+          exit 1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary

#193 didn't fix master CI — `push` to master at `97f5399` still `startup_failure`'d. That ruled out the multi-trigger / multi-line `if:` hypotheses and narrowed the cause to **GitHub's workflow validator rejecting the job-level `if:`** expression itself.

This PR moves the gate from job-level `if:` to a first-step shell check, which has the same security guarantee but no job-level `if:`.

## Behavior

| Event | Result |
|---|---|
| `push` to master | runs |
| Same-repo PR (any event) | runs |
| Fork PR with `safe-to-test` label | runs |
| Fork PR without label | first step (`Authorize`) fails with an actionable error; subsequent steps don't run; no fork code is checked out |

The Authorize step runs **before** `actions/checkout`, so unauthorized fork code never touches the runner.

## Trade-off vs. job-level `if:`

Unauthorized fork PRs now show a red X (`Authorize` step failed) instead of being silently skipped. Arguably better UX — the maintainer sees explicitly that the label is needed.

## Test plan

- [ ] This PR cannot CI itself (current master is still broken). Admin-merge it.
- [ ] After merge, watch the master `push` event — should succeed.
- [ ] On a fork PR without the label: confirm the `Authorize` step fails with the expected message.
- [ ] On a fork PR with `safe-to-test`: confirm CI runs.

This pull request and its description were written by Isaac.