### PR TITLE
Align agent operations with the Scala interface shape

### DIFF
--- a/.claude/skills/implement-connector/SKILL.md
+++ b/.claude/skills/implement-connector/SKILL.md
@@ -109,7 +109,7 @@ The framework exposes an experimental ingestion-agent operation surface
 (`spark.read.format("lakeflow_connect").option("operation", ...)`)
 that's derived automatically from the `LakeflowConnect` methods you
 implement. **Do not** subclass `SupportsIngestionAgent`, `AgentOperation`,
-or any of the built-in op classes (`ListObjectsOp`, `PreviewTableOp`,
+or any of the built-in op classes (`ListObjectsOp`, `ReadTableOp`,
 …); do not override `agent_operations()`. The shape of the
 customisation API is still being finalised. Just implement
 `LakeflowConnect` — the agent surface comes along for free.

--- a/src/databricks/labs/community_connector/interface/agent_protocol.py
+++ b/src/databricks/labs/community_connector/interface/agent_protocol.py
@@ -19,6 +19,11 @@ class ErrorCode:
     :class:`AgentOperation`. The framework defaults to ``internal_error``
     for uncategorised exceptions and ``bad_request`` for its own
     detected option errors.
+
+    ``CONNECTION_FAILED`` is the conventional code that
+    :class:`ValidateConnectionOp` implementations raise on a failed
+    health check — keep it consistent across sources so agents can
+    dispatch on it.
     """
 
     AUTH_FAILED = "auth_failed"
@@ -28,6 +33,7 @@ class ErrorCode:
     BAD_REQUEST = "bad_request"
     UNSUPPORTED = "unsupported"
     INTERNAL_ERROR = "internal_error"
+    CONNECTION_FAILED = "connection_failed"
 
 
 class AgentError(Exception):

--- a/src/databricks/labs/community_connector/sparkpds/__init__.py
+++ b/src/databricks/labs/community_connector/sparkpds/__init__.py
@@ -22,7 +22,7 @@ from databricks.labs.community_connector.sparkpds.ingestion_agent_datasource imp
     IngestionAgentReader,
     ListObjectsOp,
     ListOperationsOp,
-    PreviewTableOp,
+    ReadTableOp,
     ValidateConnectionOp,
 )
 
@@ -36,7 +36,7 @@ __all__ = [
     # Built-in ingestion-agent operations — subclass these to customise
     # behaviour while keeping the framework's schema / dispatch contract.
     "ListObjectsOp",
-    "PreviewTableOp",
+    "ReadTableOp",
     "GetObjectMetadataOp",
     "ValidateConnectionOp",
     "ListOperationsOp",

--- a/src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+++ b/src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
@@ -35,7 +35,6 @@ Source customisation goes through
 
 from __future__ import annotations
 
-import itertools
 import json
 import re
 from typing import Any, Iterable, Iterator, Mapping, Optional, Tuple
@@ -59,7 +58,6 @@ from databricks.labs.community_connector.libs.utils import parse_value
 # ---------------------------------------------------------------------------
 
 OPERATION = "operation"
-PARENT = "parent"
 SEARCH = "search"
 PATH = "path"
 NAME = "name"
@@ -67,13 +65,10 @@ METADATA_KEY = "metadataKey"
 TABLE_NAME = "tableName"
 CATALOG_NAME = "catalogName"
 SCHEMA_NAME = "schemaName"
-LIMIT = "limit"
-
-DEFAULT_PREVIEW_LIMIT = 100
 
 # Built-in operation names exposed for callers and tests.
 OP_LIST_OBJECTS = "list_objects"
-OP_PREVIEW_TABLE = "preview_table"
+OP_READ_TABLE = "read_table"
 OP_GET_OBJECT_METADATA = "get_object_metadata"
 OP_VALIDATE_CONNECTION = "validate_connection"
 OP_LIST_OPERATIONS = "list_operations"
@@ -96,7 +91,7 @@ def _requires_connector(op: AgentOperation) -> bool:
 # agent option as one of its own. The user's request options keep these
 # keys; ops read them via the AgentOperation.pull options dict.
 _AGENT_RESERVED_KEYS = frozenset(
-    {OPERATION, PARENT, SEARCH, PATH, NAME, METADATA_KEY, LIMIT}
+    {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
 )
 
 
@@ -190,15 +185,17 @@ class ListObjectsOp(AgentOperation):
 
     name = OP_LIST_OBJECTS
     description = (
-        "Hierarchical listing of objects. Returns rows of (name, type, full_path)."
+        "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+        "`type` is source-defined; conventional values are `schema` / `table` / "
+        "`view` / `synonym`."
     )
     kind = KIND_METADATA
     schema = _LIST_OBJECTS_BASE_SCHEMA
     parameters = (
         Parameter(
-            name=PARENT,
-            description="Path identifying the parent to list under. "
-            "Empty/missing lists from the source root.",
+            name=PATH,
+            description="Parent path to list under. Empty / missing = top level. "
+            "Format is source-defined.",
         ),
         Parameter(
             name=SEARCH,
@@ -207,15 +204,15 @@ class ListObjectsOp(AgentOperation):
     )
 
     def pull(self, connector, options):
-        parent = options.get(PARENT) or None
+        path = options.get(PATH) or None
         search = options.get(SEARCH) or None
-        return self.produce(connector, parent=parent, search=search)
+        return self.produce(connector, path=path, search=search)
 
     def produce(
         self,
         connector: LakeflowConnect,
         *,
-        parent: Optional[str],
+        path: Optional[str],
         search: Optional[str],
     ) -> Iterable[Mapping[str, Any]]:
         """Yield rows of ``(name, type, full_path)``.
@@ -224,11 +221,23 @@ class ListObjectsOp(AgentOperation):
         return hierarchical results or to bind to a source-native
         listing API.
         """
-        return _default_list_objects(connector, parent, search)
+        return _default_list_objects(connector, path, search)
 
 
 class GetObjectMetadataOp(AgentOperation):
-    """Built-in: per-object metadata as ``(key, value)`` rows."""
+    """Built-in: per-object metadata as ``(key, value)`` rows.
+
+    Conventional keys (sources are free to add more, but using these
+    for the shared concerns keeps results consistent across sources):
+
+    - ``primary_key`` — comma-joined ordered column list of the PK.
+    - ``table_size`` — source-reported size in bytes (string-encoded).
+    - ``index_columns`` — JSON array of ordered column lists, one per
+      index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+    The framework applies the ``metadataKey`` filter case-insensitively
+    after ``produce`` emits, so sources don't need to handle it.
+    """
 
     name = OP_GET_OBJECT_METADATA
     description = "Per-object metadata as (key, value) rows."
@@ -236,24 +245,33 @@ class GetObjectMetadataOp(AgentOperation):
     schema = _GET_OBJECT_METADATA_BASE_SCHEMA
     parameters = (
         Parameter(name=NAME, required=True, description="Object name to describe."),
-        Parameter(name=PATH, description="Path of the parent (e.g. namespace)."),
+        Parameter(
+            name=PATH,
+            description="Parent path of the target object (source-defined).",
+        ),
         Parameter(
             name=METADATA_KEY,
-            description="If set, return only this specific metadata key.",
+            description=(
+                "Case-insensitive filter; if set, only rows whose `key` "
+                "matches are returned."
+            ),
         ),
     )
 
     def pull(self, connector, options):
         name = options[NAME]  # framework validated required.
         path = options.get(PATH) or None
-        metadata_key = options.get(METADATA_KEY) or None
-        return self.produce(
+        rows = self.produce(
             connector,
             path=path,
             name=name,
-            metadata_key=metadata_key,
             table_options=_connector_options(options),
         )
+        key_filter = options.get(METADATA_KEY)
+        if key_filter:
+            needle = key_filter.lower()
+            rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+        return rows
 
     def produce(
         self,
@@ -261,7 +279,6 @@ class GetObjectMetadataOp(AgentOperation):
         *,
         path: Optional[str],
         name: str,
-        metadata_key: Optional[str],
         table_options: Mapping[str, str],
     ) -> Iterable[Mapping[str, Any]]:
         """Yield ``(key, value)`` rows describing the named object.
@@ -276,36 +293,35 @@ class GetObjectMetadataOp(AgentOperation):
             connector,
             table_name=name,
             table_options=table_options,
-            metadata_key=metadata_key,
         )
 
 
-class PreviewTableOp(AgentOperation):
-    """Built-in: sample-read a tabular object.
+class ReadTableOp(AgentOperation):
+    """Built-in: read a tabular object in its native schema.
 
     Data-kind — rows pass through with the table's natural schema (no
-    ``_meta`` column) and errors surface as Spark exceptions. Override
-    :meth:`produce` to wire to a source-native sampling API.
+    ``_meta`` column) and errors surface as Spark exceptions. The
+    operation does not enforce a row cap of its own; callers wanting
+    a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+    Override :meth:`produce` to wire to a source-native read path.
     """
 
-    name = OP_PREVIEW_TABLE
-    description = "Sample a tabular object. Returns the table's natural schema and rows."
+    name = OP_READ_TABLE
+    description = "Read a tabular object. Returns the table's natural schema and rows."
     kind = KIND_DATA
     parameters = (
-        Parameter(name=TABLE_NAME, required=True, description="Table to sample."),
-        Parameter(
-            name=CATALOG_NAME,
-            description="Catalog qualifier when the source supports it.",
-        ),
+        Parameter(name=TABLE_NAME, required=True, description="Target object name."),
         Parameter(
             name=SCHEMA_NAME,
-            description="Schema qualifier when the source supports it.",
+            description="Schema within the parent path (source-defined).",
         ),
         Parameter(
-            name=LIMIT,
-            type="integer",
-            default=DEFAULT_PREVIEW_LIMIT,
-            description=f"Maximum rows to return (default {DEFAULT_PREVIEW_LIMIT}).",
+            name=CATALOG_NAME,
+            description=(
+                "Top-level catalog (source-defined). Two-level sources should "
+                "reject this rather than silently dropping it."
+            ),
         ),
     )
 
@@ -315,32 +331,25 @@ class PreviewTableOp(AgentOperation):
 
     def pull(self, connector, options):
         table_name = options[TABLE_NAME]
-        limit = _int_option(options, LIMIT, DEFAULT_PREVIEW_LIMIT)
-        table_options = _connector_options(options)
-        records = self.produce(
+        return self.produce(
             connector,
             table_name=table_name,
-            limit=limit,
-            table_options=table_options,
+            table_options=_connector_options(options),
         )
-        # Framework-side cap. Defends against an override that ignores `limit`.
-        return itertools.islice(records, limit)
 
     def produce(
         self,
         connector: LakeflowConnect,
         *,
         table_name: str,
-        limit: int,
         table_options: Mapping[str, str],
     ) -> Iterable[Mapping[str, Any]]:
-        """Yield up to ``limit`` records from ``table_name``.
+        """Yield records from ``table_name``.
 
-        Default consumes ``read_table`` and lets the framework slice.
-        Override to use a source-native LIMIT clause when available.
+        Default reads through ``LakeflowConnect.read_table``. Override
+        to bind to a source-native scan.
         """
-        del limit
-        return _default_preview_records(connector, table_name, table_options)
+        return _default_read_records(connector, table_name, table_options)
 
 
 class ValidateConnectionOp(AgentOperation):
@@ -349,6 +358,11 @@ class ValidateConnectionOp(AgentOperation):
     Returns one row with the standard ``_meta`` struct. Override
     :meth:`produce` to use a source-native ping; the default attempts
     ``connector.list_tables()`` and reports any raised exception.
+
+    Sources reporting a failed health check should raise
+    ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+    generic ``internal_error`` so consumers can dispatch on a dedicated
+    code.
     """
 
     name = OP_VALIDATE_CONNECTION
@@ -365,14 +379,15 @@ class ValidateConnectionOp(AgentOperation):
     def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
         """Return ``{status, code, message}`` for the connection.
 
-        Default: try ``list_tables``; report exceptions as ``error``.
+        Default: try ``list_tables``; report exceptions as
+        ``connection_failed``.
         """
         try:
             connector.list_tables()
         except Exception as exc:  # pylint: disable=broad-except
             return _meta(
                 status="error",
-                code=type(exc).__name__,
+                code=ErrorCode.CONNECTION_FAILED,
                 message=_error_str(exc),
             )
         return _meta(status="ok")
@@ -413,7 +428,7 @@ _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
     op.name: op
     for op in (
         ListObjectsOp(),
-        PreviewTableOp(),
+        ReadTableOp(),
         GetObjectMetadataOp(),
         ValidateConnectionOp(),
         ListOperationsOp(),
@@ -540,12 +555,19 @@ class IngestionAgentReader(DataSourceReader):
             return
 
         # If the connector failed and this op needs it, route by kind:
-        # metadata-kind → error row, data-kind → re-raise.
+        # metadata-kind → error row, data-kind → re-raise. validate_connection
+        # treats the init failure as the health-check answer and uses the
+        # canonical CONNECTION_FAILED code.
         if self.init_error is not None and _requires_connector(self.operation):
-            if self.operation.kind == KIND_METADATA:
+            if self.operation.kind == KIND_DATA:
+                raise self.init_error
+            if self.operation.name == OP_VALIDATE_CONNECTION:
+                yield from self._yield_error_rows(
+                    self.init_error, code=ErrorCode.CONNECTION_FAILED
+                )
+            else:
                 yield from self._yield_error_rows(self.init_error)
-                return
-            raise self.init_error
+            return
 
         request_options = _agent_options(self.options)
 
@@ -570,20 +592,28 @@ class IngestionAgentReader(DataSourceReader):
         for row in rows:
             yield parse_value(_with_default_meta(row), self.schema)
 
-    def _yield_error_rows(self, exc: BaseException):
-        yield parse_value(_with_default_meta(self._error_row(exc)), self.schema)
+    def _yield_error_rows(
+        self, exc: BaseException, code: Optional[str] = None
+    ):
+        yield parse_value(
+            _with_default_meta(self._error_row(exc, code=code)), self.schema
+        )
 
-    def _error_row(self, exc: BaseException) -> dict:
-        if isinstance(exc, AgentError):
-            code = exc.code
-            message = str(exc)
-        elif isinstance(exc, ValueError):
-            # Framework-detected input errors (legacy code paths still raise
-            # ValueError for missing options).
-            code = ErrorCode.BAD_REQUEST
+    def _error_row(
+        self, exc: BaseException, code: Optional[str] = None
+    ) -> dict:
+        if code is None:
+            if isinstance(exc, AgentError):
+                code = exc.code
+            elif isinstance(exc, ValueError):
+                # Framework-detected input errors (legacy code paths still raise
+                # ValueError for missing options).
+                code = ErrorCode.BAD_REQUEST
+            else:
+                code = ErrorCode.INTERNAL_ERROR
+        if isinstance(exc, (AgentError, ValueError)):
             message = str(exc)
         else:
-            code = ErrorCode.INTERNAL_ERROR
             message = _error_str(exc)
         return {"_meta": _meta(status="error", code=code, message=message)}
 
@@ -653,19 +683,6 @@ def _required_option(
             f"Operation '{operation}' requires option '{key}'.",
         )
     return value
-
-
-def _int_option(options: Mapping[str, str], key: str, default: int) -> int:
-    raw = options.get(key)
-    if raw is None or raw == "":
-        return default
-    try:
-        return int(raw)
-    except (TypeError, ValueError) as exc:
-        raise AgentError(
-            ErrorCode.BAD_REQUEST,
-            f"Option '{key}' must be an integer, got {raw!r}.",
-        ) from exc
 
 
 def _validate_required_parameters(
@@ -785,13 +802,13 @@ def _default_get_object_metadata(
     connector: LakeflowConnect,
     table_name: str,
     table_options: Mapping[str, str],
-    metadata_key: Optional[str],
 ) -> Iterator[dict]:
     """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
 
     Maps the connector's metadata keys to the standardised ingestion-agent
     keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
-    ``cursor_field``) and preserves the others verbatim.
+    ``cursor_field``) and preserves the others verbatim. The framework
+    applies the ``metadataKey`` filter case-insensitively above this.
     """
     raw = connector.read_table_metadata(table_name, table_options)
 
@@ -808,31 +825,15 @@ def _default_get_object_metadata(
             continue
         standardized.append((key, value))
 
-    if metadata_key is not None:
-        standardized = [(k, v) for k, v in standardized if k == metadata_key]
-        if not standardized:
-            return iter([
-                {
-                    "key": metadata_key,
-                    "value": None,
-                    "_meta": _meta(
-                        status="warning",
-                        code="metadata_key_not_found",
-                        message=f"Metadata key '{metadata_key}' is not "
-                        f"available for '{table_name}'.",
-                    ),
-                }
-            ])
-
     return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
 
 
-def _default_preview_records(
+def _default_read_records(
     connector: LakeflowConnect,
     table_name: str,
     table_options: Mapping[str, str],
 ) -> Iterator[Mapping[str, Any]]:
-    """Pull records from ``read_table``; the caller slices to the limit."""
+    """Pull all records from ``connector.read_table`` and yield them."""
     records, _offset = connector.read_table(table_name, None, dict(table_options))
     return records
 

--- a/tests/unit/sparkpds_ingestion_agent_test.py
+++ b/tests/unit/sparkpds_ingestion_agent_test.py
@@ -44,13 +44,12 @@ from databricks.labs.community_connector.sources.example.example import (
     ExampleLakeflowConnect,
 )
 from databricks.labs.community_connector.sparkpds.ingestion_agent_datasource import (
-    DEFAULT_PREVIEW_LIMIT,
     IngestionAgentDispatcher,
     ListObjectsOp,
     OP_GET_OBJECT_METADATA,
     OP_LIST_OBJECTS,
     OP_LIST_OPERATIONS,
-    OP_PREVIEW_TABLE,
+    OP_READ_TABLE,
     OP_VALIDATE_CONNECTION,
 )
 
@@ -112,8 +111,8 @@ def test_list_objects_search_filters_by_regex():
     assert [r["name"] for r in rows] == ["orders"]
 
 
-def test_list_objects_returns_empty_when_parent_unknown():
-    rows = _collect(_dispatcher(OP_LIST_OBJECTS, parent="some/path"))
+def test_list_objects_returns_empty_when_path_unknown():
+    rows = _collect(_dispatcher(OP_LIST_OBJECTS, path="some/path"))
     assert rows == []
 
 
@@ -137,15 +136,20 @@ def test_get_object_metadata_filters_by_key():
     assert rows[0]["key"] == "ingestion_type"
 
 
-def test_get_object_metadata_unknown_key_returns_warning_row():
+def test_get_object_metadata_filter_is_case_insensitive():
+    rows = _collect(
+        _dispatcher(OP_GET_OBJECT_METADATA, name="orders", metadataKey="INGESTION_TYPE")
+    )
+    assert len(rows) == 1
+    assert rows[0]["key"] == "ingestion_type"
+
+
+def test_get_object_metadata_unknown_key_returns_empty():
+    """Framework filters silently; an unknown key just yields no rows."""
     rows = _collect(
         _dispatcher(OP_GET_OBJECT_METADATA, name="orders", metadataKey="does_not_exist")
     )
-    assert len(rows) == 1
-    assert rows[0]["key"] == "does_not_exist"
-    assert rows[0]["value"] is None
-    assert rows[0]["_meta"]["status"] == "warning"
-    assert rows[0]["_meta"]["code"] == "metadata_key_not_found"
+    assert rows == []
 
 
 def test_get_object_metadata_missing_name_returns_error_row():
@@ -156,27 +160,22 @@ def test_get_object_metadata_missing_name_returns_error_row():
 
 
 # ---------------------------------------------------------------------------
-# Built-in: preview_table (data-kind)
+# Built-in: read_table (data-kind)
 # ---------------------------------------------------------------------------
 
-def test_preview_table_returns_rows_capped_by_limit():
-    dispatcher = _dispatcher(OP_PREVIEW_TABLE, tableName="orders", limit="2")
+def test_read_table_returns_rows_with_natural_schema():
+    dispatcher = _dispatcher(OP_READ_TABLE, tableName="orders")
     schema = dispatcher.schema()
     # Data-kind: source's natural schema, no _meta column.
     assert "_meta" not in [f.name for f in schema.fields]
     rows = _collect(dispatcher)
-    assert 0 < len(rows) <= 2
+    assert len(rows) > 0
 
 
-def test_preview_table_default_limit():
-    rows = _collect(_dispatcher(OP_PREVIEW_TABLE, tableName="products"))
-    assert len(rows) <= DEFAULT_PREVIEW_LIMIT
-
-
-def test_preview_table_missing_table_name_raises():
+def test_read_table_missing_table_name_raises():
     from databricks.labs.community_connector.interface import AgentError
 
-    dispatcher = _dispatcher(OP_PREVIEW_TABLE)
+    dispatcher = _dispatcher(OP_READ_TABLE)
     with pytest.raises(AgentError, match="tableName") as exc_info:
         dispatcher.schema()
     assert exc_info.value.code == "bad_request"
@@ -212,7 +211,7 @@ def test_list_operations_returns_builtin_catalog():
     names = {r["name"] for r in rows}
     assert {
         OP_LIST_OBJECTS,
-        OP_PREVIEW_TABLE,
+        OP_READ_TABLE,
         OP_GET_OBJECT_METADATA,
         OP_VALIDATE_CONNECTION,
         OP_LIST_OPERATIONS,
@@ -243,21 +242,22 @@ def test_list_operations_rows_carry_planning_metadata():
     # Schema is exposed as JSON; round-trippable.
     schema_json = json.loads(list_objects["result_schema_json"])
     assert any(f["name"] == "name" for f in schema_json["fields"])
-    # Parameters declare parent and search.
+    # Parameters declare path and search.
     params = json.loads(list_objects["parameters_json"])
     param_names = {p["name"] for p in params}
-    assert {"parent", "search"} == param_names
+    assert {"path", "search"} == param_names
 
-    preview = by_name[OP_PREVIEW_TABLE]
-    # preview_table is data-kind; its schema is dynamic, so result_schema_json is null.
-    assert preview["kind"] == "data"
-    assert preview["result_schema_json"] is None
-    preview_params = json.loads(preview["parameters_json"])
-    table_name_param = next(p for p in preview_params if p["name"] == "tableName")
+    read_table = by_name[OP_READ_TABLE]
+    # read_table is data-kind; its schema is dynamic, so result_schema_json is null.
+    assert read_table["kind"] == "data"
+    assert read_table["result_schema_json"] is None
+    read_table_params = json.loads(read_table["parameters_json"])
+    table_name_param = next(
+        p for p in read_table_params if p["name"] == "tableName"
+    )
     assert table_name_param["required"] is True
-    limit_param = next(p for p in preview_params if p["name"] == "limit")
-    assert limit_param["type"] == "integer"
-    assert limit_param["default"] == DEFAULT_PREVIEW_LIMIT
+    # No `limit` option on the shared interface — Spark's .limit() pushes down.
+    assert "limit" not in {p["name"] for p in read_table_params}
 
 
 # ---------------------------------------------------------------------------
@@ -338,13 +338,25 @@ def test_data_op_raises_when_connector_failed():
     """Data-kind ops → exception propagates."""
     init_error = RuntimeError("bad creds")
     dispatcher = _dispatcher(
-        OP_PREVIEW_TABLE,
+        OP_READ_TABLE,
         tableName="orders",
         connector=None,
         init_error=init_error,
     )
     with pytest.raises(RuntimeError, match="bad creds"):
         dispatcher.schema()
+
+
+def test_validate_connection_init_failure_uses_connection_failed_code():
+    """Init failure on validate_connection → connection_failed (not internal_error)."""
+    dispatcher = _dispatcher(
+        OP_VALIDATE_CONNECTION,
+        connector=None,
+        init_error=RuntimeError("bad creds"),
+    )
+    rows = _collect(dispatcher)
+    assert len(rows) == 1
+    assert rows[0]["_meta"]["code"] == ErrorCode.CONNECTION_FAILED
 
 
 # ---------------------------------------------------------------------------
@@ -354,11 +366,11 @@ def test_data_op_raises_when_connector_failed():
 class _NamespacedListObjectsOp(ListObjectsOp):
     """Subclass that returns a fake catalog/schema/table hierarchy."""
 
-    def produce(self, connector, *, parent, search):
+    def produce(self, connector, *, path, search):
         del connector, search
-        if parent is None:
+        if path is None:
             return [{"name": "public", "type": "schema", "full_path": "public"}]
-        if parent == "public":
+        if path == "public":
             return [{"name": "orders", "type": "table", "full_path": "public.orders"}]
         return []
 
@@ -383,15 +395,15 @@ def test_builtin_subclass_replaces_default_at_root():
     assert rows[0]["_meta"]["status"] == "ok"
 
 
-def test_builtin_subclass_handles_parent_drill_down():
-    rows = _collect(_namespaced_dispatcher(OP_LIST_OBJECTS, parent="public"))
+def test_builtin_subclass_handles_path_drill_down():
+    rows = _collect(_namespaced_dispatcher(OP_LIST_OBJECTS, path="public"))
     assert len(rows) == 1
     assert rows[0]["name"] == "orders"
     assert rows[0]["full_path"] == "public.orders"
 
 
-def test_builtin_subclass_returns_empty_for_unknown_parent():
-    rows = _collect(_namespaced_dispatcher(OP_LIST_OBJECTS, parent="other"))
+def test_builtin_subclass_returns_empty_for_unknown_path():
+    rows = _collect(_namespaced_dispatcher(OP_LIST_OBJECTS, path="other"))
     assert rows == []
 
 
@@ -493,7 +505,7 @@ def test_list_operations_includes_source_plug_ins():
     names = {r["name"] for r in rows}
     assert {
         "list_objects",
-        "preview_table",
+        "read_table",
         "get_object_metadata",
         "validate_connection",
         "list_operations",


### PR DESCRIPTION
Align the Python community-side `AgentOperation` shapes with the Scala interface bases established by [databricks-eng/universe#1930432](https://github.com/databricks-eng/universe/pull/1930432) (Oracle source on `ingestion_agent` v2 DSv2). Same protocol vocabulary on both sides.

## Changes

| Scala interface | Community Python after this PR |
|---|---|
| `ListObjectsOp` — opts `path`, `search`; rows `(name, type, full_path)` | ✅ same shape — renamed `parent` → `path` |
| `GetObjectMetadataOp` — opts `path`, `name` (required), `metadataKey` (case-insensitive); rows `(key, value)`; framework filters | ✅ same shape — moved `metadataKey` filter framework-side; dropped "key not found" warning row |
| `ReadTableOp` — opts `tableName` (required), `catalogName`, `schemaName`; data-kind; no `limit` (Spark `.limit()` pushes down) | ✅ renamed from `PreviewTableOp`; dropped framework-side row cap |
| `ValidateConnectionOp` — empty data fields; `CONNECTION_FAILED` on failed health check | ✅ same shape; added `ErrorCode.CONNECTION_FAILED`; dispatcher stamps it on init-failure error rows |

Conventional `get_object_metadata` keys documented (`primary_key`, `table_size`, `index_columns`) — sources can emit additional keys; the framework still standardises `primary_keys` / `cursor_field` / `ingestion_type` mappings.

## Out of scope

- The community-side dispatcher is still standalone scaffolding. Wiring it into `LakeflowSource` + extending the merge script to bundle `interface/agent_protocol.py` / `interface/supports_ingestion_agent.py` / `sparkpds/ingestion_agent_datasource.py` is a separate follow-up that touches the `_generated_*` files in lockstep.
- `implement-connector` skill's "out of scope" note still tells source authors not to wire any agent-related classes by hand.

## Test plan

- [x] `pytest tests/unit/sparkpds_ingestion_agent_test.py` — 33 passed (one new: case-insensitive metadataKey filter; one renamed: `init failure → connection_failed`)
- [x] `pytest tests/unit/libs tests/unit/source_simulator tests/unit/sparkpds_registry_test.py tests/unit/sparkpds_ingestion_agent_test.py tests/unit/test_sparkpds_virtual_tables.py tests/unit/sources/example` — 430 / 432 pass (2 unrelated skips)

This pull request and its description were written by Isaac.