### PR TITLE
Add Required CI Gate to make required checks unskippable

### DIFF
--- a/.github/workflows/required-ci-gate.yml
+++ b/.github/workflows/required-ci-gate.yml
@@ -1,0 +1,107 @@
+name: Required CI Gate
+
+# Single aggregated check that branch protection on master should
+# require. It pins down a stricter contract than listing each CI
+# workflow individually:
+#
+#   * **Cannot be silently skipped.** A workflow's job-level `if:`
+#     evaluating false reports the check as "skipped", which GitHub's
+#     branch protection counts as success. That can let a PR through
+#     without actual CI coverage. The gate below explicitly checks the
+#     *conclusion* of each required workflow and only passes when each
+#     one is literally "success" — "skipped", "missing", "cancelled",
+#     and "failure" all fail the gate.
+#
+#   * **Cannot be path-filtered away.** Each upstream workflow has its
+#     own `paths:` filter, so a docs-only PR may not fire any of them.
+#     This gate has no `paths:` filter — it always fires for every PR.
+#     If you want a docs-only PR to merge, either expand a workflow's
+#     paths or remove this gate from the required-checks list.
+#
+# Branch-protection setup: in repo Settings → Branches → master rule,
+# add "Required CI Gate / gate" to the required status checks. Do NOT
+# also list the individual workflows there — let this gate be the
+# single source of truth.
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+  # Re-evaluate the gate after each upstream required workflow finishes.
+  # Without this the initial PR-open run would fail (others haven't
+  # completed yet) and the gate would never re-run on its own.
+  workflow_run:
+    workflows:
+      - Tests
+      - Generate Merged Source File
+      - Connector Self-Review
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read   # needed to query other workflow runs via the API
+
+# Only the most recent gate evaluation per head SHA is meaningful;
+# cancel older in-flight runs when a newer one starts.
+concurrency:
+  group: required-ci-gate-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    runs-on:
+      group: databrickslabs-protected-runner-group
+      labels: linux-ubuntu-latest
+    steps:
+      - name: Aggregate required workflow conclusions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # pull_request: PR head SHA. workflow_run: SHA the upstream
+          # workflow executed against (which is the PR head for fork
+          # `pull_request` events too, via the merge-commit indirection
+          # GitHub provides for `workflow_run`).
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          REQUIRED=(
+            "Tests"
+            "Generate Merged Source File"
+            "Connector Self-Review"
+          )
+
+          echo "Checking required workflows for HEAD ${HEAD_SHA}:"
+          echo
+
+          FAILED=()
+          for wf in "${REQUIRED[@]}"; do
+            # Take the most recent run for this workflow on this SHA.
+            # `// "missing"` falls back when the workflow never fired.
+            CONCLUSION=$(gh api \
+              "repos/${REPO}/actions/runs?head_sha=${HEAD_SHA}&per_page=50" \
+              --jq "[.workflow_runs[] | select(.name == \"$wf\")] | sort_by(.created_at) | reverse | .[0].conclusion // \"missing\"")
+
+            printf '  %-32s %s\n' "$wf" "$CONCLUSION"
+
+            if [ "$CONCLUSION" != "success" ]; then
+              FAILED+=("${wf} (${CONCLUSION})")
+            fi
+          done
+
+          echo
+
+          if [ ${#FAILED[@]} -gt 0 ]; then
+            echo "::error title=Required CI Gate failed::One or more required workflows did not succeed on ${HEAD_SHA}:"
+            for f in "${FAILED[@]}"; do
+              echo "  - $f"
+            done
+            echo
+            echo "Next steps:"
+            echo "  * 'missing' — the workflow never fired. Check its paths/types filters or trigger it manually."
+            echo "  * 'skipped' — a job-level if: evaluated false. Re-run the workflow or change the gating condition."
+            echo "  * 'failure' / 'cancelled' — fix the underlying problem, push, and the gate will re-evaluate."
+            exit 1
+          fi
+
+          echo "All required workflows succeeded for ${HEAD_SHA}."

--- a/.github/workflows/required-ci-gate.yml
+++ b/.github/workflows/required-ci-gate.yml
@@ -1,35 +1,38 @@
 name: Required CI Gate
 
 # Single aggregated check that branch protection on master should
-# require. It pins down a stricter contract than listing each CI
-# workflow individually:
+# require. It checks the conclusion of each required workflow on the
+# PR's head SHA:
 #
-#   * **Cannot be silently skipped.** A workflow's job-level `if:`
-#     evaluating false reports the check as "skipped", which GitHub's
-#     branch protection counts as success. That can let a PR through
-#     without actual CI coverage. The gate below explicitly checks the
-#     *conclusion* of each required workflow and only passes when each
-#     one is literally "success" — "skipped", "missing", "cancelled",
-#     and "failure" all fail the gate.
+#   * **No run record exists** → workflow's own trigger filters
+#     (paths / branches / event types) excluded this PR. The workflow
+#     legitimately wasn't going to fire. Treated as **not applicable
+#     → OK**. (This is what makes the gate practical for docs-only or
+#     workflow-only PRs.)
 #
-#   * **Cannot be path-filtered away.** Each upstream workflow has its
-#     own `paths:` filter, so a docs-only PR may not fire any of them.
-#     This gate has no `paths:` filter — it always fires for every PR.
-#     If you want a docs-only PR to merge, either expand a workflow's
-#     paths or remove this gate from the required-checks list.
+#   * **Run record exists, conclusion = success** → OK.
+#
+#   * **Run record exists, status != completed** (in_progress, queued)
+#     → FAIL. `workflow_run` will re-fire the gate after the upstream
+#     workflow completes; the gate will re-evaluate then.
+#
+#   * **Run record exists, conclusion != success** (skipped, failure,
+#     cancelled, timed_out, etc.) → FAIL. This is the loophole the
+#     gate exists to close: GitHub treats a job-level skip as success
+#     for branch-protection purposes, but the gate doesn't.
 #
 # Branch-protection setup: in repo Settings → Branches → master rule,
 # add "Required CI Gate / gate" to the required status checks. Do NOT
-# also list the individual workflows there — let this gate be the
-# single source of truth.
+# also list the individual workflows — the gate is the single source
+# of truth.
 
 on:
   pull_request:
     branches: [master]
     types: [opened, synchronize, reopened, ready_for_review]
   # Re-evaluate the gate after each upstream required workflow finishes.
-  # Without this the initial PR-open run would fail (others haven't
-  # completed yet) and the gate would never re-run on its own.
+  # Without this the initial PR-open gate run would never re-fire on
+  # its own when upstream workflows complete.
   workflow_run:
     workflows:
       - Tests
@@ -58,9 +61,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           # pull_request: PR head SHA. workflow_run: SHA the upstream
-          # workflow executed against (which is the PR head for fork
-          # `pull_request` events too, via the merge-commit indirection
-          # GitHub provides for `workflow_run`).
+          # workflow executed against.
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
@@ -76,15 +77,34 @@ jobs:
 
           FAILED=()
           for wf in "${REQUIRED[@]}"; do
-            # Take the most recent run for this workflow on this SHA.
-            # `// "missing"` falls back when the workflow never fired.
-            CONCLUSION=$(gh api \
+            RUNS=$(gh api \
               "repos/${REPO}/actions/runs?head_sha=${HEAD_SHA}&per_page=50" \
-              --jq "[.workflow_runs[] | select(.name == \"$wf\")] | sort_by(.created_at) | reverse | .[0].conclusion // \"missing\"")
+              --jq "[.workflow_runs[] | select(.name == \"$wf\")]")
+            COUNT=$(echo "$RUNS" | jq 'length')
 
-            printf '  %-32s %s\n' "$wf" "$CONCLUSION"
+            if [ "$COUNT" = "0" ]; then
+              # No run record at all. The workflow's own trigger filters
+              # (paths / event types / branches) excluded this PR — it
+              # legitimately wasn't going to fire. Treat as not-applicable.
+              printf '  %-32s %s\n' "$wf" "not-applicable (no run record)"
+              continue
+            fi
 
-            if [ "$CONCLUSION" != "success" ]; then
+            LATEST=$(echo "$RUNS" | jq -c 'sort_by(.created_at) | reverse | .[0]')
+            STATUS=$(echo "$LATEST" | jq -r '.status')
+            CONCLUSION=$(echo "$LATEST" | jq -r '.conclusion // "null"')
+
+            if [ "$CONCLUSION" = "success" ]; then
+              printf '  %-32s %s\n' "$wf" "success"
+            elif [ "$STATUS" != "completed" ]; then
+              # Workflow is still queued / in_progress. Gate will re-fire
+              # via workflow_run when it completes.
+              printf '  %-32s %s\n' "$wf" "${STATUS} (waiting)"
+              FAILED+=("${wf} (${STATUS})")
+            else
+              # Completed but not success (skipped, failure, cancelled,
+              # timed_out, action_required, startup_failure, …).
+              printf '  %-32s %s\n' "$wf" "$CONCLUSION"
               FAILED+=("${wf} (${CONCLUSION})")
             fi
           done
@@ -92,16 +112,20 @@ jobs:
           echo
 
           if [ ${#FAILED[@]} -gt 0 ]; then
-            echo "::error title=Required CI Gate failed::One or more required workflows did not succeed on ${HEAD_SHA}:"
+            echo "::error title=Required CI Gate failed::One or more required workflows did not succeed for ${HEAD_SHA}:"
             for f in "${FAILED[@]}"; do
               echo "  - $f"
             done
             echo
             echo "Next steps:"
-            echo "  * 'missing' — the workflow never fired. Check its paths/types filters or trigger it manually."
+            echo "  * 'in_progress' / 'queued' — wait; gate re-fires via workflow_run when the workflow completes."
             echo "  * 'skipped' — a job-level if: evaluated false. Re-run the workflow or change the gating condition."
-            echo "  * 'failure' / 'cancelled' — fix the underlying problem, push, and the gate will re-evaluate."
+            echo "  * 'failure' / 'cancelled' / 'timed_out' — fix the underlying problem and push; gate re-evaluates."
+            echo
+            echo "Note: a workflow with no run record at all is treated as not-applicable"
+            echo "(its own trigger filters excluded this PR). To enforce it on every PR,"
+            echo "expand its trigger to match all paths."
             exit 1
           fi
 
-          echo "All required workflows succeeded for ${HEAD_SHA}."
+          echo "✅ All required workflows passed (or are not applicable to this PR)."


### PR DESCRIPTION
## What this adds

A new workflow `.github/workflows/required-ci-gate.yml` that aggregates the conclusions of:

- `Tests`
- `Generate Merged Source File`
- `Connector Self-Review`

…for the PR's head SHA and reports a single pass/fail check.

## Per-workflow logic

| Upstream state on this SHA | Gate verdict |
|---|---|
| No run record (workflow's own paths/types filter excluded this PR) | **Not-applicable → OK** |
| Run exists, `conclusion == success` | **OK** |
| Run exists, still `in_progress` / `queued` | Fail; gate re-fires via `workflow_run` when it completes |
| Run exists, completed but not success — `skipped`, `failure`, `cancelled`, `timed_out`, `startup_failure`, etc. | Fail |

The "skipped → fail" path is the loophole the gate exists to close: GitHub branch protection treats a job-level skip as success, which can let PRs through without real CI coverage. The gate explicitly checks the conclusion string and rejects anything that isn't `success`.

The "no run record → OK" path makes the gate practical for docs-only / workflow-only PRs that legitimately don't fire the path-filtered workflows.

## Triggers

```yaml
on:
  pull_request:
    branches: [master]
    types: [opened, synchronize, reopened, ready_for_review]
  workflow_run:
    workflows: [Tests, Generate Merged Source File, Connector Self-Review]
    types: [completed]
```

`pull_request` fires the gate on every PR event (no paths filter, so it's always reported). `workflow_run` re-fires the gate every time an upstream workflow completes, so a red gate goes green automatically as upstream workflows finish.

## Required follow-up (manual)

The workflow file alone doesn't block anything. To make it actually gate merges:

1. Settings → Branches → branch protection rule for master → Require status checks to pass.
2. Add `Required CI Gate / gate` to the required check list.
3. **Remove** any direct listings of `Tests`, `Generate Merged Source File`, or `Connector Self-Review` from required checks — let the gate be the single source of truth (otherwise skipped-as-success comes back via those direct listings).

## One-time bootstrap caveat

`workflow_run` only loads its workflow file from the default branch. Until this PR is merged, master doesn't have `required-ci-gate.yml`, so `workflow_run` won't re-fire the gate on this PR. That means the gate on this PR can race against upstream workflows: if the gate fires while `Tests` is still in progress, it reports `in_progress` and fails — and won't re-evaluate on its own.

Workarounds (one-time):

- Push a no-op commit after `Tests` completes to re-fire the gate via `synchronize`.
- Or admin-bypass merge this PR once. After merge, future PRs benefit from `workflow_run` automatically.

## Test plan

- [ ] Confirm YAML parses (actionlint clean — done).
- [ ] After merge + branch protection update: open a same-repo no-op PR, watch initial gate fail, watch it auto-pass once upstream workflows complete via `workflow_run`.
- [ ] Open a docs-only PR — confirm `Generate Merged Source File` and `Connector Self-Review` are reported as `not-applicable` and the gate passes if `Tests` succeeds.
- [ ] Open a fork PR without `safe-to-test` — confirm `Tests` reports `skipped`, gate fails.

This pull request and its description were written by Isaac.