### PR TITLE
Revert #193 and #194 (failed fix attempts)

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -50,6 +50,8 @@ permissions:
 
 jobs:
   build:
+    # Gate fork PRs behind the `safe-to-test` label. See trigger model above.
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test') }}
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
@@ -57,27 +59,6 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-    - name: Authorize
-      env:
-        EVENT_NAME: ${{ github.event_name }}
-        HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-        BASE_REPO: ${{ github.repository }}
-        HAS_SAFE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
-      run: |
-        if [ "$EVENT_NAME" = "push" ]; then
-          echo "OK: push to master."
-          exit 0
-        fi
-        if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
-          echo "OK: same-repo PR ($HEAD_REPO)."
-          exit 0
-        fi
-        if [ "$HAS_SAFE_LABEL" = "true" ]; then
-          echo "OK: fork PR with safe-to-test label."
-          exit 0
-        fi
-        echo "::error title=Fork PR not authorized::Apply the 'safe-to-test' label to run CI against this commit. See CONTRIBUTING.md."
-        exit 1
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         # pull_request_target defaults to checking out the base ref; we want

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -3,27 +3,27 @@ name: Pylint
 # Trigger model. CI needs the GitHub OIDC token because the protected
 # runner group's only egress to PyPI is the JFrog proxy
 # (.github/actions/configure-jfrog-pypi), and the proxy authenticates by
-# exchanging an OIDC ID token for a JFrog access token. Plain
-# `pull_request` events from forks don't receive OIDC, so we can't use
-# that trigger for fork PRs at all.
+# exchanging an OIDC ID token for a JFrog access token. Fork-PR runs on
+# plain `pull_request` don't receive OIDC, so configure-jfrog-pypi fails
+# with `ACTIONS_ID_TOKEN_REQUEST_TOKEN: unbound variable`.
 #
-# Naively using `pull_request_target` for every PR event would give
-# fork-controlled code the OIDC token — the classic "pwn request"
-# footgun (GitHub Security Lab). H1 #3730634 (PR #188) exploited that.
+# Naively switching all PR runs to `pull_request_target` to get OIDC is
+# the classic "pwn request" footgun (GitHub Security Lab) — it runs
+# fork-controlled code in base-repo context with secrets/OIDC in scope.
+# H1 report #3730634 (PR #188) exploited exactly that.
 #
-# So: a single `pull_request_target` trigger for all PR events, with a
-# job-level `if` that decides what actually runs:
+# The compromise:
 #
-#   * push to master           — always runs.
-#   * same-repo PR (any event) — runs.
-#   * fork PR opened/sync/etc. — skipped (no fork code executes).
-#   * fork PR labeled          — runs *only* if the added label is
-#                                `safe-to-test`. That label is the
-#                                reviewer's "I read this diff; it's safe
-#                                to execute on the runner" signal. The
-#                                label auto-strips on every subsequent
-#                                push (strip-safe-to-test.yml) so each
-#                                new commit re-requires approval.
+#   * push / same-repo pull_request → run normally. These already have
+#     OIDC; nothing fork-controlled is checked out.
+#   * Fork PR pull_request          → workflow fires but `build` is
+#     skipped by the job's `if` (cannot pass OIDC anyway).
+#   * Fork PR pull_request_target   → wired *only* to `types: [labeled]`
+#     and gated on `label.name == 'safe-to-test'`. The label add is the
+#     reviewer's explicit "I have read this diff; it's safe to execute"
+#     signal. The label is auto-stripped on every subsequent push
+#     (.github/workflows/strip-safe-to-test.yml) so each new commit
+#     re-requires approval.
 #
 # The explicit head-SHA checkout is the SHA the reviewer just labeled —
 # i.e. the version they signed off on.
@@ -35,9 +35,16 @@ on:
       - 'pyproject.toml'
       - 'requirements/**'
       - '.github/workflows/pylint.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - 'requirements/**'
+      - '.github/workflows/pylint.yml'
   pull_request_target:
     branches: [master]
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
     paths:
       - '**/*.py'
       - 'pyproject.toml'
@@ -51,7 +58,10 @@ permissions:
 jobs:
   build:
     # Gate fork PRs behind the `safe-to-test` label. See trigger model above.
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test') }}
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-test' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
@@ -63,9 +73,8 @@ jobs:
       with:
         # pull_request_target defaults to checking out the base ref; we want
         # to lint the PR's actual code (specifically: the SHA the reviewer
-        # just labeled `safe-to-test`, or the head SHA for same-repo PRs).
-        # For push events the variable is empty and checkout falls back to
-        # the workflow ref.
+        # just labeled `safe-to-test`). For push/same-repo events the variable
+        # is empty and checkout falls back to the workflow ref.
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,22 +3,16 @@ name: Tests
 # Trigger model (full rationale in .github/workflows/pylint.yml).
 #
 # All PR events route through a single `pull_request_target` trigger
-# (base-repo context, OIDC available). The `Authorize` step at the top
-# of each gated job decides whether the rest runs:
+# (base-repo context, OIDC available). The job-level `if` decides whether
+# a given event actually runs CI:
 #
 #   * push to master           — always runs.
 #   * same-repo PR (any event) — runs.
-#   * fork PR opened/sync/etc. — Authorize fails the job (red X on PR).
-#   * fork PR labeled          — runs *only* if `safe-to-test` is on the
-#                                PR's labels. The label auto-strips on
+#   * fork PR opened/sync/etc. — skipped.
+#   * fork PR labeled          — runs *only* if the added label is
+#                                `safe-to-test`. The label auto-strips on
 #                                every push (strip-safe-to-test.yml) so
 #                                each new commit re-requires approval.
-#
-# We use a step-level shell gate instead of a job-level `if:` because
-# GitHub's workflow validator rejected the latter form (PR #193 chased
-# this; symptom was `startup_failure` for every event). The step-level
-# gate runs *before* `actions/checkout`, so no fork code touches the
-# runner unless authorized.
 on:
   push:
     branches: [master]
@@ -33,6 +27,8 @@ permissions:
 jobs:
   # Detect which paths changed
   changes:
+    # Gate fork PRs behind the `safe-to-test` label. See trigger model above.
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test') }}
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
@@ -43,27 +39,6 @@ jobs:
       community_connector: ${{ steps.check.outputs.community_connector }}
       sources: ${{ steps.check.outputs.sources }}
     steps:
-      - name: Authorize
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          BASE_REPO: ${{ github.repository }}
-          HAS_SAFE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
-        run: |
-          if [ "$EVENT_NAME" = "push" ]; then
-            echo "OK: push to master."
-            exit 0
-          fi
-          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
-            echo "OK: same-repo PR ($HEAD_REPO)."
-            exit 0
-          fi
-          if [ "$HAS_SAFE_LABEL" = "true" ]; then
-            echo "OK: fork PR with safe-to-test label."
-            exit 0
-          fi
-          echo "::error title=Fork PR not authorized::Apply the 'safe-to-test' label to run CI against this commit. See CONTRIBUTING.md."
-          exit 1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       # cannot use dorny because of ip allowlisting
       # - uses: dorny/paths-filter@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,24 +1,27 @@
 name: Tests
 
-# Trigger model (full rationale in .github/workflows/pylint.yml).
+# Trigger model (full rationale in .github/workflows/pylint.yml):
 #
-# All PR events route through a single `pull_request_target` trigger
-# (base-repo context, OIDC available). The job-level `if` decides whether
-# a given event actually runs CI:
-#
-#   * push to master           — always runs.
-#   * same-repo PR (any event) — runs.
-#   * fork PR opened/sync/etc. — skipped.
-#   * fork PR labeled          — runs *only* if the added label is
-#                                `safe-to-test`. The label auto-strips on
-#                                every push (strip-safe-to-test.yml) so
-#                                each new commit re-requires approval.
+#   * push to master            — internal/trusted; OIDC available.
+#   * pull_request (same-repo)  — internal-branch PRs only; OIDC available.
+#                                 Fork-PR pull_request events also fire here
+#                                 (we can't filter at trigger level), but
+#                                 the `changes` job's `if` skips them.
+#   * pull_request_target       — *only* on label add. A maintainer adding
+#     types: [labeled]            the `safe-to-test` label is the explicit
+#                                 approval signal that this fork commit is
+#                                 safe to execute with secrets in scope.
+#                                 The label is auto-stripped on every push
+#                                 (.github/workflows/strip-safe-to-test.yml)
+#                                 so each new commit re-requires approval.
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
   pull_request_target:
     branches: [master]
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
 
 permissions:
   contents: read
@@ -28,7 +31,10 @@ jobs:
   # Detect which paths changed
   changes:
     # Gate fork PRs behind the `safe-to-test` label. See trigger model above.
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test') }}
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-test' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
@@ -52,7 +58,7 @@ jobs:
             BASE_SHA="${{ github.event.before }}"
             HEAD_SHA="${{ github.event.after }}"
           else
-            # pull_request_target (same-repo any event, or fork labeled safe-to-test)
+            # pull_request (same-repo) or pull_request_target (labeled fork)
             BASE_SHA="${{ github.event.pull_request.base.sha }}"
             HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           fi

--- a/.github/workflows/verify-locks.yml
+++ b/.github/workflows/verify-locks.yml
@@ -31,31 +31,12 @@ permissions:
 
 jobs:
   verify:
+    # Gate fork PRs behind the `safe-to-test` label. See trigger model in pylint.yml.
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test') }}
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
     steps:
-      - name: Authorize
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          BASE_REPO: ${{ github.repository }}
-          HAS_SAFE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
-        run: |
-          if [ "$EVENT_NAME" = "push" ]; then
-            echo "OK: push to master."
-            exit 0
-          fi
-          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
-            echo "OK: same-repo PR ($HEAD_REPO)."
-            exit 0
-          fi
-          if [ "$HAS_SAFE_LABEL" = "true" ]; then
-            echo "OK: fork PR with safe-to-test label."
-            exit 0
-          fi
-          echo "::error title=Fork PR not authorized::Apply the 'safe-to-test' label to run CI against this commit. See CONTRIBUTING.md."
-          exit 1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/verify-locks.yml
+++ b/.github/workflows/verify-locks.yml
@@ -14,9 +14,18 @@ on:
       - 'src/databricks/labs/community_connector/sources/**/pyproject.toml'
       - 'requirements/**'
       - 'tools/scripts/regenerate-locks.sh'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'pyproject.toml'
+      - 'tools/community_connector/pyproject.toml'
+      - 'src/databricks/labs/community_connector/sources/**/pyproject.toml'
+      - 'requirements/**'
+      - 'tools/scripts/regenerate-locks.sh'
+      - '.github/workflows/verify-locks.yml'
   pull_request_target:
     branches: [master]
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
     paths:
       - 'pyproject.toml'
       - 'tools/community_connector/pyproject.toml'
@@ -32,7 +41,10 @@ permissions:
 jobs:
   verify:
     # Gate fork PRs behind the `safe-to-test` label. See trigger model in pylint.yml.
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || (github.event.action == 'labeled' && github.event.label.name == 'safe-to-test') }}
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-test' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest


### PR DESCRIPTION
## Summary

Reverts the two admin-merged fix attempts that did not resolve the `startup_failure` introduced by #192:

- #194 — *v2: move auth gate to first-step shell check*
- #193 — *Fix workflow startup_failure introduced by #192*

After this PR, master's workflow YAML returns exactly to #192's state (verified: `git diff 2eab82d..HEAD` is empty).

## Important

**CI on master is still broken after this revert** — #192's YAML also startup_fails. This PR only undoes the two failed fix attempts; it does NOT restore the last-working YAML. Reverting #192 itself (which would unblock CI) is a separate decision because that would also remove the `safe-to-test` security gate and reopen the H1 #3730634 attack surface.

## Followup

We still need to either:

1. Fix the YAML problem in #192 (need GitHub's actual error message from the run page UI to diagnose), or
2. Revert #192 too as a temporary unblock, then re-introduce the gate with a different design once we understand what GitHub's validator rejects.

This pull request and its description were written by Isaac.