### PR TITLE
Add `upload` subcommand to community-connector CLI

### DIFF
--- a/.claude/skills/build_connector_package/SKILL.md
+++ b/.claude/skills/build_connector_package/SKILL.md
@@ -58,48 +58,58 @@ packages = ["databricks.labs.community_connector.sources.{{source_name}}"]
 
 2. **Package Naming**: Use `lakeflow-community-connectors-{{source_name}}` format (with hyphens, not underscores)
 
-## Build Commands
+## Build + upload via the CLI (recommended)
 
-Run the following commands to set up a virtual environment and build the source package:
+`community-connector upload` wraps the build step and pushes the wheel to a UC
+Volume in one call. The destination volume and any subdirectories are created
+if they don't exist.
 
 ```bash
-# Navigate to the source directory
-cd src/databricks/labs/community_connector/sources/{{source_name}}
-
-# Create and activate a virtual environment
-python3 -m venv .venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-
-# Install build dependencies
-pip install build
-
-# Build the package
-python -m build
-
-# The built packages will be in the dist/ directory:
-# - lakeflow_community_connectors_{{source_name}}-0.1.0.tar.gz (source distribution)
-# - lakeflow_community_connectors_{{source_name}}-0.1.0-py3-none-any.whl (wheel)
+community-connector upload {{source_name}} \
+  --volume-path /Volumes/<catalog>/<schema>/community_connector/packages
 ```
 
-## Clean Up
-
-After building, clean up build artifacts:
+To skip the build step and upload a pre-built wheel:
 
 ```bash
-# Remove build artifacts (optional, before committing)
-rm -rf dist/ build/ *.egg-info .venv
+community-connector upload {{source_name}} \
+  --volume-path /Volumes/<catalog>/<schema>/community_connector/packages \
+  --wheel dist/{{source_name}}/lakeflow_community_connectors_{{source_name}}-0.1.0-py3-none-any.whl
+```
+
+The CLI sanity-checks the built wheel against
+`databricks/labs/community_connector/sources/{{source_name}}/` before upload, so
+a misconfigured `pyproject.toml` is caught before it reaches the volume.
+
+## Build-only commands (no upload)
+
+Use these only when you need a local wheel artifact without uploading.
+`python -m build` runs setuptools inside a PEP 517 isolated environment, so a
+per-connector `.venv` is not needed — install `build` once into whichever venv
+runs the command.
+
+```bash
+# One-time, in the venv that owns the CLI / your dev workflow
+pip install build
+
+# Build the wheel for {{source_name}}
+python -m build --wheel \
+  src/databricks/labs/community_connector/sources/{{source_name}} \
+  --outdir dist/{{source_name}}
+
+# Result:
+# dist/{{source_name}}/lakeflow_community_connectors_{{source_name}}-0.1.0-py3-none-any.whl
 ```
 
 ## Verification
 
-After building, verify the package contents:
+After building, list the wheel contents:
 
 ```bash
-# List contents of the wheel
-unzip -l dist/*.whl
+unzip -l dist/{{source_name}}/*.whl
 ```
 
-The wheel should contain files under the path:
+The wheel must contain files under:
 `databricks/labs/community_connector/sources/{{source_name}}/`
 
 ## References

--- a/tools/community_connector/README.md
+++ b/tools/community_connector/README.md
@@ -173,6 +173,44 @@ community-connector update_connection github my_github_conn \
 | `--options` | `-o` | Connection options as JSON string (required) |
 | `--spec` | `-s` | Optional: local path to connector_spec.yaml, or a GitHub repo URL |
 
+### `upload`
+
+Build a connector wheel from its `pyproject.toml` and upload it to a UC Volume.
+The volume and any missing subdirectories are created automatically.
+
+```bash
+# Build sources/example/ and upload to a UC Volume
+community-connector upload example \
+  --volume-path /Volumes/main/default/community_connector/packages
+
+# Skip the build step and upload a pre-built wheel
+community-connector upload example \
+  --volume-path /Volumes/main/default/community_connector/packages \
+  --wheel ./dist/lakeflow_community_connectors_example-0.1.0-py3-none-any.whl
+
+# Build from a non-conventional source location and keep the wheel locally
+community-connector upload my_source \
+  --volume-path /Volumes/main/default/community_connector/packages \
+  --source-dir ./my_connector \
+  --keep-wheel ./dist
+```
+
+The build step shells out to `python -m build`, which runs setuptools inside a
+PEP 517 isolated environment — no per-connector venv setup needed. Install the
+`build` frontend once into the venv that owns the CLI:
+
+```bash
+pip install build
+```
+
+**Options:**
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--volume-path` | `-v` | UC Volume directory to upload into (required). Auto-creates the volume and any subdirectories. |
+| `--wheel` | | Skip the build step and upload this pre-built wheel. |
+| `--source-dir` | | Override the connector source directory (default: locate `sources/<source_name>/`). |
+| `--keep-wheel` | | After upload, copy the built wheel into this local directory. Ignored when `--wheel` is supplied. |
+
 ## Pipeline Spec Format
 
 The pipeline spec defines which tables to ingest and how:

--- a/tools/community_connector/README.md
+++ b/tools/community_connector/README.md
@@ -175,20 +175,31 @@ community-connector update_connection github my_github_conn \
 
 ### `upload`
 
-Build a connector wheel from its `pyproject.toml` and upload it to a UC Volume.
-The volume and any missing subdirectories are created automatically.
+Build and upload connector wheels to a UC Volume. By default `upload` ships
+**two** wheels per call: the root framework wheel
+(`lakeflow_community_connectors-*.whl`) and the connector wheel
+(`lakeflow_community_connectors_<source>-*.whl`). The connector declares the
+framework as a runtime dep, so shipping both keeps clusters from trying to
+fetch the framework from PyPI (where it is not published). The volume and any
+missing subdirectories are created automatically.
 
 ```bash
-# Build sources/example/ and upload to a UC Volume
+# Default: build + upload framework wheel and connector wheel
 community-connector upload example \
   --volume-path /Volumes/main/default/community_connector/packages
 
-# Skip the build step and upload a pre-built wheel
+# Iterating on the connector: framework already on the volume, skip it
 community-connector upload example \
   --volume-path /Volumes/main/default/community_connector/packages \
-  --wheel ./dist/lakeflow_community_connectors_example-0.1.0-py3-none-any.whl
+  --skip-framework
 
-# Build from a non-conventional source location and keep the wheel locally
+# Bring your own wheels
+community-connector upload example \
+  --volume-path /Volumes/main/default/community_connector/packages \
+  --wheel ./dist/lakeflow_community_connectors_example-0.1.0-py3-none-any.whl \
+  --framework-wheel ./dist/lakeflow_community_connectors-0.1.0-py3-none-any.whl
+
+# Non-conventional source layout + retain a local copy of what we built
 community-connector upload my_source \
   --volume-path /Volumes/main/default/community_connector/packages \
   --source-dir ./my_connector \
@@ -203,13 +214,20 @@ PEP 517 isolated environment — no per-connector venv setup needed. Install the
 pip install build
 ```
 
+After upload, reference both wheel paths in your pipeline's
+`environment.dependencies` (e.g. via `community-connector create_pipeline
+--package <fw_path> --package <connector_path>`) so the cluster installs them
+in order.
+
 **Options:**
 | Option | Short | Description |
 |--------|-------|-------------|
 | `--volume-path` | `-v` | UC Volume directory to upload into (required). Auto-creates the volume and any subdirectories. |
-| `--wheel` | | Skip the build step and upload this pre-built wheel. |
+| `--wheel` | | Pre-built connector wheel; skip building it. |
+| `--framework-wheel` | | Pre-built framework (root) wheel; skip building it. |
+| `--skip-framework` | | Do not upload the framework wheel (use when it is already on the volume). |
 | `--source-dir` | | Override the connector source directory (default: locate `sources/<source_name>/`). |
-| `--keep-wheel` | | After upload, copy the built wheel into this local directory. Ignored when `--wheel` is supplied. |
+| `--keep-wheel` | | After upload, copy any wheels built in this run into this local directory. User-supplied wheels are not copied. |
 
 ## Pipeline Spec Format
 

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -14,9 +14,14 @@ import dataclasses
 import json
 import os
 import re
+import shutil
+import subprocess
+import sys
+import tempfile
 import traceback
+import zipfile
 from pathlib import Path
-from typing import Optional, List, Set
+from typing import Optional, List, Set, Tuple
 
 import click
 import yaml
@@ -742,6 +747,167 @@ def _resolve_package_catalog_schema(
             "Provide --catalog and --schema, or ensure the pipeline service assigns them."
         )
     return pkg_catalog, pkg_schema
+
+
+# ---- Helpers for the standalone `upload` command -----------------------------
+
+_VOLUME_PATH_RE = re.compile(r"^/Volumes/([^/]+)/([^/]+)/([^/]+)(?:/(.*))?$")
+
+
+def _parse_volume_path(volume_path: str) -> Tuple[str, str, str, str]:
+    """Parse a UC Volume path into (catalog, schema, volume, subpath).
+
+    Accepts ``/Volumes/<catalog>/<schema>/<volume>`` with or without a trailing
+    subpath. The subpath is normalized: empty string when the path points at
+    the volume root, with no leading or trailing slash.
+    """
+    cleaned = volume_path.rstrip("/")
+    match = _VOLUME_PATH_RE.match(cleaned)
+    if not match:
+        raise click.ClickException(
+            f"Invalid volume path '{volume_path}'. "
+            "Expected /Volumes/<catalog>/<schema>/<volume>[/<subdir>...]."
+        )
+    catalog, schema, volume, subpath = match.groups()
+    return catalog, schema, volume, (subpath or "")
+
+
+def _ensure_volume_directory(workspace_client, volume_path: str, debug: bool) -> str:
+    """Ensure the UC Volume and any subdirectory in ``volume_path`` exist.
+
+    Creates the volume (MANAGED) if missing, then creates the nested
+    subdirectory tree via the Files API. Returns the normalized destination
+    path (no trailing slash) ready for an upload.
+    """
+    catalog, schema, volume, subpath = _parse_volume_path(volume_path)
+    volume_fqn = f"{catalog}.{schema}.{volume}"
+
+    try:
+        workspace_client.volumes.read(volume_fqn)
+        if debug:
+            click.echo(f"[DEBUG] Volume '{volume_fqn}' already exists")
+    except Exception:
+        click.echo(f"  Creating volume '{volume_fqn}'...")
+        try:
+            workspace_client.volumes.create(
+                catalog_name=catalog,
+                schema_name=schema,
+                name=volume,
+                volume_type=VolumeType.MANAGED,
+            )
+            click.echo("  ✓ Volume created")
+        except Exception as e:
+            if "ALREADY_EXISTS" in str(e):
+                if debug:
+                    click.echo(f"[DEBUG] Volume already exists (race condition): {e}")
+            else:
+                raise click.ClickException(f"Failed to create volume: {e}")
+
+    dest_dir = f"/Volumes/{catalog}/{schema}/{volume}"
+    if subpath:
+        dest_dir = f"{dest_dir}/{subpath}"
+        try:
+            workspace_client.files.create_directory(dest_dir)
+            if debug:
+                click.echo(f"[DEBUG] Ensured directory: {dest_dir}")
+        except Exception as e:
+            # SDKs differ: some return success on existing dirs, some raise.
+            if "ALREADY_EXISTS" in str(e) or "exists" in str(e).lower():
+                if debug:
+                    click.echo(f"[DEBUG] Directory already exists: {dest_dir}")
+            else:
+                raise click.ClickException(
+                    f"Failed to create directory '{dest_dir}': {e}"
+                )
+
+    return dest_dir
+
+
+def _check_build_module_available() -> None:
+    """Verify the ``build`` PEP 517 frontend is importable.
+
+    Raises a ClickException with a clear install hint if it is missing. We do
+    not declare ``build`` as a CLI dependency to keep the runtime install
+    light, so users opt in by installing it themselves.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", "import build"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise click.ClickException(
+            "The `build` package is required to build connector wheels. "
+            f"Install it with: {sys.executable} -m pip install build"
+        )
+
+
+def _build_connector_wheel(source_dir: Path, outdir: Path, debug: bool) -> Path:
+    """Build the connector wheel at ``source_dir`` into ``outdir``.
+
+    Shells out to ``python -m build`` so the actual setuptools build runs in a
+    PEP 517 isolated environment. Returns the path to the built ``.whl``.
+    """
+    _check_build_module_available()
+
+    if not (source_dir / "pyproject.toml").is_file():
+        raise click.ClickException(
+            f"No pyproject.toml found at {source_dir}. "
+            "Each connector source directory must have its own pyproject.toml."
+        )
+
+    click.echo(f"  Building wheel from: {source_dir}")
+    cmd = [sys.executable, "-m", "build", "--wheel", str(source_dir), "--outdir", str(outdir)]
+    if debug:
+        click.echo(f"[DEBUG] Running: {' '.join(cmd)}")
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        if debug:
+            click.echo(result.stdout)
+            click.echo(result.stderr)
+        # Surface the last few lines of stderr to give users a useful hint
+        # without dumping the entire build log.
+        tail = "\n".join(result.stderr.strip().splitlines()[-10:])
+        raise click.ClickException(f"`python -m build` failed:\n{tail}")
+
+    wheels = sorted(outdir.glob("*.whl"))
+    if not wheels:
+        raise click.ClickException(
+            f"Build succeeded but no wheel was produced in {outdir}."
+        )
+    if len(wheels) > 1:
+        # Take the newest by mtime; warn so the user knows.
+        click.echo(
+            f"  ⚠️  Multiple wheels found in {outdir}; using {wheels[-1].name}"
+        )
+    click.echo(f"  ✓ Built wheel: {wheels[-1].name}")
+    return wheels[-1]
+
+
+def _validate_wheel_layout(wheel_path: Path, source_name: str) -> None:
+    """Sanity check: the wheel must ship files under the connector's namespace.
+
+    Catches mistakes like building from a directory whose pyproject.toml
+    doesn't include the right package — without this the upload would silently
+    publish an unusable wheel.
+    """
+    expected_prefix = f"databricks/labs/community_connector/sources/{source_name}/"
+    try:
+        with zipfile.ZipFile(wheel_path) as zf:
+            names = zf.namelist()
+    except zipfile.BadZipFile as e:
+        raise click.ClickException(f"Built artifact {wheel_path} is not a valid wheel: {e}")
+
+    if not any(name.startswith(expected_prefix) for name in names):
+        raise click.ClickException(
+            f"Wheel {wheel_path.name} does not contain '{expected_prefix}'. "
+            "Check the connector's pyproject.toml [tool.setuptools.packages]."
+        )
+
+
+# ---- end upload helpers ------------------------------------------------------
 
 
 def _upload_packages_and_update_pipeline(
@@ -1692,6 +1858,109 @@ def update_connection(
             click.echo(f"\n[DEBUG] Full connection info: {connection_info}")
     except Exception as e:
         _handle_api_error(e, "update", debug)
+
+
+@main.command("upload")
+@click.argument("source_name")
+@click.option(
+    "--volume-path",
+    "-v",
+    required=True,
+    help="UC Volume directory to upload the wheel into, "
+    "e.g. /Volumes/main/default/community_connector/packages. "
+    "The volume and any missing subdirectories are created automatically.",
+)
+@click.option(
+    "--wheel",
+    "wheel_path",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Skip the build step and upload this pre-built wheel.",
+)
+@click.option(
+    "--source-dir",
+    type=click.Path(exists=True, file_okay=False),
+    help="Override the connector source directory (default: locate sources/<source_name>/).",
+)
+@click.option(
+    "--keep-wheel",
+    "keep_wheel_dir",
+    type=click.Path(file_okay=False),
+    help="After upload, copy the built wheel into this local directory.",
+)
+@click.pass_context
+def upload(
+    ctx: click.Context,
+    source_name: str,
+    volume_path: str,
+    wheel_path: Optional[str],
+    source_dir: Optional[str],
+    keep_wheel_dir: Optional[str],
+):
+    """
+    Build a connector wheel and upload it to a UC Volume.
+
+    Builds the wheel from the connector's pyproject.toml (or uses --wheel if
+    given) and uploads it to --volume-path. Auto-creates the volume and any
+    missing subdirectories.
+
+    Example:
+
+        community-connector upload example \
+            --volume-path /Volumes/main/default/community_connector/packages
+    """
+    debug = ctx.obj.get("debug", False)
+    workspace_client = _make_workspace_client()
+
+    click.echo(f"Uploading connector: {source_name}")
+
+    click.echo("\nStep 1: Ensuring destination volume and directory exist...")
+    dest_dir = _ensure_volume_directory(workspace_client, volume_path, debug)
+    click.echo(f"  Destination: {dest_dir}")
+
+    cleanup_dir: Optional[Path] = None
+    try:
+        if wheel_path:
+            click.echo("\nStep 2: Using pre-built wheel (--wheel provided)")
+            wheel = Path(wheel_path).resolve()
+        else:
+            click.echo("\nStep 2: Building wheel...")
+            if source_dir:
+                src = Path(source_dir).resolve()
+            else:
+                src = _find_local_source_path(source_name)
+                if src is None:
+                    raise click.ClickException(
+                        f"Could not find source directory for '{source_name}'. "
+                        "Run from the repo root, or pass --source-dir explicitly."
+                    )
+            cleanup_dir = Path(tempfile.mkdtemp(prefix=f"cc-build-{source_name}-"))
+            wheel = _build_connector_wheel(src, cleanup_dir, debug)
+
+        _validate_wheel_layout(wheel, source_name)
+
+        click.echo("\nStep 3: Uploading wheel...")
+        dest_path = f"{dest_dir}/{wheel.name}"
+        click.echo(f"  Uploading to: {dest_path}")
+        try:
+            with open(wheel, "rb") as f:
+                workspace_client.files.upload(dest_path, f, overwrite=True)
+        except Exception as e:
+            raise click.ClickException(f"Failed to upload wheel: {e}")
+        click.echo("  ✓ Uploaded")
+
+        if keep_wheel_dir and not wheel_path:
+            keep = Path(keep_wheel_dir)
+            keep.mkdir(parents=True, exist_ok=True)
+            kept = keep / wheel.name
+            shutil.copy2(wheel, kept)
+            click.echo(f"  ✓ Wheel retained at: {kept}")
+
+        click.echo(f"\n{'=' * 60}")
+        click.echo(f"Uploaded: {dest_path}")
+        click.echo(f"{'=' * 60}")
+    finally:
+        if cleanup_dir and cleanup_dir.exists():
+            shutil.rmtree(cleanup_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -968,6 +968,108 @@ def _upload_wheel(workspace_client, wheel: Path, dest_dir: str) -> str:
     return dest_path
 
 
+def _resolve_source_dir(source_name: str, source_dir: Optional[str]) -> Path:
+    """Pick the connector source dir from --source-dir or the conventional layout."""
+    if source_dir:
+        return Path(source_dir).resolve()
+    src = _find_local_source_path(source_name)
+    if src is None:
+        raise click.ClickException(
+            f"Could not find source directory for '{source_name}'. "
+            "Run from the repo root, or pass --source-dir explicitly."
+        )
+    return src
+
+
+def _resolve_repo_root_for_upload(
+    src: Path, skip_framework: bool, framework_wheel_path: Optional[str],
+) -> Optional[Path]:
+    """Locate the framework repo root, or return None if we won't build it.
+
+    Only resolves when we actually intend to build the framework wheel — if
+    the user supplied --framework-wheel or --skip-framework, no lookup needed.
+    """
+    if skip_framework or framework_wheel_path:
+        return None
+    repo_root = _find_repo_root(src)
+    if repo_root is None:
+        raise click.ClickException(
+            "Could not find the framework repo root (a pyproject.toml with "
+            "name = \"lakeflow-community-connectors\"). Pass --framework-wheel, "
+            "or use --skip-framework if the framework is already on the volume."
+        )
+    return repo_root
+
+
+def _prepare_upload_wheels(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    source_name: str,
+    src: Path,
+    repo_root: Optional[Path],
+    wheel_path: Optional[str],
+    framework_wheel_path: Optional[str],
+    skip_framework: bool,
+    build_dir: Path,
+    debug: bool,
+) -> List[Tuple[Path, str, bool]]:
+    """Build or accept pre-built wheels; return (path, kind, was_built) list.
+
+    Framework wheel comes first so pip resolves the connector's framework
+    dep locally when both are installed in order.
+    """
+    click.echo("\nStep 2: Preparing wheels...")
+    wheels: List[Tuple[Path, str, bool]] = []
+
+    if not skip_framework:
+        if framework_wheel_path:
+            fw = Path(framework_wheel_path).resolve()
+            click.echo(f"  Using pre-built framework wheel: {fw.name}")
+            wheels.append((fw, "framework", False))
+        else:
+            assert repo_root is not None
+            click.echo(f"  Building framework wheel from: {repo_root}")
+            fw = _build_connector_wheel(repo_root, build_dir, debug)
+            wheels.append((fw, "framework", True))
+        _validate_framework_wheel(wheels[-1][0])
+
+    if wheel_path:
+        conn = Path(wheel_path).resolve()
+        click.echo(f"  Using pre-built connector wheel: {conn.name}")
+        wheels.append((conn, "connector", False))
+    else:
+        click.echo(f"  Building connector wheel from: {src}")
+        conn = _build_connector_wheel(src, build_dir, debug)
+        wheels.append((conn, "connector", True))
+    _validate_wheel_layout(wheels[-1][0], source_name)
+
+    return wheels
+
+
+def _retain_built_wheels(
+    wheels: List[Tuple[Path, str, bool]], keep_wheel_dir: str,
+) -> None:
+    """Copy wheels we built in this run (not user-supplied ones) to a local dir."""
+    keep = Path(keep_wheel_dir)
+    keep.mkdir(parents=True, exist_ok=True)
+    for wheel, _kind, was_built in wheels:
+        if was_built:
+            kept = keep / wheel.name
+            shutil.copy2(wheel, kept)
+            click.echo(f"  ✓ Wheel retained at: {kept}")
+
+
+def _echo_upload_summary(dest_paths: List[str]) -> None:
+    """Print the final list of uploaded wheel paths."""
+    click.echo(f"\n{'=' * 60}")
+    click.echo("Uploaded:")
+    for path in dest_paths:
+        click.echo(f"  - {path}")
+    click.echo(f"{'=' * 60}")
+    click.echo(
+        "\nReference both paths in your pipeline's "
+        "`environment.dependencies` to install on the cluster."
+    )
+
+
 # ---- end upload helpers ------------------------------------------------------
 
 
@@ -1988,102 +2090,40 @@ def upload(
             --volume-path /Volumes/main/default/community_connector/packages
     """
     debug = ctx.obj.get("debug", False)
-    workspace_client = _make_workspace_client()
 
     if skip_framework and framework_wheel_path:
         raise click.ClickException(
             "--skip-framework and --framework-wheel are mutually exclusive."
         )
 
+    workspace_client = _make_workspace_client()
     click.echo(f"Uploading connector: {source_name}")
 
     click.echo("\nStep 1: Ensuring destination volume and directory exist...")
     dest_dir = _ensure_volume_directory(workspace_client, volume_path, debug)
     click.echo(f"  Destination: {dest_dir}")
 
-    # Resolve source dir up front — we need it for both connector-build and
-    # repo-root discovery.
-    if source_dir:
-        src = Path(source_dir).resolve()
-    else:
-        src = _find_local_source_path(source_name)
-        if src is None:
-            raise click.ClickException(
-                f"Could not find source directory for '{source_name}'. "
-                "Run from the repo root, or pass --source-dir explicitly."
-            )
-
-    # Resolve repo root only when we will actually build the framework wheel.
-    repo_root: Optional[Path] = None
-    if not skip_framework and not framework_wheel_path:
-        repo_root = _find_repo_root(src)
-        if repo_root is None:
-            raise click.ClickException(
-                "Could not find the framework repo root (a pyproject.toml with "
-                "name = \"lakeflow-community-connectors\"). Pass --framework-wheel, "
-                "or use --skip-framework if the framework is already on the volume."
-            )
+    src = _resolve_source_dir(source_name, source_dir)
+    repo_root = _resolve_repo_root_for_upload(src, skip_framework, framework_wheel_path)
 
     cleanup_dir: Optional[Path] = None
     try:
         cleanup_dir = Path(tempfile.mkdtemp(prefix=f"cc-build-{source_name}-"))
-
-        # Step 2: assemble the list of wheels to upload (framework first so
-        # the connector's dep on it resolves when both are installed in order).
-        click.echo("\nStep 2: Preparing wheels...")
-        # Each entry: (wheel_path, validator, was_built_in_this_run)
-        wheels: List[Tuple[Path, str, bool]] = []
-
-        if not skip_framework:
-            if framework_wheel_path:
-                fw = Path(framework_wheel_path).resolve()
-                click.echo(f"  Using pre-built framework wheel: {fw.name}")
-                _validate_framework_wheel(fw)
-                wheels.append((fw, "framework", False))
-            else:
-                assert repo_root is not None
-                click.echo(f"  Building framework wheel from: {repo_root}")
-                fw = _build_connector_wheel(repo_root, cleanup_dir, debug)
-                _validate_framework_wheel(fw)
-                wheels.append((fw, "framework", True))
-
-        if wheel_path:
-            conn = Path(wheel_path).resolve()
-            click.echo(f"  Using pre-built connector wheel: {conn.name}")
-            _validate_wheel_layout(conn, source_name)
-            wheels.append((conn, "connector", False))
-        else:
-            click.echo(f"  Building connector wheel from: {src}")
-            conn = _build_connector_wheel(src, cleanup_dir, debug)
-            _validate_wheel_layout(conn, source_name)
-            wheels.append((conn, "connector", True))
-
-        # Step 3: upload each wheel.
-        click.echo("\nStep 3: Uploading wheels...")
-        dest_paths: List[str] = []
-        for wheel, _kind, _built in wheels:
-            dest_paths.append(_upload_wheel(workspace_client, wheel, dest_dir))
-
-        # Step 4: optionally retain the wheels we built (not the ones the
-        # user supplied — those are already on their disk).
-        if keep_wheel_dir:
-            keep = Path(keep_wheel_dir)
-            keep.mkdir(parents=True, exist_ok=True)
-            for wheel, _kind, was_built in wheels:
-                if was_built:
-                    kept = keep / wheel.name
-                    shutil.copy2(wheel, kept)
-                    click.echo(f"  ✓ Wheel retained at: {kept}")
-
-        click.echo(f"\n{'=' * 60}")
-        click.echo("Uploaded:")
-        for path in dest_paths:
-            click.echo(f"  - {path}")
-        click.echo(f"{'=' * 60}")
-        click.echo(
-            "\nReference both paths in your pipeline's "
-            "`environment.dependencies` to install on the cluster."
+        wheels = _prepare_upload_wheels(
+            source_name, src, repo_root, wheel_path, framework_wheel_path,
+            skip_framework, cleanup_dir, debug,
         )
+
+        click.echo("\nStep 3: Uploading wheels...")
+        dest_paths = [
+            _upload_wheel(workspace_client, wheel, dest_dir)
+            for wheel, _kind, _built in wheels
+        ]
+
+        if keep_wheel_dir:
+            _retain_built_wheels(wheels, keep_wheel_dir)
+
+        _echo_upload_summary(dest_paths)
     finally:
         if cleanup_dir and cleanup_dir.exists():
             shutil.rmtree(cleanup_dir, ignore_errors=True)

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -910,6 +910,64 @@ def _validate_wheel_layout(wheel_path: Path, source_name: str) -> None:
         )
 
 
+def _validate_framework_wheel(wheel_path: Path) -> None:
+    """Sanity check: the framework wheel must ship the interface package.
+
+    The connector wheel declares ``lakeflow-community-connectors>=0.1.0`` as a
+    runtime dep, so the framework wheel must satisfy that import path on the
+    cluster.
+    """
+    expected_prefix = "databricks/labs/community_connector/interface/"
+    try:
+        with zipfile.ZipFile(wheel_path) as zf:
+            names = zf.namelist()
+    except zipfile.BadZipFile as e:
+        raise click.ClickException(f"Built artifact {wheel_path} is not a valid wheel: {e}")
+
+    if not any(name.startswith(expected_prefix) for name in names):
+        raise click.ClickException(
+            f"Framework wheel {wheel_path.name} does not contain "
+            f"'{expected_prefix}'. Check the root pyproject.toml."
+        )
+
+
+def _find_repo_root(start: Path) -> Optional[Path]:
+    """Walk up from ``start`` looking for the framework's repo root.
+
+    The repo root is identified by a ``pyproject.toml`` whose ``[project]``
+    name is ``lakeflow-community-connectors`` (the framework package, not a
+    connector). Returns None if no such directory is found.
+    """
+    for candidate in [start, *start.parents]:
+        pyproject = candidate / "pyproject.toml"
+        if not pyproject.is_file():
+            continue
+        try:
+            content = pyproject.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        # Cheap check: the framework root's [project] block is the only one
+        # whose name is exactly ``lakeflow-community-connectors`` (connectors
+        # are named ``lakeflow-community-connectors-<source>``).
+        if re.search(r'^\s*name\s*=\s*"lakeflow-community-connectors"\s*$',
+                     content, re.MULTILINE):
+            return candidate.resolve()
+    return None
+
+
+def _upload_wheel(workspace_client, wheel: Path, dest_dir: str) -> str:
+    """Upload a single wheel to ``dest_dir`` and return the destination path."""
+    dest_path = f"{dest_dir}/{wheel.name}"
+    click.echo(f"  Uploading {wheel.name} → {dest_path}")
+    try:
+        with open(wheel, "rb") as f:
+            workspace_client.files.upload(dest_path, f, overwrite=True)
+    except Exception as e:
+        raise click.ClickException(f"Failed to upload {wheel.name}: {e}")
+    click.echo("  ✓ Uploaded")
+    return dest_path
+
+
 # ---- end upload helpers ------------------------------------------------------
 
 
@@ -1869,7 +1927,7 @@ def update_connection(
     "--volume-path",
     "-v",
     required=True,
-    help="UC Volume directory to upload the wheel into, "
+    help="UC Volume directory to upload wheels into, "
     "e.g. /Volumes/main/default/community_connector/packages. "
     "The volume and any missing subdirectories are created automatically.",
 )
@@ -1877,7 +1935,19 @@ def update_connection(
     "--wheel",
     "wheel_path",
     type=click.Path(exists=True, dir_okay=False),
-    help="Skip the build step and upload this pre-built wheel.",
+    help="Pre-built connector wheel; skip building it.",
+)
+@click.option(
+    "--framework-wheel",
+    "framework_wheel_path",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Pre-built framework (root) wheel; skip building it.",
+)
+@click.option(
+    "--skip-framework",
+    is_flag=True,
+    help="Do not upload the framework wheel "
+    "(use when it is already present on the volume from a prior run).",
 )
 @click.option(
     "--source-dir",
@@ -1888,7 +1958,7 @@ def update_connection(
     "--keep-wheel",
     "keep_wheel_dir",
     type=click.Path(file_okay=False),
-    help="After upload, copy the built wheel into this local directory.",
+    help="After upload, copy any wheels built in this run into this local directory.",
 )
 @click.pass_context
 def upload(
@@ -1896,15 +1966,21 @@ def upload(
     source_name: str,
     volume_path: str,
     wheel_path: Optional[str],
+    framework_wheel_path: Optional[str],
+    skip_framework: bool,
     source_dir: Optional[str],
     keep_wheel_dir: Optional[str],
 ):
     """
-    Build a connector wheel and upload it to a UC Volume.
+    Build and upload connector wheels to a UC Volume.
 
-    Builds the wheel from the connector's pyproject.toml (or uses --wheel if
-    given) and uploads it to --volume-path. Auto-creates the volume and any
-    missing subdirectories.
+    By default uploads two wheels: the root framework wheel
+    (``lakeflow_community_connectors-*.whl``) and the connector wheel
+    (``lakeflow_community_connectors_<source>-*.whl``). The connector wheel
+    declares the framework as a runtime dep, so shipping both keeps clusters
+    from trying to fetch the framework from PyPI.
+
+    Use ``--skip-framework`` once the framework wheel is already on the volume.
 
     Example:
 
@@ -1914,53 +1990,100 @@ def upload(
     debug = ctx.obj.get("debug", False)
     workspace_client = _make_workspace_client()
 
+    if skip_framework and framework_wheel_path:
+        raise click.ClickException(
+            "--skip-framework and --framework-wheel are mutually exclusive."
+        )
+
     click.echo(f"Uploading connector: {source_name}")
 
     click.echo("\nStep 1: Ensuring destination volume and directory exist...")
     dest_dir = _ensure_volume_directory(workspace_client, volume_path, debug)
     click.echo(f"  Destination: {dest_dir}")
 
+    # Resolve source dir up front — we need it for both connector-build and
+    # repo-root discovery.
+    if source_dir:
+        src = Path(source_dir).resolve()
+    else:
+        src = _find_local_source_path(source_name)
+        if src is None:
+            raise click.ClickException(
+                f"Could not find source directory for '{source_name}'. "
+                "Run from the repo root, or pass --source-dir explicitly."
+            )
+
+    # Resolve repo root only when we will actually build the framework wheel.
+    repo_root: Optional[Path] = None
+    if not skip_framework and not framework_wheel_path:
+        repo_root = _find_repo_root(src)
+        if repo_root is None:
+            raise click.ClickException(
+                "Could not find the framework repo root (a pyproject.toml with "
+                "name = \"lakeflow-community-connectors\"). Pass --framework-wheel, "
+                "or use --skip-framework if the framework is already on the volume."
+            )
+
     cleanup_dir: Optional[Path] = None
     try:
-        if wheel_path:
-            click.echo("\nStep 2: Using pre-built wheel (--wheel provided)")
-            wheel = Path(wheel_path).resolve()
-        else:
-            click.echo("\nStep 2: Building wheel...")
-            if source_dir:
-                src = Path(source_dir).resolve()
+        cleanup_dir = Path(tempfile.mkdtemp(prefix=f"cc-build-{source_name}-"))
+
+        # Step 2: assemble the list of wheels to upload (framework first so
+        # the connector's dep on it resolves when both are installed in order).
+        click.echo("\nStep 2: Preparing wheels...")
+        # Each entry: (wheel_path, validator, was_built_in_this_run)
+        wheels: List[Tuple[Path, str, bool]] = []
+
+        if not skip_framework:
+            if framework_wheel_path:
+                fw = Path(framework_wheel_path).resolve()
+                click.echo(f"  Using pre-built framework wheel: {fw.name}")
+                _validate_framework_wheel(fw)
+                wheels.append((fw, "framework", False))
             else:
-                src = _find_local_source_path(source_name)
-                if src is None:
-                    raise click.ClickException(
-                        f"Could not find source directory for '{source_name}'. "
-                        "Run from the repo root, or pass --source-dir explicitly."
-                    )
-            cleanup_dir = Path(tempfile.mkdtemp(prefix=f"cc-build-{source_name}-"))
-            wheel = _build_connector_wheel(src, cleanup_dir, debug)
+                assert repo_root is not None
+                click.echo(f"  Building framework wheel from: {repo_root}")
+                fw = _build_connector_wheel(repo_root, cleanup_dir, debug)
+                _validate_framework_wheel(fw)
+                wheels.append((fw, "framework", True))
 
-        _validate_wheel_layout(wheel, source_name)
+        if wheel_path:
+            conn = Path(wheel_path).resolve()
+            click.echo(f"  Using pre-built connector wheel: {conn.name}")
+            _validate_wheel_layout(conn, source_name)
+            wheels.append((conn, "connector", False))
+        else:
+            click.echo(f"  Building connector wheel from: {src}")
+            conn = _build_connector_wheel(src, cleanup_dir, debug)
+            _validate_wheel_layout(conn, source_name)
+            wheels.append((conn, "connector", True))
 
-        click.echo("\nStep 3: Uploading wheel...")
-        dest_path = f"{dest_dir}/{wheel.name}"
-        click.echo(f"  Uploading to: {dest_path}")
-        try:
-            with open(wheel, "rb") as f:
-                workspace_client.files.upload(dest_path, f, overwrite=True)
-        except Exception as e:
-            raise click.ClickException(f"Failed to upload wheel: {e}")
-        click.echo("  ✓ Uploaded")
+        # Step 3: upload each wheel.
+        click.echo("\nStep 3: Uploading wheels...")
+        dest_paths: List[str] = []
+        for wheel, _kind, _built in wheels:
+            dest_paths.append(_upload_wheel(workspace_client, wheel, dest_dir))
 
-        if keep_wheel_dir and not wheel_path:
+        # Step 4: optionally retain the wheels we built (not the ones the
+        # user supplied — those are already on their disk).
+        if keep_wheel_dir:
             keep = Path(keep_wheel_dir)
             keep.mkdir(parents=True, exist_ok=True)
-            kept = keep / wheel.name
-            shutil.copy2(wheel, kept)
-            click.echo(f"  ✓ Wheel retained at: {kept}")
+            for wheel, _kind, was_built in wheels:
+                if was_built:
+                    kept = keep / wheel.name
+                    shutil.copy2(wheel, kept)
+                    click.echo(f"  ✓ Wheel retained at: {kept}")
 
         click.echo(f"\n{'=' * 60}")
-        click.echo(f"Uploaded: {dest_path}")
+        click.echo("Uploaded:")
+        for path in dest_paths:
+            click.echo(f"  - {path}")
         click.echo(f"{'=' * 60}")
+        click.echo(
+            "\nReference both paths in your pipeline's "
+            "`environment.dependencies` to install on the cluster."
+        )
     finally:
         if cleanup_dir and cleanup_dir.exists():
             shutil.rmtree(cleanup_dir, ignore_errors=True)

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -838,8 +838,11 @@ def _check_build_module_available() -> None:
     )
     if result.returncode != 0:
         raise click.ClickException(
-            "The `build` package is required to build connector wheels. "
-            f"Install it with: {sys.executable} -m pip install build"
+            "`build` is not installed in this environment, but is required "
+            "to build connector wheels.\n\n"
+            "Install it with:\n"
+            "    pip install build\n\n"
+            "Then re-run the upload command."
         )
 
 

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -38,6 +38,8 @@ from databricks.labs.community_connector_cli.cli import (
     _parse_volume_path,
     _ensure_volume_directory,
     _validate_wheel_layout,
+    _validate_framework_wheel,
+    _find_repo_root,
 )
 from databricks.labs.community_connector_cli.connector_spec import (
     ParsedConnectorSpec,
@@ -2071,6 +2073,44 @@ def _make_fake_wheel(path: Path, source_name: str) -> Path:
     return wheel
 
 
+def _make_fake_framework_wheel(path: Path) -> Path:
+    """Build a minimal in-process zip that looks like the framework wheel."""
+    import zipfile
+    wheel = path / "lakeflow_community_connectors-0.1.0-py3-none-any.whl"
+    namespace = "databricks/labs/community_connector/interface"
+    with zipfile.ZipFile(wheel, "w") as zf:
+        zf.writestr(f"{namespace}/__init__.py", "")
+        zf.writestr(f"{namespace}/lakeflow_connect.py", "# framework code")
+        zf.writestr(
+            "lakeflow_community_connectors-0.1.0.dist-info/METADATA",
+            "Metadata-Version: 2.1\nName: lakeflow-community-connectors\nVersion: 0.1.0\n",
+        )
+    return wheel
+
+
+def _make_fake_repo_root(tmp_path: Path, source_name: str = "example") -> tuple:
+    """Lay out a tmp directory that looks like the connectors repo.
+
+    Returns (repo_root, source_dir). Both have ``pyproject.toml`` files: the
+    root's marks itself as ``name = "lakeflow-community-connectors"`` so
+    ``_find_repo_root`` can identify it.
+    """
+    repo_root = tmp_path / "repo"
+    source_dir = (
+        repo_root / "src" / "databricks" / "labs"
+        / "community_connector" / "sources" / source_name
+    )
+    source_dir.mkdir(parents=True)
+    (repo_root / "pyproject.toml").write_text(
+        '[project]\nname = "lakeflow-community-connectors"\nversion = "0.1.0"\n'
+    )
+    (source_dir / "pyproject.toml").write_text(
+        f'[project]\nname = "lakeflow-community-connectors-{source_name}"\n'
+        'version = "0.1.0"\n'
+    )
+    return repo_root, source_dir
+
+
 class TestParseVolumePath:
     """Tests for _parse_volume_path."""
 
@@ -2179,54 +2219,64 @@ class TestValidateWheelLayout:
             _validate_wheel_layout(bad, "example")
 
 
-class TestUploadCommand:
-    """Tests for the `upload` Click command."""
+class TestValidateFrameworkWheel:
+    """Tests for _validate_framework_wheel."""
 
-    def test_upload_with_prebuilt_wheel(self, tmp_path):
-        """--wheel skips the build step entirely."""
+    def test_valid_framework_wheel(self, tmp_path):
+        wheel = _make_fake_framework_wheel(tmp_path)
+        _validate_framework_wheel(wheel)  # no exception
+
+    def test_connector_wheel_rejected_as_framework(self, tmp_path):
+        """A connector wheel does not contain the interface/ namespace."""
         wheel = _make_fake_wheel(tmp_path, "example")
+        with pytest.raises(click.ClickException, match="does not contain"):
+            _validate_framework_wheel(wheel)
 
-        runner = CliRunner()
-        with patch(
-            "databricks.labs.community_connector_cli.cli._make_workspace_client"
-        ) as mock_ws_factory, patch(
-            "databricks.labs.community_connector_cli.cli._build_connector_wheel"
-        ) as mock_build:
-            mock_ws = MagicMock()
-            mock_ws.volumes.read.return_value = MagicMock()  # volume exists
-            mock_ws_factory.return_value = mock_ws
+    def test_corrupt_framework_wheel_raises(self, tmp_path):
+        bad = tmp_path / "bogus.whl"
+        bad.write_bytes(b"not a zip")
+        with pytest.raises(click.ClickException, match="not a valid wheel"):
+            _validate_framework_wheel(bad)
 
-            result = runner.invoke(
-                main,
-                [
-                    "upload",
-                    "example",
-                    "--volume-path",
-                    "/Volumes/main/default/cc/packages",
-                    "--wheel",
-                    str(wheel),
-                ],
-            )
 
-            assert result.exit_code == 0, result.output
-            mock_build.assert_not_called()
-            mock_ws.files.upload.assert_called_once()
-            dest = mock_ws.files.upload.call_args.args[0]
-            assert dest == f"/Volumes/main/default/cc/packages/{wheel.name}"
+class TestFindRepoRoot:
+    """Tests for _find_repo_root."""
 
-    def test_upload_builds_when_wheel_not_given(self, tmp_path):
-        """Default path: invoke _build_connector_wheel."""
-        # Place a fake "source" tree the source-resolver can find via --source-dir.
-        source_dir = (
-            tmp_path / "src" / "databricks" / "labs"
-            / "community_connector" / "sources" / "example"
-        )
-        source_dir.mkdir(parents=True)
-        (source_dir / "pyproject.toml").write_text("[project]\nname='x'\n")
+    def test_walks_up_from_source_dir(self, tmp_path):
+        repo_root, source_dir = _make_fake_repo_root(tmp_path)
+        assert _find_repo_root(source_dir) == repo_root.resolve()
 
-        # Build helper writes a fake wheel into the temp outdir.
+    def test_returns_none_when_no_framework_root(self, tmp_path):
+        """No pyproject anywhere in the parent chain → None."""
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+        assert _find_repo_root(nested) is None
+
+    def test_skips_connector_pyproject(self, tmp_path):
+        """A connector pyproject (different name) must not be mistaken for root."""
+        _, source_dir = _make_fake_repo_root(tmp_path, "example")
+        # The source_dir itself has a pyproject named
+        # `lakeflow-community-connectors-example` — it should be skipped, and
+        # the walk should continue until it finds the framework root above.
+        result = _find_repo_root(source_dir)
+        assert result is not None
+        assert (result / "pyproject.toml").is_file()
+        # Sanity: it's not the connector's pyproject.
+        assert "sources" not in str(result)
+
+
+class TestUploadCommand:
+    """Tests for the `upload` Click command (two-wheel flow)."""
+
+    def test_upload_default_builds_both_wheels(self, tmp_path):
+        """Default path: framework + connector wheels are both built and uploaded."""
+        repo_root, source_dir = _make_fake_repo_root(tmp_path, "example")
+
         def fake_build(src, outdir, debug):
-            return _make_fake_wheel(outdir, "example")
+            # Distinguish the two builds by the source path we receive.
+            if Path(src).resolve() == source_dir.resolve():
+                return _make_fake_wheel(outdir, "example")
+            return _make_fake_framework_wheel(outdir)
 
         runner = CliRunner()
         with patch(
@@ -2252,8 +2302,222 @@ class TestUploadCommand:
             )
 
             assert result.exit_code == 0, result.output
-            mock_build.assert_called_once()
+            # Two builds (framework + connector), two uploads.
+            assert mock_build.call_count == 2
+            assert mock_ws.files.upload.call_count == 2
+
+            # Framework must be uploaded first so that, if the cluster's pip
+            # processes the deps array in order, the connector's
+            # lakeflow-community-connectors dep resolves locally.
+            first_dest = mock_ws.files.upload.call_args_list[0].args[0]
+            second_dest = mock_ws.files.upload.call_args_list[1].args[0]
+            assert "lakeflow_community_connectors-" in first_dest
+            assert "lakeflow_community_connectors_example-" in second_dest
+
+    def test_upload_skip_framework(self, tmp_path):
+        """--skip-framework uploads only the connector wheel."""
+        repo_root, source_dir = _make_fake_repo_root(tmp_path, "example")
+
+        def fake_build(src, outdir, debug):
+            return _make_fake_wheel(outdir, "example")
+
+        runner = CliRunner()
+        with patch(
+            "databricks.labs.community_connector_cli.cli._make_workspace_client"
+        ) as mock_ws_factory, patch(
+            "databricks.labs.community_connector_cli.cli._build_connector_wheel",
+            side_effect=fake_build,
+        ) as mock_build:
+            mock_ws = MagicMock()
+            mock_ws.volumes.read.return_value = MagicMock()
+            mock_ws_factory.return_value = mock_ws
+
+            result = runner.invoke(
+                main,
+                [
+                    "upload",
+                    "example",
+                    "--volume-path",
+                    "/Volumes/main/default/cc/packages",
+                    "--source-dir",
+                    str(source_dir),
+                    "--skip-framework",
+                ],
+            )
+
+            assert result.exit_code == 0, result.output
+            mock_build.assert_called_once()  # only the connector
             mock_ws.files.upload.assert_called_once()
+
+    def test_upload_with_prebuilt_connector_wheel(self, tmp_path):
+        """--wheel skips the connector build but still builds the framework."""
+        repo_root, source_dir = _make_fake_repo_root(tmp_path, "example")
+        prebuilt = _make_fake_wheel(tmp_path, "example")
+
+        def fake_build(src, outdir, debug):
+            return _make_fake_framework_wheel(outdir)
+
+        runner = CliRunner()
+        with patch(
+            "databricks.labs.community_connector_cli.cli._make_workspace_client"
+        ) as mock_ws_factory, patch(
+            "databricks.labs.community_connector_cli.cli._build_connector_wheel",
+            side_effect=fake_build,
+        ) as mock_build:
+            mock_ws = MagicMock()
+            mock_ws.volumes.read.return_value = MagicMock()
+            mock_ws_factory.return_value = mock_ws
+
+            result = runner.invoke(
+                main,
+                [
+                    "upload",
+                    "example",
+                    "--volume-path",
+                    "/Volumes/main/default/cc/packages",
+                    "--source-dir",
+                    str(source_dir),
+                    "--wheel",
+                    str(prebuilt),
+                ],
+            )
+
+            assert result.exit_code == 0, result.output
+            mock_build.assert_called_once()  # only the framework
+            assert mock_ws.files.upload.call_count == 2
+
+    def test_upload_with_prebuilt_framework_wheel(self, tmp_path):
+        """--framework-wheel skips the framework build but still builds the connector."""
+        repo_root, source_dir = _make_fake_repo_root(tmp_path, "example")
+        fw_prebuilt = _make_fake_framework_wheel(tmp_path)
+
+        def fake_build(src, outdir, debug):
+            return _make_fake_wheel(outdir, "example")
+
+        runner = CliRunner()
+        with patch(
+            "databricks.labs.community_connector_cli.cli._make_workspace_client"
+        ) as mock_ws_factory, patch(
+            "databricks.labs.community_connector_cli.cli._build_connector_wheel",
+            side_effect=fake_build,
+        ) as mock_build:
+            mock_ws = MagicMock()
+            mock_ws.volumes.read.return_value = MagicMock()
+            mock_ws_factory.return_value = mock_ws
+
+            result = runner.invoke(
+                main,
+                [
+                    "upload",
+                    "example",
+                    "--volume-path",
+                    "/Volumes/main/default/cc/packages",
+                    "--source-dir",
+                    str(source_dir),
+                    "--framework-wheel",
+                    str(fw_prebuilt),
+                ],
+            )
+
+            assert result.exit_code == 0, result.output
+            mock_build.assert_called_once()  # only the connector
+            assert mock_ws.files.upload.call_count == 2
+
+    def test_upload_with_both_prebuilt_wheels(self, tmp_path):
+        """Pre-built connector + pre-built framework → no build at all."""
+        repo_root, source_dir = _make_fake_repo_root(tmp_path, "example")
+        conn_prebuilt = _make_fake_wheel(tmp_path, "example")
+        fw_prebuilt = _make_fake_framework_wheel(tmp_path)
+
+        runner = CliRunner()
+        with patch(
+            "databricks.labs.community_connector_cli.cli._make_workspace_client"
+        ) as mock_ws_factory, patch(
+            "databricks.labs.community_connector_cli.cli._build_connector_wheel"
+        ) as mock_build:
+            mock_ws = MagicMock()
+            mock_ws.volumes.read.return_value = MagicMock()
+            mock_ws_factory.return_value = mock_ws
+
+            result = runner.invoke(
+                main,
+                [
+                    "upload",
+                    "example",
+                    "--volume-path",
+                    "/Volumes/main/default/cc/packages",
+                    "--source-dir",
+                    str(source_dir),
+                    "--wheel",
+                    str(conn_prebuilt),
+                    "--framework-wheel",
+                    str(fw_prebuilt),
+                ],
+            )
+
+            assert result.exit_code == 0, result.output
+            mock_build.assert_not_called()
+            assert mock_ws.files.upload.call_count == 2
+
+    def test_upload_skip_framework_and_framework_wheel_mutually_exclusive(self, tmp_path):
+        """--skip-framework + --framework-wheel is contradictory and must error."""
+        repo_root, source_dir = _make_fake_repo_root(tmp_path, "example")
+        fw_prebuilt = _make_fake_framework_wheel(tmp_path)
+
+        runner = CliRunner()
+        with patch(
+            "databricks.labs.community_connector_cli.cli._make_workspace_client"
+        ) as mock_ws_factory:
+            mock_ws_factory.return_value = MagicMock()
+            result = runner.invoke(
+                main,
+                [
+                    "upload",
+                    "example",
+                    "--volume-path",
+                    "/Volumes/main/default/cc/packages",
+                    "--source-dir",
+                    str(source_dir),
+                    "--skip-framework",
+                    "--framework-wheel",
+                    str(fw_prebuilt),
+                ],
+            )
+
+            assert result.exit_code != 0
+            assert "mutually exclusive" in result.output
+
+    def test_upload_raises_when_repo_root_not_found(self, tmp_path):
+        """No framework root in the source's parent chain → ClickException."""
+        # Build a source dir that has no root pyproject anywhere above it.
+        bare_source = tmp_path / "isolated_source"
+        bare_source.mkdir()
+        (bare_source / "pyproject.toml").write_text(
+            '[project]\nname = "lakeflow-community-connectors-example"\n'
+        )
+
+        runner = CliRunner()
+        with patch(
+            "databricks.labs.community_connector_cli.cli._make_workspace_client"
+        ) as mock_ws_factory:
+            mock_ws = MagicMock()
+            mock_ws.volumes.read.return_value = MagicMock()
+            mock_ws_factory.return_value = mock_ws
+
+            result = runner.invoke(
+                main,
+                [
+                    "upload",
+                    "example",
+                    "--volume-path",
+                    "/Volumes/main/default/cc/packages",
+                    "--source-dir",
+                    str(bare_source),
+                ],
+            )
+
+            assert result.exit_code != 0
+            assert "Could not find the framework repo root" in result.output
 
     def test_upload_raises_when_source_not_found(self):
         """No --source-dir and the locator can't find anything → ClickException."""
@@ -2283,6 +2547,7 @@ class TestUploadCommand:
 
     def test_upload_invalid_volume_path(self, tmp_path):
         """Malformed --volume-path raises before any network call."""
+        repo_root, source_dir = _make_fake_repo_root(tmp_path, "example")
         wheel = _make_fake_wheel(tmp_path, "example")
         runner = CliRunner()
         with patch(
@@ -2296,21 +2561,23 @@ class TestUploadCommand:
                     "example",
                     "--volume-path",
                     "/Workspace/Users/me/wheels",
+                    "--source-dir",
+                    str(source_dir),
                     "--wheel",
                     str(wheel),
+                    "--skip-framework",
                 ],
             )
             assert result.exit_code != 0
             assert "Invalid volume path" in result.output
 
-    def test_upload_keep_wheel_copies_artifact(self, tmp_path):
-        """--keep-wheel copies the built wheel to the requested local dir."""
-        source_dir = (
-            tmp_path / "src" / "databricks" / "labs"
-            / "community_connector" / "sources" / "example"
-        )
-        source_dir.mkdir(parents=True)
-        (source_dir / "pyproject.toml").write_text("[project]\nname='x'\n")
+    def test_upload_keep_wheel_copies_only_built_artifacts(self, tmp_path):
+        """--keep-wheel copies wheels we built in this run, not user-supplied ones."""
+        repo_root, source_dir = _make_fake_repo_root(tmp_path, "example")
+        # User supplies framework wheel; CLI builds the connector wheel.
+        user_supplied_dir = tmp_path / "user_supplied"
+        user_supplied_dir.mkdir()
+        fw_prebuilt = _make_fake_framework_wheel(user_supplied_dir)
 
         def fake_build(src, outdir, debug):
             return _make_fake_wheel(outdir, "example")
@@ -2337,6 +2604,8 @@ class TestUploadCommand:
                     "/Volumes/main/default/cc/packages",
                     "--source-dir",
                     str(source_dir),
+                    "--framework-wheel",
+                    str(fw_prebuilt),
                     "--keep-wheel",
                     str(keep_dir),
                 ],
@@ -2344,36 +2613,7 @@ class TestUploadCommand:
 
             assert result.exit_code == 0, result.output
             kept_files = list(keep_dir.glob("*.whl"))
+            # Only the connector wheel (which we built) should be copied —
+            # not the user-supplied framework wheel.
             assert len(kept_files) == 1
-
-    def test_upload_keep_wheel_ignored_when_wheel_provided(self, tmp_path):
-        """--keep-wheel is a no-op when the user already supplied --wheel."""
-        wheel = _make_fake_wheel(tmp_path, "example")
-        keep_dir = tmp_path / "kept"
-
-        runner = CliRunner()
-        with patch(
-            "databricks.labs.community_connector_cli.cli._make_workspace_client"
-        ) as mock_ws_factory:
-            mock_ws = MagicMock()
-            mock_ws.volumes.read.return_value = MagicMock()
-            mock_ws_factory.return_value = mock_ws
-
-            result = runner.invoke(
-                main,
-                [
-                    "upload",
-                    "example",
-                    "--volume-path",
-                    "/Volumes/main/default/cc/packages",
-                    "--wheel",
-                    str(wheel),
-                    "--keep-wheel",
-                    str(keep_dir),
-                ],
-            )
-
-            assert result.exit_code == 0, result.output
-            # When --wheel is given there's nothing fresh to "keep" — don't
-            # silently copy the user's input. Directory may not even exist.
-            assert not keep_dir.exists() or not list(keep_dir.glob("*.whl"))
+            assert "example" in kept_files[0].name

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -35,6 +35,9 @@ from databricks.labs.community_connector_cli.cli import (
     _merge_external_options_allowlist,
     _get_ingest_path_from_pipeline,
     _extract_source_name_from_ingest,
+    _parse_volume_path,
+    _ensure_volume_directory,
+    _validate_wheel_layout,
 )
 from databricks.labs.community_connector_cli.connector_spec import (
     ParsedConnectorSpec,
@@ -2046,3 +2049,331 @@ objects:
                 assert "not found" in result.output
         finally:
             os.unlink(temp_path)
+
+
+def _make_fake_wheel(path: Path, source_name: str) -> Path:
+    """Build a minimal in-process zip that looks like a connector wheel.
+
+    Only used by the wheel-layout and upload-command tests — we never invoke
+    the real ``python -m build`` from unit tests.
+    """
+    import zipfile  # local to keep top-of-file imports unchanged
+    wheel = path / f"lakeflow_community_connectors_{source_name}-0.1.0-py3-none-any.whl"
+    namespace = f"databricks/labs/community_connector/sources/{source_name}"
+    with zipfile.ZipFile(wheel, "w") as zf:
+        zf.writestr(f"{namespace}/__init__.py", "")
+        zf.writestr(f"{namespace}/{source_name}.py", "# connector code")
+        zf.writestr(
+            f"lakeflow_community_connectors_{source_name}-0.1.0.dist-info/METADATA",
+            "Metadata-Version: 2.1\nName: lakeflow-community-connectors-"
+            f"{source_name}\nVersion: 0.1.0\n",
+        )
+    return wheel
+
+
+class TestParseVolumePath:
+    """Tests for _parse_volume_path."""
+
+    def test_volume_root(self):
+        assert _parse_volume_path("/Volumes/main/default/cc") == (
+            "main", "default", "cc", "",
+        )
+
+    def test_with_subpath(self):
+        assert _parse_volume_path("/Volumes/main/default/cc/packages") == (
+            "main", "default", "cc", "packages",
+        )
+
+    def test_trailing_slash_normalized(self):
+        assert _parse_volume_path("/Volumes/main/default/cc/packages/") == (
+            "main", "default", "cc", "packages",
+        )
+
+    def test_nested_subpath(self):
+        assert _parse_volume_path("/Volumes/c/s/v/a/b/c") == ("c", "s", "v", "a/b/c")
+
+    def test_invalid_raises(self):
+        with pytest.raises(click.ClickException, match="Invalid volume path"):
+            _parse_volume_path("/Workspace/Users/me/wheels")
+
+    def test_missing_volume_part_raises(self):
+        with pytest.raises(click.ClickException, match="Invalid volume path"):
+            _parse_volume_path("/Volumes/main/default")
+
+
+class TestEnsureVolumeDirectory:
+    """Tests for _ensure_volume_directory — volume + subdir auto-create."""
+
+    def test_volume_exists_no_subpath(self):
+        ws = MagicMock()
+        ws.volumes.read.return_value = MagicMock()  # volume exists
+        result = _ensure_volume_directory(ws, "/Volumes/c/s/v", debug=False)
+        assert result == "/Volumes/c/s/v"
+        ws.volumes.create.assert_not_called()
+        ws.files.create_directory.assert_not_called()
+
+    def test_volume_created_when_missing(self):
+        ws = MagicMock()
+        ws.volumes.read.side_effect = Exception("NOT_FOUND")
+        result = _ensure_volume_directory(ws, "/Volumes/c/s/v", debug=False)
+        assert result == "/Volumes/c/s/v"
+        ws.volumes.create.assert_called_once()
+        kwargs = ws.volumes.create.call_args.kwargs
+        assert kwargs["catalog_name"] == "c"
+        assert kwargs["schema_name"] == "s"
+        assert kwargs["name"] == "v"
+
+    def test_subdir_created(self):
+        ws = MagicMock()
+        ws.volumes.read.return_value = MagicMock()
+        result = _ensure_volume_directory(ws, "/Volumes/c/s/v/pkg", debug=False)
+        assert result == "/Volumes/c/s/v/pkg"
+        ws.files.create_directory.assert_called_once_with("/Volumes/c/s/v/pkg")
+
+    def test_subdir_already_exists_is_swallowed(self):
+        ws = MagicMock()
+        ws.volumes.read.return_value = MagicMock()
+        ws.files.create_directory.side_effect = Exception("RESOURCE_ALREADY_EXISTS")
+        result = _ensure_volume_directory(ws, "/Volumes/c/s/v/pkg", debug=False)
+        assert result == "/Volumes/c/s/v/pkg"
+
+    def test_volume_create_already_exists_swallowed(self):
+        """Race condition: read fails but create reports ALREADY_EXISTS."""
+        ws = MagicMock()
+        ws.volumes.read.side_effect = Exception("NOT_FOUND")
+        ws.volumes.create.side_effect = Exception("ALREADY_EXISTS")
+        result = _ensure_volume_directory(ws, "/Volumes/c/s/v", debug=False)
+        assert result == "/Volumes/c/s/v"
+
+    def test_volume_create_other_error_raises(self):
+        ws = MagicMock()
+        ws.volumes.read.side_effect = Exception("NOT_FOUND")
+        ws.volumes.create.side_effect = Exception("PERMISSION_DENIED")
+        with pytest.raises(click.ClickException, match="Failed to create volume"):
+            _ensure_volume_directory(ws, "/Volumes/c/s/v", debug=False)
+
+    def test_subdir_unexpected_error_raises(self):
+        ws = MagicMock()
+        ws.volumes.read.return_value = MagicMock()
+        ws.files.create_directory.side_effect = Exception("PERMISSION_DENIED")
+        with pytest.raises(click.ClickException, match="Failed to create directory"):
+            _ensure_volume_directory(ws, "/Volumes/c/s/v/pkg", debug=False)
+
+
+class TestValidateWheelLayout:
+    """Tests for _validate_wheel_layout."""
+
+    def test_valid_layout(self, tmp_path):
+        wheel = _make_fake_wheel(tmp_path, "example")
+        _validate_wheel_layout(wheel, "example")  # no exception
+
+    def test_wrong_source_name_raises(self, tmp_path):
+        wheel = _make_fake_wheel(tmp_path, "example")
+        with pytest.raises(click.ClickException, match="does not contain"):
+            _validate_wheel_layout(wheel, "different_source")
+
+    def test_corrupt_wheel_raises(self, tmp_path):
+        bad = tmp_path / "bogus.whl"
+        bad.write_bytes(b"not a zip")
+        with pytest.raises(click.ClickException, match="not a valid wheel"):
+            _validate_wheel_layout(bad, "example")
+
+
+class TestUploadCommand:
+    """Tests for the `upload` Click command."""
+
+    def test_upload_with_prebuilt_wheel(self, tmp_path):
+        """--wheel skips the build step entirely."""
+        wheel = _make_fake_wheel(tmp_path, "example")
+
+        runner = CliRunner()
+        with patch(
+            "databricks.labs.community_connector_cli.cli._make_workspace_client"
+        ) as mock_ws_factory, patch(
+            "databricks.labs.community_connector_cli.cli._build_connector_wheel"
+        ) as mock_build:
+            mock_ws = MagicMock()
+            mock_ws.volumes.read.return_value = MagicMock()  # volume exists
+            mock_ws_factory.return_value = mock_ws
+
+            result = runner.invoke(
+                main,
+                [
+                    "upload",
+                    "example",
+                    "--volume-path",
+                    "/Volumes/main/default/cc/packages",
+                    "--wheel",
+                    str(wheel),
+                ],
+            )
+
+            assert result.exit_code == 0, result.output
+            mock_build.assert_not_called()
+            mock_ws.files.upload.assert_called_once()
+            dest = mock_ws.files.upload.call_args.args[0]
+            assert dest == f"/Volumes/main/default/cc/packages/{wheel.name}"
+
+    def test_upload_builds_when_wheel_not_given(self, tmp_path):
+        """Default path: invoke _build_connector_wheel."""
+        # Place a fake "source" tree the source-resolver can find via --source-dir.
+        source_dir = (
+            tmp_path / "src" / "databricks" / "labs"
+            / "community_connector" / "sources" / "example"
+        )
+        source_dir.mkdir(parents=True)
+        (source_dir / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+        # Build helper writes a fake wheel into the temp outdir.
+        def fake_build(src, outdir, debug):
+            return _make_fake_wheel(outdir, "example")
+
+        runner = CliRunner()
+        with patch(
+            "databricks.labs.community_connector_cli.cli._make_workspace_client"
+        ) as mock_ws_factory, patch(
+            "databricks.labs.community_connector_cli.cli._build_connector_wheel",
+            side_effect=fake_build,
+        ) as mock_build:
+            mock_ws = MagicMock()
+            mock_ws.volumes.read.return_value = MagicMock()
+            mock_ws_factory.return_value = mock_ws
+
+            result = runner.invoke(
+                main,
+                [
+                    "upload",
+                    "example",
+                    "--volume-path",
+                    "/Volumes/main/default/cc/packages",
+                    "--source-dir",
+                    str(source_dir),
+                ],
+            )
+
+            assert result.exit_code == 0, result.output
+            mock_build.assert_called_once()
+            mock_ws.files.upload.assert_called_once()
+
+    def test_upload_raises_when_source_not_found(self):
+        """No --source-dir and the locator can't find anything → ClickException."""
+        runner = CliRunner()
+        with patch(
+            "databricks.labs.community_connector_cli.cli._make_workspace_client"
+        ) as mock_ws_factory, patch(
+            "databricks.labs.community_connector_cli.cli._find_local_source_path",
+            return_value=None,
+        ):
+            mock_ws = MagicMock()
+            mock_ws.volumes.read.return_value = MagicMock()
+            mock_ws_factory.return_value = mock_ws
+
+            result = runner.invoke(
+                main,
+                [
+                    "upload",
+                    "ghost_source",
+                    "--volume-path",
+                    "/Volumes/main/default/cc/packages",
+                ],
+            )
+
+            assert result.exit_code != 0
+            assert "Could not find source directory" in result.output
+
+    def test_upload_invalid_volume_path(self, tmp_path):
+        """Malformed --volume-path raises before any network call."""
+        wheel = _make_fake_wheel(tmp_path, "example")
+        runner = CliRunner()
+        with patch(
+            "databricks.labs.community_connector_cli.cli._make_workspace_client"
+        ) as mock_ws_factory:
+            mock_ws_factory.return_value = MagicMock()
+            result = runner.invoke(
+                main,
+                [
+                    "upload",
+                    "example",
+                    "--volume-path",
+                    "/Workspace/Users/me/wheels",
+                    "--wheel",
+                    str(wheel),
+                ],
+            )
+            assert result.exit_code != 0
+            assert "Invalid volume path" in result.output
+
+    def test_upload_keep_wheel_copies_artifact(self, tmp_path):
+        """--keep-wheel copies the built wheel to the requested local dir."""
+        source_dir = (
+            tmp_path / "src" / "databricks" / "labs"
+            / "community_connector" / "sources" / "example"
+        )
+        source_dir.mkdir(parents=True)
+        (source_dir / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+        def fake_build(src, outdir, debug):
+            return _make_fake_wheel(outdir, "example")
+
+        keep_dir = tmp_path / "kept"
+
+        runner = CliRunner()
+        with patch(
+            "databricks.labs.community_connector_cli.cli._make_workspace_client"
+        ) as mock_ws_factory, patch(
+            "databricks.labs.community_connector_cli.cli._build_connector_wheel",
+            side_effect=fake_build,
+        ):
+            mock_ws = MagicMock()
+            mock_ws.volumes.read.return_value = MagicMock()
+            mock_ws_factory.return_value = mock_ws
+
+            result = runner.invoke(
+                main,
+                [
+                    "upload",
+                    "example",
+                    "--volume-path",
+                    "/Volumes/main/default/cc/packages",
+                    "--source-dir",
+                    str(source_dir),
+                    "--keep-wheel",
+                    str(keep_dir),
+                ],
+            )
+
+            assert result.exit_code == 0, result.output
+            kept_files = list(keep_dir.glob("*.whl"))
+            assert len(kept_files) == 1
+
+    def test_upload_keep_wheel_ignored_when_wheel_provided(self, tmp_path):
+        """--keep-wheel is a no-op when the user already supplied --wheel."""
+        wheel = _make_fake_wheel(tmp_path, "example")
+        keep_dir = tmp_path / "kept"
+
+        runner = CliRunner()
+        with patch(
+            "databricks.labs.community_connector_cli.cli._make_workspace_client"
+        ) as mock_ws_factory:
+            mock_ws = MagicMock()
+            mock_ws.volumes.read.return_value = MagicMock()
+            mock_ws_factory.return_value = mock_ws
+
+            result = runner.invoke(
+                main,
+                [
+                    "upload",
+                    "example",
+                    "--volume-path",
+                    "/Volumes/main/default/cc/packages",
+                    "--wheel",
+                    str(wheel),
+                    "--keep-wheel",
+                    str(keep_dir),
+                ],
+            )
+
+            assert result.exit_code == 0, result.output
+            # When --wheel is given there's nothing fresh to "keep" — don't
+            # silently copy the user's input. Directory may not even exist.
+            assert not keep_dir.exists() or not list(keep_dir.glob("*.whl"))


### PR DESCRIPTION
## Summary

- Adds `community-connector upload <source>` that builds the connector wheel and uploads it to a UC Volume in one step.
- `--volume-path /Volumes/<cat>/<sch>/<vol>[/<subdir>...]` is the only destination flag; the volume and any missing subdirectories are auto-created.
- `--wheel <path>` bypasses the build step for users who already have a wheel; `--source-dir` overrides the default `sources/<name>/` location; `--keep-wheel <dir>` retains the built artifact locally after upload.
- Build shells out to `python -m build`, which uses PEP 517 isolation under the hood — so no per-connector `.venv` ceremony is needed. The CLI surfaces a clear `pip install build` hint if the frontend is missing.
- The wheel is sanity-checked against `databricks/labs/community_connector/sources/<source>/` before upload, catching mis-configured `pyproject.toml` files before the artifact reaches the volume.
- Updates `tools/community_connector/README.md` and the `build_connector_package` skill to point at the new command and drop the obsolete per-connector venv instructions.

## Why

Before this PR, build was the only step in the connector-developer workflow that lived outside the CLI: contributors had to `cd sources/<name> && python3 -m venv .venv && source .venv/bin/activate && pip install build && python -m build`, locate the resulting wheel, and then pass it to `create_pipeline --package`. Volume creation, wheel upload, and pipeline create/update were already in the CLI — build was the orphan. The new `upload` subcommand closes that gap so users no longer have to context-switch out of the CLI to ship a wheel.

## Test plan

- [x] `pytest tools/community_connector/tests/` — 210 passed (22 new tests covering volume-path parsing, volume/subdir auto-create, wheel layout validation, build-path and pre-built-wheel flows, `--keep-wheel`, malformed `--volume-path`, missing-source error).
- [x] Smoke test: built the `example` connector wheel end-to-end via `_build_connector_wheel` + `_validate_wheel_layout` against the live source tree.
- [ ] Live test: run `community-connector upload example --volume-path /Volumes/<cat>/<sch>/community_connector/packages` against a real workspace.

This pull request and its description were written by Isaac.