### PR TITLE
Add gmail-connector skill for driving Gmail via cluster command execution

### DIFF
--- a/.claude/skills/gmail-connector/SKILL.md
+++ b/.claude/skills/gmail-connector/SKILL.md
@@ -89,7 +89,7 @@ The connection option key **must** be `databricks.connection` — that exact str
    ```
    If terminated, ask the user before starting it.
 
-2. **Open a Python context.** Path: `/api/1.2/contexts/create` (not `/api/1.2/commands/contexts/create` — see the path table above):
+2. **Open a Python context** (`/api/1.2/contexts/create`):
    ```bash
    databricks api post /api/1.2/contexts/create \
      --json '{"clusterId":"0528-081139-nh2l2jnu","language":"python"}' -o json
@@ -106,7 +106,7 @@ The connection option key **must** be `databricks.connection` — that exact str
 
 ### Execution envelope (every read)
 
-1. **Build the snippet.** End it with `print(json.dumps([r.asDict(recursive=True) for r in df.collect()], default=str))` so the result comes back parseable.
+1. **Build the snippet** from the template above, ending with the `print(json.dumps(...))` line so the result comes back parseable.
 
 2. **Submit** (path: `/api/1.2/commands/execute`):
    ```bash
@@ -139,7 +139,7 @@ databricks api post /api/1.2/contexts/destroy \
   --json '{"clusterId":"0528-081139-nh2l2jnu","contextId":"<CTX>"}'
 ```
 
-Contexts are a cluster resource — don't leak them across sessions.
+Contexts are a cluster resource — don't leak them across sessions; tear down even when a read errored.
 
 ---
 
@@ -162,26 +162,15 @@ Practical:
 
 ## Error handling
 
-The deployed connector surfaces failures as Spark exceptions (the agent-dispatcher's normalised `_meta.code` envelope is not on the dispatch path yet). When `results.resultType == "error"`, parse `results.summary` + `results.cause` and act on the underlying cause:
+The deployed connector surfaces failures as Spark exceptions. When `results.resultType == "error"`, parse `results.summary` + `results.cause` and act on the underlying cause:
 
 | Symptom | Likely cause | What to do |
 |---|---|---|
 | `Bad Target: /api/...` from `databricks api` | REST path wrong (most often `commands/contexts/...`) | Re-check the path table at the top of this file. |
-| Gmail HTTP 401 in the traceback | OAuth token expired / revoked | Stop; ask the user to re-run `create_connection`. |
+| Gmail HTTP 401 in the traceback | OAuth token expired / revoked | Stop; ask the user to re-authorize the connection. |
 | Gmail HTTP 403 | Missing scope or Workspace admin restriction | Surface the message; if Drive-related, the connector still works for Gmail-only reads. |
 | Gmail HTTP 404 on the history endpoint | `historyId` expired (~30 days) | The connector falls back to a full scan on retry; warn the user the next read may be slow. |
 | Gmail HTTP 429 | Rate limit | Back off a few seconds and retry once. Don't hammer. |
-| `Connection not found` | connection name is wrong or missing | Re-confirm with the user; offer to create via the prerequisite step. |
+| `Connection not found` | connection name is wrong or missing | Re-confirm the connection name with the user. |
 | `Gmail connector requires 'access_token' in options` | Read used the wrong connection option key, so UC injected no token | Use `.option("databricks.connection", "<CONN>")` — not `connection_name`/`connectionName`. |
 | Module import error on `GmailDataSource` | Connector wheel not installed on the cluster | Stop and surface — this skill can't fix cluster libraries. |
-
----
-
-## Rules
-
-- Don't invent things stated explicitly above — the cluster id, the REST paths, and the table surface are all fixed. Use them verbatim.
-- Register the data source on the first command in every fresh context, never on later commands in the same context.
-- Always `print(json.dumps(...))` inside the snippet so the cluster response is machine-parseable; don't rely on Spark's text-table output.
-- If the user wants something the table surface can't do (writes, attachment bytes, push notifications), say so plainly — don't fake it through an unrelated read.
-- Tear down the execution context when the conversation's Gmail work is finished, including on error.
-- For sustained ingestion, hand off to `deploy-connector` rather than looping the execution envelope yourself.

--- a/.claude/skills/gmail-connector/SKILL.md
+++ b/.claude/skills/gmail-connector/SKILL.md
@@ -74,7 +74,7 @@ If the user asks for something the table surface can't do (write actions, byte-l
 
 ## How you call into the connector
 
-Every read is a Python snippet executed in a long-lived context on the fixed cluster (`0528-081139-nh2l2jnu`):
+Every read is a Python snippet executed in a long-lived context on the cluster:
 
 ```python
 df = (spark.read.format("lakeflow_connect")
@@ -202,11 +202,9 @@ The deployed connector surfaces failures as Spark exceptions (the agent-dispatch
 
 ## Rules
 
-- The `cluster_id` is **hard-coded** to `0528-081139-nh2l2jnu`. Never ask the user for it and never substitute another id.
-- The **path table** at the top is the source of truth for REST endpoints. Never invent a path. Never paste `/api/2.0/commands/...` or `/api/1.2/commands/contexts/...`.
-- The **README** is the source of truth for the table surface — table names and `table_configuration` keys. Never invent either; don't claim ops (`search_messages`, `download_attachment`, etc.) work today.
+- Don't invent things stated explicitly above — the cluster id, the REST paths, and the table surface are all fixed. Use them verbatim.
 - Register the data source on the first command in every fresh context, never on later commands in the same context.
-- Always print results as JSON inside the snippet so the cluster response is machine-parseable; don't rely on Spark's text-table output.
-- Stay inside the table surface. If the user wants something it can't do, say so plainly — don't fake it through an unrelated read.
+- Always `print(json.dumps(...))` inside the snippet so the cluster response is machine-parseable; don't rely on Spark's text-table output.
+- If the user wants something the table surface can't do (writes, attachment bytes, push notifications), say so plainly — don't fake it through an unrelated read.
 - Tear down the execution context when the conversation's Gmail work is finished, including on error.
 - For sustained ingestion, hand off to `deploy-connector` rather than looping the execution envelope yourself.

--- a/.claude/skills/gmail-connector/SKILL.md
+++ b/.claude/skills/gmail-connector/SKILL.md
@@ -78,13 +78,15 @@ Every read is a Python snippet executed in a long-lived context on the cluster:
 
 ```python
 df = (spark.read.format("lakeflow_connect")
-        .option("connection_name", "<CONN>")
+        .option("databricks.connection", "<CONN>")   # UC injects the OAuth access_token from this connection
         .option("tableName", "<TABLE_NAME>")
         .option("<filter_key>", "<value>")    # 0+ from README's table_configuration
         .load()
         .limit(<N>))                          # always cap rows you don't need
 print(json.dumps([r.asDict(recursive=True) for r in df.collect()], default=str))
 ```
+
+The connection option key **must** be `databricks.connection` — that exact string is what Unity Catalog watches for to inject the connection's OAuth `access_token` into the connector options at query time. Other spellings (`connection_name`, `connectionName`) are silently ignored: UC injects nothing and the read fails inside the connector with `Gmail connector requires 'access_token' in options`.
 
 ### Bootstrap (do once at the start of a Gmail-shaped conversation)
 
@@ -195,7 +197,8 @@ The deployed connector surfaces failures as Spark exceptions (the agent-dispatch
 | Gmail HTTP 403 | Missing scope or Workspace admin restriction | Surface the message; if Drive-related, the connector still works for Gmail-only reads. |
 | Gmail HTTP 404 on the history endpoint | `historyId` expired (~30 days) | The connector falls back to a full scan on retry; warn the user the next read may be slow. |
 | Gmail HTTP 429 | Rate limit | Back off a few seconds and retry once. Don't hammer. |
-| `Connection not found` | `connection_name` is wrong or missing | Re-confirm with the user; offer to create via the prerequisite step. |
+| `Connection not found` | connection name is wrong or missing | Re-confirm with the user; offer to create via the prerequisite step. |
+| `Gmail connector requires 'access_token' in options` | Read used the wrong connection option key, so UC injected no token | Use `.option("databricks.connection", "<CONN>")` — not `connection_name`/`connectionName`. |
 | Module import error on `GmailDataSource` | Connector wheel not installed on the cluster | Stop and surface — this skill can't fix cluster libraries. |
 
 ---

--- a/.claude/skills/gmail-connector/SKILL.md
+++ b/.claude/skills/gmail-connector/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: gmail-connector
-description: Tool layer for Gmail tasks. Loads the connector's operation catalogue dynamically from a Databricks cluster via the Command Execution REST API and composes those operations to satisfy the user's intent. The tool surface is whatever `list_operations` returns; scheduled-ingestion requests hand off to `deploy-connector`. Use whenever the user asks the agent to do something with their mailbox.
+description: Tool layer for ad-hoc Gmail reads against the project's `lakeflow_connect` table surface. Runs read queries on a user-supplied Databricks cluster via the Command Execution REST API; scheduled-ingestion requests hand off to `deploy-connector`. Use whenever the user asks the agent to read something from their mailbox.
 args:
   - name: cluster_id
-    description: All-purpose cluster the agent runs Gmail operations on (required — must be supplied by the user, never invented).
+    description: All-purpose cluster the agent runs Gmail reads on (required — must be supplied by the user, never invented).
     required: true
   - name: connection_name
     description: Name of the UC COMMUNITY connection holding the Gmail OAuth grant. Create one (see "Connection prerequisite") if absent.
@@ -12,122 +12,154 @@ args:
 
 # Gmail Connector
 
-This skill turns the project's Gmail Spark APIs into a tool surface the agent can call. You — the agent — translate the user's natural request into a sequence of connector operations, run them on a Databricks cluster, and return the answer.
+This skill turns the project's Gmail tables into a tool surface the agent can call. You — the agent — translate the user's request into table reads with optional filter options, run them on a Databricks cluster via the Command Execution REST API, and return the answer.
 
-You **never** invent operations or parameter names, and you don't infer the surface from this file. The cluster is the source of truth: load the catalogue once with `list_operations`, then drive everything from what it reports.
+You **never** invent table names, option keys, or REST paths. The connector README is the source of truth for the tables; the path table below is the source of truth for the cluster API.
+
+---
+
+## Critical: Command Execution REST paths
+
+This is the single most common cause of `Bad Target` / 404 in this skill. Two URL trees, both under `/api/1.2/`, and they are *not* nested — `contexts` and `commands` are siblings, not parent/child.
+
+| Action | Method | Path |
+|---|---|---|
+| Open a Python context | `POST` | `/api/1.2/contexts/create` |
+| Check context status | `GET`  | `/api/1.2/contexts/status` |
+| Tear context down | `POST` | `/api/1.2/contexts/destroy` |
+| Submit a command | `POST` | `/api/1.2/commands/execute` |
+| Poll command status | `GET`  | `/api/1.2/commands/status` |
+| Cancel a command | `POST` | `/api/1.2/commands/cancel` |
+
+Paths that **look** right but return errors:
+
+| Wrong path | What happens | What to use instead |
+|---|---|---|
+| `/api/1.2/commands/contexts/create` | `{"error":"Bad Target: /api/1.2/commands/contexts/create"}` | `/api/1.2/contexts/create` |
+| `/api/1.2/commands/contexts/destroy` | Same `Bad Target` | `/api/1.2/contexts/destroy` |
+| `/api/2.0/commands/...` (any) | 404 on most workspaces | The corresponding `/api/1.2/...` path |
+
+The Databricks Go SDK and the docs.databricks.com pages reference a `2.0` alias for Command Execution. It isn't live on the workspaces we run against — don't trust it. The clusters API is a separate, unrelated surface at `/api/2.1/clusters/...`; the version number there is correct.
 
 ---
 
 ## What this skill is for
 
-This skill is the **tool layer** for Gmail. Your tool surface is exactly what `list_operations` returns when called against the user's connection — nothing more, nothing less. Each catalogue entry carries a `description` and `parameters_json` written for exactly this purpose: read them to decide whether a request is satisfiable and how to call it. If the catalogue doesn't expose what the user is asking for, say so plainly — don't fake it with an op that isn't a fit.
+The Gmail connector exposes Gmail as **Spark tables** — one table per Gmail object (`messages`, `threads`, `labels`, `drafts`, `profile`, `settings`, `filters`, `forwarding_addresses`, `send_as`, `delegates`). Each accepts a small set of filter options (`q`, `labelIds`, `maxResults`, `includeSpamTrash`, `format`). Your tool surface is exactly those tables and options — nothing more.
 
-There is one explicit carve-out, because it's owned by a sibling skill rather than the read-side tool surface:
+Read the connector README before planning a request; it is the authoritative manifest:
 
-- **Standing up a scheduled / continuous ingestion pipeline** (e.g. "ingest my labels table into UC every hour", "land my inbox in `main.gmail.messages` daily") — hand off to the `deploy-connector` skill with `source_name=gmail`. That skill provisions an SDP pipeline via the `community-connector` CLI, which is the right vehicle for ongoing sync. Do not loop the read envelope in this skill to fake periodic ingestion.
+- `src/databricks/labs/community_connector/sources/gmail/README.md`
 
-For everything else — including whether write actions, push notifications, multi-mailbox routing, etc. are supported — let `list_operations` answer. The catalogue is the truth; this file is not.
+It enumerates each table, its primary key, ingestion type, schema highlights, and the keys accepted under `table_configuration`.
+
+The one explicit carve-out, owned by a sibling skill:
+
+- **Scheduled / continuous ingestion** ("land my inbox in UC hourly") → hand off to the `deploy-connector` skill with `source_name=gmail`. That skill provisions an SDP pipeline via the `community-connector` CLI. Don't loop the read envelope here to fake it.
+
+> **Today's limit.** The connector source contains an agent-dispatcher with richer ops (`list_operations`, `search_messages`, `list_attachments`, `download_attachment`, …), but that surface is **not yet on the Spark format dispatch path** in the deployed builds — i.e. setting `option("operation", ...)` does nothing. Until that wiring ships, ignore those ops; the table read path is the only surface you can call. **Attachment-byte downloads in particular are out of reach via this skill today** — the table surface returns attachment *metadata* on `messages.payload`, not bytes.
+
+If the user asks for something the table surface can't do (write actions, byte-level attachment fetch, push notifications), say so plainly.
 
 ---
 
-## How you actually call into the connector
+## How you call into the connector
 
-Every call has the same envelope — a Python snippet executed in a long-lived context on the user's cluster:
+Every read is a Python snippet executed in a long-lived context on the user's cluster:
 
 ```python
 df = (spark.read.format("lakeflow_connect")
-        .option("connection_name", "{{connection_name}}")
-        .option("operation", "<OP_NAME>")
-        .option("<param>", "<value>")        # 0+ params from list_operations
-        .load())
+        .option("connection_name", "<CONN>")
+        .option("tableName", "<TABLE_NAME>")
+        .option("<filter_key>", "<value>")    # 0+ from README's table_configuration
+        .load()
+        .limit(<N>))                          # always cap rows you don't need
+print(json.dumps([r.asDict(recursive=True) for r in df.collect()], default=str))
 ```
-
-Composing a snippet, shipping it to the cluster, and parsing the result is one helper, not a per-task ritual — see *Execution envelope* below.
 
 ### Bootstrap (do once at the start of a Gmail-shaped conversation)
 
-1. **Confirm the cluster** the user gave you (`{{cluster_id}}`) is `RUNNING`:
+1. **Confirm the cluster** is `RUNNING`:
    ```bash
    databricks api get /api/2.1/clusters/get \
      --json "{\"cluster_id\":\"{{cluster_id}}\"}" -o json | jq '{state, spark_version}'
    ```
    If terminated, ask the user before starting it.
-2. **Open a Python context** on that cluster and remember the returned `id`:
+
+2. **Open a Python context.** Path: `/api/1.2/contexts/create` (not `/api/1.2/commands/contexts/create` — see the path table above):
    ```bash
-   databricks api post /api/1.2/commands/contexts/create \
+   databricks api post /api/1.2/contexts/create \
      --json '{"clusterId":"{{cluster_id}}","language":"python"}' -o json
    ```
-3. **Register the data source and load the catalogue**. The very first command you ship into a fresh context **must** include the import + `register` lines below — Spark's data-source registry is per-driver-session, so without them `format("lakeflow_connect")` resolves to nothing:
+   Returns `{"id": "<CONTEXT_ID>"}`. Remember it for the rest of the session.
+
+3. **Register the data source on the first command.** Spark's data-source registry is per-driver-session, so the *first* command you ship into a fresh context **must** lead with:
    ```python
    import json
    from databricks.labs.community_connector.sources.gmail import GmailDataSource
    spark.dataSource.register(GmailDataSource)
-   df = (spark.read.format("lakeflow_connect")
-           .option("connection_name", "{{connection_name}}")
-           .option("operation", "list_operations").load())
-   print(json.dumps([r.asDict() for r in df.collect()]))
    ```
-   The printed JSON gives you `name`, `description`, `kind`, `result_schema_json`, and `parameters_json` for **every** operation this connection exposes. Cache it for the rest of the session. If `list_operations` fails, the connector isn't installed on the cluster — surface that and stop.
+   Subsequent commands in the same context **must not** re-emit those lines — the registration is cached. Re-registering is wasted overhead, not an error. If you open a new context later (cluster restart, you destroyed the previous one), the first command in *that* context must include them again.
 
-After this first command lands `Finished`, registration is cached on the cluster for the lifetime of the context. **Do not** re-emit the `import` / `spark.dataSource.register(...)` lines on subsequent commands in the same context — they're noise and slow the snippet down. If you open a new context later (or the user explicitly restarts one), the *first* command in that context must include them again.
+### Execution envelope (every read)
 
-### Execution envelope (the universal "call any operation")
+1. **Build the snippet.** End it with `print(json.dumps([r.asDict(recursive=True) for r in df.collect()], default=str))` so the result comes back parseable.
 
-For any one operation:
-
-1. Build the snippet — pick `OP_NAME` and only the parameters that the catalogue declares for it. End the snippet with `print(json.dumps([r.asDict(recursive=True) for r in df.collect()], default=str))` so the result comes back parseable.
-2. Submit to the cluster:
+2. **Submit** (path: `/api/1.2/commands/execute`):
    ```bash
    databricks api post /api/1.2/commands/execute \
-     --json '{"clusterId":"{{cluster_id}}","contextId":"<CTX>","language":"python","command":"<SNIPPET>"}' -o json
+     --json '{"clusterId":"{{cluster_id}}","contextId":"<CTX>","language":"python","command":"<SNIPPET>"}' \
+     -o json
    ```
-3. Poll until terminal status:
+
+3. **Poll** until terminal (path: `/api/1.2/commands/status`):
    ```bash
    databricks api get /api/1.2/commands/status \
      --json "{\"clusterId\":\"{{cluster_id}}\",\"contextId\":\"<CTX>\",\"commandId\":\"<CMD>\"}" -o json
    ```
    `status` walks `Queued → Running → Finished | Error | Cancelled`.
-4. Read the result:
-   - `Finished`, `results.resultType == "text"` → `results.data` is the JSON you printed. Parse and use.
-   - `Error` → `results.summary` is the one-liner; `results.cause` is the traceback. The dispatcher writes a canonical code into `_meta.code` of the printed row when the error is connector-level (see *Error codes* below).
 
-A few details that bite if you skip them:
-- **Use `/api/1.2/commands/...`, not `/api/2.0/`.** The Command Execution API is served under 1.2. The 2.0 path 404s on the workspaces we run against — if you see `Not Found` from `/api/2.0/commands/...`, you have the wrong version, not a wrong cluster.
+4. **Read the result:**
+   - `Finished`, `results.resultType == "text"` → `results.data` is the JSON you printed. Parse and use.
+   - `Error` → `results.summary` is the one-liner; `results.cause` is the Python traceback from the cluster.
+
+Quoting notes that bite if you skip them:
 - The `command` field is a JSON string containing Python source — preserve newlines (`\n`) and quote your inner strings.
-- Spark's `CaseInsensitiveStringMap` lowercases option keys, but the connector already handles the standard parameter spellings; just match whatever `list_operations` shows.
-- `spark.dataSource.register(GmailDataSource)` runs once per context — only in the first command, never again. If you accidentally open a *new* context (cluster restart, you destroyed the previous one), the next snippet must re-import + re-register; until then, `format("lakeflow_connect")` will not resolve.
+- Spark's `CaseInsensitiveStringMap` lowercases option keys, but the connector handles the standard spellings; use the keys the README documents.
 
 ### Teardown
 
-At the end of the session, free the context:
+Free the context when you're done. Path: `/api/1.2/contexts/destroy`:
 
 ```bash
-databricks api post /api/1.2/commands/contexts/destroy \
+databricks api post /api/1.2/contexts/destroy \
   --json '{"clusterId":"{{cluster_id}}","contextId":"<CTX>"}'
 ```
 
-Contexts are a cluster resource — don't leak them.
+Contexts are a cluster resource — don't leak them across sessions.
 
 ---
 
-## Composing operations to satisfy a request
+## Composing reads to satisfy a request
 
-After bootstrap, read the catalogue's entries — their `description` and `parameters_json` fields tell you what each op does and what it needs. Plan a request as a sequence of ops the catalogue actually exposes; an op you don't see is one you can't call.
+Plan a request as one or more table reads with `table_configuration` filters from the README. Examples for orientation only — the README is authoritative for what each table accepts:
 
-A request often decomposes across multiple ops, each one a normal execution-envelope call. For example, "download the latest attachment from Alice" typically becomes: find the candidate messages, pick the right one, enumerate its attachments, fetch the bytes — each step a separate op chosen from the catalogue.
+- **"Find emails from Alice last week"** → read `messages` with `q="from:alice@example.com newer_than:7d"`; cap with `.limit(N)`.
+- **"What labels do I have?"** → read `labels`, no filters.
+- **"50 unread inbox messages, headers only"** → read `messages` with `q="is:unread"`, `labelIds="INBOX"`, `format="metadata"`, `.limit(50)`. Gmail charges ~4× more per message for `format="full"`.
+- **"Show my profile"** → read `profile`, no filters.
+- **"Find the latest invoice from Vendor"** → read `messages` with `q="from:vendor@example.com subject:invoice"`, `.limit(5)`, let the user pick by id, then a tighter follow-up read if needed.
 
-Two general practices help regardless of which ops the catalogue exposes:
-
-- **Prefer lightweight discovery before heavy fetches.** If the catalogue offers a triage-style op (header-only listing) alongside a full-fetch op, run the triage one first to narrow the set, then fetch full bodies only for what you actually need. Gmail charges roughly 4× more per message for full-format reads than for metadata-only.
-- **Cap rows you don't need.** Some ops accept a `limit` parameter; for ones that don't, chain `.limit(N)` inside the snippet before `.collect()`.
-
-When the request is about *ongoing or scheduled* ingestion rather than an ad-hoc read, stop here and hand off to the `deploy-connector` skill — see the carve-out in the previous section.
+Practical:
+- Always cap rows by chaining `.limit(N)` on the DataFrame; the read path itself enforces no row cap.
+- Prefer `format="metadata"` on the `messages` table when the user only needs headers.
+- The connector internally translates `q` to Gmail's search syntax — pass it through verbatim (e.g. `is:unread`, `has:attachment`, `newer_than:7d`).
 
 ---
 
 ## Connection prerequisite
 
-If `{{connection_name}}` is provided, trust it and try `validate_connection` early; surface `_meta` errors verbatim.
+If `{{connection_name}}` is provided, trust it and run a small read early to validate (e.g. `tableName=labels`, `.limit(1)`); surface any error verbatim.
 
 If it isn't, the connection must be created on the **user's laptop** because the OAuth U2M flow opens their browser:
 
@@ -139,30 +171,33 @@ community-connector create_connection gmail <CONN_NAME> \
 
 Google's `authorization_endpoint`, `token_endpoint`, and scopes are baked into `connector_spec.yaml`; the user only supplies their OAuth Web Application's `client_id` + `client_secret`. Choose `u2m_per_user` instead when each end user should re-consent independently.
 
-You can't shortcut this — UC mints and refreshes the `access_token`, and the connector treats it as opaque. If `validate_connection` returns `auth_failed` mid-session, send the user back here to re-consent.
+You can't shortcut this — UC mints and refreshes the `access_token`, and the connector treats it as opaque.
 
 ---
 
-## Error codes (canonical `_meta.code` values)
+## Error handling
 
-The dispatcher normalises connector failures. When you see one, decide whether to retry, recompose, or surface to the user:
+The deployed connector surfaces failures as Spark exceptions (the agent-dispatcher's normalised `_meta.code` envelope is not on the dispatch path yet). When `results.resultType == "error"`, parse `results.summary` + `results.cause` and act on the underlying cause:
 
-| Code | Meaning | What you should do |
+| Symptom | Likely cause | What to do |
 |---|---|---|
-| `auth_failed` | OAuth token expired or revoked. | Stop; ask the user to re-run the `create_connection` flow. |
-| `permission_denied` | Usually missing `drive.readonly` on a Drive-hosted attachment. | Tell the user; offer to retry once they re-consent with both scopes. |
-| `not_found` | Bad `message_id` / `attachment_id` / `drive_file_id`. | Recheck the id you computed — typically a stale search result. |
-| `rate_limited` | Gmail 429. | Back off (a few seconds), retry once. Don't hammer. |
-| `bad_request` | Missing/malformed option. | Re-read the parameter list from `list_operations`; you probably picked a wrong key. |
-| `connection_failed` | The UC connection itself is broken. | Run `validate_connection`, surface the message, stop. |
+| `Bad Target: /api/...` from `databricks api` | REST path wrong (most often `commands/contexts/...`) | Re-check the path table at the top of this file. |
+| Gmail HTTP 401 in the traceback | OAuth token expired / revoked | Stop; ask the user to re-run `create_connection`. |
+| Gmail HTTP 403 | Missing scope or Workspace admin restriction | Surface the message; if Drive-related, the connector still works for Gmail-only reads. |
+| Gmail HTTP 404 on the history endpoint | `historyId` expired (~30 days) | The connector falls back to a full scan on retry; warn the user the next read may be slow. |
+| Gmail HTTP 429 | Rate limit | Back off a few seconds and retry once. Don't hammer. |
+| `Connection not found` | `connection_name` is wrong or missing | Re-confirm with the user; offer to create via the prerequisite step. |
+| Module import error on `GmailDataSource` | Connector wheel not installed on the cluster | Stop and surface — this skill can't fix cluster libraries. |
 
 ---
 
 ## Rules
 
 - The `cluster_id` always comes from the user. Don't reuse a stale one across sessions.
-- `list_operations` is the source of truth for what's callable — load it at bootstrap, and re-load whenever the connector might have changed (e.g. after the user redeploys).
-- Always print results as JSON inside the snippet so the cluster response is machine-parseable; never rely on the Spark text-table output.
-- Stay inside the catalogue. If the user wants a write action or anything outside it, say so plainly — don't try to fake it through a read op.
+- The **path table** at the top is the source of truth for REST endpoints. Never invent a path. Never paste `/api/2.0/commands/...` or `/api/1.2/commands/contexts/...`.
+- The **README** is the source of truth for the table surface — table names and `table_configuration` keys. Never invent either; don't claim ops (`search_messages`, `download_attachment`, etc.) work today.
+- Register the data source on the first command in every fresh context, never on later commands in the same context.
+- Always print results as JSON inside the snippet so the cluster response is machine-parseable; don't rely on Spark's text-table output.
+- Stay inside the table surface. If the user wants something it can't do, say so plainly — don't fake it through an unrelated read.
 - Tear down the execution context when the conversation's Gmail work is finished, including on error.
 - For sustained ingestion, hand off to `deploy-connector` rather than looping the execution envelope yourself.

--- a/.claude/skills/gmail-connector/SKILL.md
+++ b/.claude/skills/gmail-connector/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: gmail-connector
+description: Tool layer for Gmail tasks. Loads the connector's operation catalogue from a Databricks cluster via the Command Execution REST API and composes operations (search, fetch, attachments) to satisfy the user's intent. Use whenever the user asks the agent to do something with their mailbox.
+args:
+  - name: cluster_id
+    description: All-purpose cluster the agent runs Gmail operations on (required — must be supplied by the user, never invented).
+    required: true
+  - name: connection_name
+    description: Name of the UC COMMUNITY connection holding the Gmail OAuth grant. Create one (see "Connection prerequisite") if absent.
+    required: false
+---
+
+# Gmail Connector
+
+This skill turns the project's Gmail Spark APIs into an MCP-style tool surface. You — the agent — translate the user's natural request into a sequence of connector operations, run them on a Databricks cluster, and return the answer.
+
+You **never** invent operations or parameter names. The cluster is the source of truth: load the catalogue once with `list_operations`, then drive everything else from it.
+
+---
+
+## What the user can ask for
+
+The connector is **read-side only**. Anything in this list is in scope:
+
+- "Search / find / show me emails matching X" — typed filters on sender, subject, date window, label, attachments, unread, plus free-form Gmail query syntax.
+- "Open / show / summarise this specific email" — by id, with decoded plain-text and HTML body.
+- "What's attached to this email?" / "Download the attachment / file" — Gmail-native parts and Drive-hosted links, written to a UC Volume.
+- "List my Gmail labels / drafts / filters / forwarding addresses / send-as aliases / delegates / account info."
+- "Ingest my Gmail tables into Unity Catalog on a schedule" — hand off to the `deploy-connector` skill with `source_name=gmail`; do not loop the read path.
+
+## What the user **cannot** ask for through this skill
+
+If the user asks for any of the following, stop, explain it isn't supported by this connector, and offer the closest in-scope alternative:
+
+- **Anything that writes to Gmail** — send, reply, draft, archive, delete, mark read, modify labels, create/edit filters or signatures. The connector ships read-only OAuth scopes (`gmail.readonly` + `drive.readonly`).
+- **Mailboxes other than the connection's** — there's no per-call account switching beyond the OAuth subject the connection was created for.
+- **Real-time push / webhooks** — the connector polls; it doesn't receive Gmail push notifications.
+
+If the user asks for something Gmail-shaped but not in the loaded catalogue (e.g. a calendar event, a Drive folder listing), check `list_operations` first; if it isn't there, say so plainly rather than guessing.
+
+---
+
+## How you actually call into the connector
+
+Every call has the same envelope — a Python snippet executed in a long-lived context on the user's cluster:
+
+```python
+df = (spark.read.format("lakeflow_connect")
+        .option("connection_name", "{{connection_name}}")
+        .option("operation", "<OP_NAME>")
+        .option("<param>", "<value>")        # 0+ params from list_operations
+        .load())
+```
+
+Composing a snippet, shipping it to the cluster, and parsing the result is one helper, not a per-task ritual — see *Execution envelope* below.
+
+### Bootstrap (do once at the start of a Gmail-shaped conversation)
+
+1. **Confirm the cluster** the user gave you (`{{cluster_id}}`) is `RUNNING`:
+   ```bash
+   databricks api get /api/2.1/clusters/get \
+     --json "{\"cluster_id\":\"{{cluster_id}}\"}" -o json | jq '{state, spark_version}'
+   ```
+   If terminated, ask the user before starting it.
+2. **Open a Python context** on that cluster and remember the returned `id`:
+   ```bash
+   databricks api post /api/2.0/commands/contexts/create \
+     --json '{"clusterId":"{{cluster_id}}","language":"python"}' -o json
+   ```
+3. **Register the data source and load the catalogue**:
+   ```python
+   import json
+   from databricks.labs.community_connector.sources.gmail import GmailDataSource
+   spark.dataSource.register(GmailDataSource)
+   df = (spark.read.format("lakeflow_connect")
+           .option("connection_name", "{{connection_name}}")
+           .option("operation", "list_operations").load())
+   print(json.dumps([r.asDict() for r in df.collect()]))
+   ```
+   The printed JSON gives you `name`, `description`, `kind`, `result_schema_json`, and `parameters_json` for **every** operation this connection exposes. Cache it for the rest of the session. If `list_operations` fails, the connector isn't installed on the cluster — surface that and stop.
+
+After that, individual user requests don't repeat steps 1–3. They just run more snippets against the same context.
+
+### Execution envelope (the universal "call any operation")
+
+For any one operation:
+
+1. Build the snippet — pick `OP_NAME` and only the parameters that the catalogue declares for it. End the snippet with `print(json.dumps([r.asDict(recursive=True) for r in df.collect()], default=str))` so the result comes back parseable.
+2. Submit to the cluster:
+   ```bash
+   databricks api post /api/2.0/commands/execute \
+     --json '{"clusterId":"{{cluster_id}}","contextId":"<CTX>","language":"python","command":"<SNIPPET>"}' -o json
+   ```
+3. Poll until terminal status:
+   ```bash
+   databricks api get /api/2.0/commands/status \
+     --json "{\"clusterId\":\"{{cluster_id}}\",\"contextId\":\"<CTX>\",\"commandId\":\"<CMD>\"}" -o json
+   ```
+   `status` walks `Queued → Running → Finished | Error | Cancelled`.
+4. Read the result:
+   - `Finished`, `results.resultType == "text"` → `results.data` is the JSON you printed. Parse and use.
+   - `Error` → `results.summary` is the one-liner; `results.cause` is the traceback. The dispatcher writes a canonical code into `_meta.code` of the printed row when the error is connector-level (see *Error codes* below).
+
+A few quoting notes that bite if you skip them:
+- The `command` field is a JSON string containing Python source — preserve newlines (`\n`) and quote your inner strings.
+- Spark's `CaseInsensitiveStringMap` lowercases option keys, but the connector already handles the standard parameter spellings; just match whatever `list_operations` shows.
+- `spark.dataSource.register(GmailDataSource)` is idempotent inside a context; do it once at bootstrap, not per call.
+
+### Teardown
+
+At the end of the session, free the context:
+
+```bash
+databricks api post /api/2.0/commands/contexts/destroy \
+  --json '{"clusterId":"{{cluster_id}}","contextId":"<CTX>"}'
+```
+
+Contexts are a cluster resource — don't leak them.
+
+---
+
+## Composing operations to satisfy a request
+
+Walk the catalogue first, then plan. Patterns that tend to work:
+
+- **"Find emails from Alice last week"** → `search_messages` with `from_address=alice@…` and `newer_than=7d` (and `limit` if the user wants a small sample). Returns header-only rows — cheap, no bodies fetched.
+- **"Open the latest invoice from Vendor"** → first `search_messages` (`from_address=vendor@…`, `subject=invoice`, `limit=5`) to choose the message id, then `get_message` for full body + attachments + Drive file ids.
+- **"Download the PDF attached to that mail"** → `list_attachments` to read `attachment_id` / `drive_file_id` and the right `kind`, then `download_attachment` with `volume_path` under `/Volumes/<cat>/<schema>/<vol>/<filename>`. For Gmail-native parts pass `message_id` + `attachment_id`; for Drive parts pass `drive_file_id` (optionally `export_mime_type` for Google-native docs).
+- **"Is the connection alive?"** → `validate_connection`. One row, check `_meta.status == "ok"`.
+- **"What can you do?"** → answer from the loaded catalogue, not from this file. Each entry has a `description` written for exactly this.
+
+When a request mixes capabilities (e.g. "download the latest attachment from Alice"), you compose: `search_messages` → pick id → `list_attachments` → `download_attachment`. Each is a normal execution-envelope call.
+
+Always cap rows you don't need: `search_messages` honours `limit` (default 50, max 500); `read_table` honours nothing, so chain `.limit(N)` inside the snippet.
+
+---
+
+## Picking the right read path
+
+The catalogue exposes two read shapes; choose by intent:
+
+- `search_messages` — header-only triage. Cheap (Gmail charges ~5 quota units per message vs ~20 for full). Use any time the user wants to *find* messages.
+- `read_table` — full table scan with the table's natural schema. Use when the user wants raw `messages`, `threads`, `labels`, `drafts`, `profile`, `settings`, `filters`, `forwarding_addresses`, `send_as`, or `delegates`. For `messages`/`threads` it accepts the same typed filters as `search_messages` (composed into Gmail's `q` syntax).
+
+When the user wants periodic / scheduled ingestion of full tables into UC, **stop driving the read path** and route to the `deploy-connector` skill with `source_name=gmail`. That spins up an SDP pipeline backed by the same connector, which is the right vehicle for ongoing sync.
+
+---
+
+## Connection prerequisite
+
+If `{{connection_name}}` is provided, trust it and try `validate_connection` early; surface `_meta` errors verbatim.
+
+If it isn't, the connection must be created on the **user's laptop** because the OAuth U2M flow opens their browser:
+
+```bash
+community-connector create_connection gmail <CONN_NAME> \
+  --auth-type u2m \
+  -o '{"client_id":"<CLIENT_ID>","client_secret":"<CLIENT_SECRET>"}'
+```
+
+Google's `authorization_endpoint`, `token_endpoint`, and scopes are baked into `connector_spec.yaml`; the user only supplies their OAuth Web Application's `client_id` + `client_secret`. Choose `u2m_per_user` instead when each end user should re-consent independently.
+
+You can't shortcut this — UC mints and refreshes the `access_token`, and the connector treats it as opaque. If `validate_connection` returns `auth_failed` mid-session, send the user back here to re-consent.
+
+---
+
+## Error codes (canonical `_meta.code` values)
+
+The dispatcher normalises connector failures. When you see one, decide whether to retry, recompose, or surface to the user:
+
+| Code | Meaning | What you should do |
+|---|---|---|
+| `auth_failed` | OAuth token expired or revoked. | Stop; ask the user to re-run the `create_connection` flow. |
+| `permission_denied` | Usually missing `drive.readonly` on a Drive-hosted attachment. | Tell the user; offer to retry once they re-consent with both scopes. |
+| `not_found` | Bad `message_id` / `attachment_id` / `drive_file_id`. | Recheck the id you computed — typically a stale search result. |
+| `rate_limited` | Gmail 429. | Back off (a few seconds), retry once. Don't hammer. |
+| `bad_request` | Missing/malformed option. | Re-read the parameter list from `list_operations`; you probably picked a wrong key. |
+| `connection_failed` | The UC connection itself is broken. | Run `validate_connection`, surface the message, stop. |
+
+---
+
+## Rules
+
+- The `cluster_id` always comes from the user. Don't reuse a stale one across sessions.
+- `list_operations` is the source of truth for what's callable — load it at bootstrap, and re-load whenever the connector might have changed (e.g. after the user redeploys).
+- Always print results as JSON inside the snippet so the cluster response is machine-parseable; never rely on the Spark text-table output.
+- Stay inside the catalogue. If the user wants a write action or anything outside it, say so plainly — don't try to fake it through a read op.
+- Tear down the execution context when the conversation's Gmail work is finished, including on error.
+- For sustained ingestion, hand off to `deploy-connector` rather than looping the execution envelope yourself.

--- a/.claude/skills/gmail-connector/SKILL.md
+++ b/.claude/skills/gmail-connector/SKILL.md
@@ -3,7 +3,7 @@ name: gmail-connector
 description: Tool layer for Gmail reads. Runs read queries on a fixed Databricks cluster via the Command Execution REST API; scheduled-ingestion requests hand off to `deploy-connector`. Use whenever the user asks the agent to read something from their mailbox.
 args:
   - name: connection_name
-    description: Name of the UC COMMUNITY connection holding the Gmail OAuth grant.
+    description: Name of the UC COMMUNITY connection holding the Gmail OAuth grant. Must be supplied by the user; if they don't have one, see "Connection" for how to create it.
     required: false
 ---
 
@@ -63,6 +63,22 @@ The one explicit carve-out, owned by a sibling skill:
 - **Scheduled / continuous ingestion** ("land my inbox in UC hourly") → hand off to the `deploy-connector` skill with `source_name=gmail`. That skill provisions an SDP pipeline via the `community-connector` CLI. Don't loop the read envelope here to fake it.
 
 If the user wants something no operation in the catalog supports (sending/writing mail, push notifications), say so plainly.
+
+---
+
+## Connection
+
+Every read goes through a Unity Catalog **COMMUNITY** connection that holds the Gmail OAuth grant. **The connection name must come from the user — ask for it; never invent, guess, or default one.** Pass it as the `databricks.connection` option on every read.
+
+If the user doesn't have a connection yet, they create one on their **own laptop** (the OAuth U2M flow opens their browser — you can't run it for them):
+
+```bash
+community-connector create_connection gmail <CONN_NAME> \
+  --auth-type u2m \
+  -o '{"client_id":"<CLIENT_ID>","client_secret":"<CLIENT_SECRET>"}'
+```
+
+Google's authorization/token endpoints and scopes are baked into `connector_spec.yaml`; the user supplies only their OAuth Web Application's `client_id` and `client_secret`. Choose `u2m_per_user` instead when each end user should consent independently. UC then mints and refreshes the `access_token` and the connector treats it as opaque — there's no shortcut from the cluster.
 
 ---
 
@@ -188,6 +204,6 @@ The deployed connector surfaces hard failures as Spark exceptions and soft failu
 | Gmail HTTP 403 | Missing scope or Workspace admin restriction | Surface the message; if Drive-related, the connector still works for Gmail-only reads. |
 | Gmail HTTP 404 on the history endpoint | `historyId` expired (~30 days) | The connector falls back to a full scan on retry; warn the user the next read may be slow. |
 | Gmail HTTP 429 | Rate limit | Back off a few seconds and retry once. Don't hammer. |
-| `Connection not found` | connection name is wrong or missing | Re-confirm the connection name with the user. |
+| `Connection not found` | connection name is wrong or missing | Re-confirm the name with the user; if they have none, see "Connection" to create one. |
 | `Gmail connector requires 'access_token' in options` | Read used the wrong connection option key, so UC injected no token | Use `.option("databricks.connection", "<CONN>")` — not `connection_name`/`connectionName`. |
 | Module import error on `GmailDataSource` | Connector wheel not installed on the cluster | Stop and surface — this skill can't fix cluster libraries. |

--- a/.claude/skills/gmail-connector/SKILL.md
+++ b/.claude/skills/gmail-connector/SKILL.md
@@ -3,7 +3,7 @@ name: gmail-connector
 description: Tool layer for Gmail reads. Runs read queries on a fixed Databricks cluster via the Command Execution REST API; scheduled-ingestion requests hand off to `deploy-connector`. Use whenever the user asks the agent to read something from their mailbox.
 args:
   - name: connection_name
-    description: Name of the UC COMMUNITY connection holding the Gmail OAuth grant. Create one (see "Connection prerequisite") if absent.
+    description: Name of the UC COMMUNITY connection holding the Gmail OAuth grant.
     required: false
 ---
 
@@ -157,24 +157,6 @@ Practical:
 - Always cap rows by chaining `.limit(N)` on the DataFrame; the read path itself enforces no row cap.
 - Prefer `format="metadata"` on the `messages` table when the user only needs headers.
 - The connector internally translates `q` to Gmail's search syntax — pass it through verbatim (e.g. `is:unread`, `has:attachment`, `newer_than:7d`).
-
----
-
-## Connection prerequisite
-
-If `{{connection_name}}` is provided, trust it and run a small read early to validate (e.g. `tableName=labels`, `.limit(1)`); surface any error verbatim.
-
-If it isn't, the connection must be created on the **user's laptop** because the OAuth U2M flow opens their browser:
-
-```bash
-community-connector create_connection gmail <CONN_NAME> \
-  --auth-type u2m \
-  -o '{"client_id":"<CLIENT_ID>","client_secret":"<CLIENT_SECRET>"}'
-```
-
-Google's `authorization_endpoint`, `token_endpoint`, and scopes are baked into `connector_spec.yaml`; the user only supplies their OAuth Web Application's `client_id` + `client_secret`. Choose `u2m_per_user` instead when each end user should re-consent independently.
-
-You can't shortcut this — UC mints and refreshes the `access_token`, and the connector treats it as opaque.
 
 ---
 

--- a/.claude/skills/gmail-connector/SKILL.md
+++ b/.claude/skills/gmail-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gmail-connector
-description: Tool layer for ad-hoc Gmail reads against the project's `lakeflow_connect` table surface. Runs read queries on a fixed Databricks cluster via the Command Execution REST API; scheduled-ingestion requests hand off to `deploy-connector`. Use whenever the user asks the agent to read something from their mailbox.
+description: Tool layer for Gmail reads. Runs read queries on a fixed Databricks cluster via the Command Execution REST API; scheduled-ingestion requests hand off to `deploy-connector`. Use whenever the user asks the agent to read something from their mailbox.
 args:
   - name: connection_name
     description: Name of the UC COMMUNITY connection holding the Gmail OAuth grant. Create one (see "Connection prerequisite") if absent.
@@ -11,7 +11,7 @@ args:
 
 This skill turns the project's Gmail tables into a tool surface the agent can call. You — the agent — translate the user's request into table reads with optional filter options, run them on a Databricks cluster via the Command Execution REST API, and return the answer.
 
-You **never** invent table names, option keys, or REST paths. The connector README is the source of truth for the tables; the path table below is the source of truth for the cluster API.
+You **never** invent table names, option keys, or REST paths. The table surface in "What this skill is for" is the source of truth for the tables and options; the path table below is the source of truth for the cluster API.
 
 ---
 
@@ -23,7 +23,7 @@ This skill runs every Gmail snippet on the fixed cluster:
 0528-081139-nh2l2jnu
 ```
 
-Use that id verbatim in every Command Execution request. **Do not ask the user for a cluster id** and do not substitute a different one — the connector wheel + Python environment this skill assumes are only known to be present on that cluster. If a request to it fails with a state other than `RUNNING`, ask the user before starting it; do not fall back to another cluster.
+Use that id verbatim in every Command Execution request. **Do not ask the user for a cluster id** and do not substitute a different one. If a request to it fails with a state other than `RUNNING`, report the error back to user and terminate. 
 
 ---
 
@@ -56,17 +56,9 @@ The Databricks Go SDK and the docs.databricks.com pages reference a `2.0` alias 
 
 The Gmail connector exposes Gmail as **Spark tables** — one table per Gmail object (`messages`, `threads`, `labels`, `drafts`, `profile`, `settings`, `filters`, `forwarding_addresses`, `send_as`, `delegates`). Each accepts a small set of filter options (`q`, `labelIds`, `maxResults`, `includeSpamTrash`, `format`). Your tool surface is exactly those tables and options — nothing more.
 
-Read the connector README before planning a request; it is the authoritative manifest:
-
-- `src/databricks/labs/community_connector/sources/gmail/README.md`
-
-It enumerates each table, its primary key, ingestion type, schema highlights, and the keys accepted under `table_configuration`.
-
 The one explicit carve-out, owned by a sibling skill:
 
 - **Scheduled / continuous ingestion** ("land my inbox in UC hourly") → hand off to the `deploy-connector` skill with `source_name=gmail`. That skill provisions an SDP pipeline via the `community-connector` CLI. Don't loop the read envelope here to fake it.
-
-> **Today's limit.** The connector source contains an agent-dispatcher with richer ops (`list_operations`, `search_messages`, `list_attachments`, `download_attachment`, …), but that surface is **not yet on the Spark format dispatch path** in the deployed builds — i.e. setting `option("operation", ...)` does nothing. Until that wiring ships, ignore those ops; the table read path is the only surface you can call. **Attachment-byte downloads in particular are out of reach via this skill today** — the table surface returns attachment *metadata* on `messages.payload`, not bytes.
 
 If the user asks for something the table surface can't do (write actions, byte-level attachment fetch, push notifications), say so plainly.
 
@@ -80,7 +72,7 @@ Every read is a Python snippet executed in a long-lived context on the cluster:
 df = (spark.read.format("lakeflow_connect")
         .option("databricks.connection", "<CONN>")   # UC injects the OAuth access_token from this connection
         .option("tableName", "<TABLE_NAME>")
-        .option("<filter_key>", "<value>")    # 0+ from README's table_configuration
+        .option("<filter_key>", "<value>")    # 0+ from the option set above
         .load()
         .limit(<N>))                          # always cap rows you don't need
 print(json.dumps([r.asDict(recursive=True) for r in df.collect()], default=str))
@@ -136,7 +128,7 @@ The connection option key **must** be `databricks.connection` — that exact str
 
 Quoting notes that bite if you skip them:
 - The `command` field is a JSON string containing Python source — preserve newlines (`\n`) and quote your inner strings.
-- Spark's `CaseInsensitiveStringMap` lowercases option keys, but the connector handles the standard spellings; use the keys the README documents.
+- Spark's `CaseInsensitiveStringMap` lowercases option keys, but the connector handles the standard spellings; use the option keys listed in "What this skill is for".
 
 ### Teardown
 
@@ -153,7 +145,7 @@ Contexts are a cluster resource — don't leak them across sessions.
 
 ## Composing reads to satisfy a request
 
-Plan a request as one or more table reads with `table_configuration` filters from the README. Examples for orientation only — the README is authoritative for what each table accepts:
+Plan a request as one or more table reads with the filter options listed in "What this skill is for". Examples for orientation only:
 
 - **"Find emails from Alice last week"** → read `messages` with `q="from:alice@example.com newer_than:7d"`; cap with `.limit(N)`.
 - **"What labels do I have?"** → read `labels`, no filters.

--- a/.claude/skills/gmail-connector/SKILL.md
+++ b/.claude/skills/gmail-connector/SKILL.md
@@ -9,9 +9,9 @@ args:
 
 # Gmail Connector
 
-This skill turns the project's Gmail tables into a tool surface the agent can call. You — the agent — translate the user's request into table reads with optional filter options, run them on a Databricks cluster via the Command Execution REST API, and return the answer.
+This skill turns the Gmail connector's operations into a tool surface the agent can call. You — the agent — translate the user's request into one or more operation reads, run them on a Databricks cluster via the Command Execution REST API, and return the answer.
 
-You **never** invent table names, option keys, or REST paths. The table surface in "What this skill is for" is the source of truth for the tables and options; the path table below is the source of truth for the cluster API.
+You **never** invent operation names, parameters, or REST paths. The `list_operations` catalog (fetched at bootstrap) is the source of truth for what the connector supports and how to call it; the path table below is the source of truth for the cluster API.
 
 ---
 
@@ -54,31 +54,37 @@ The Databricks Go SDK and the docs.databricks.com pages reference a `2.0` alias 
 
 ## What this skill is for
 
-The Gmail connector exposes Gmail as **Spark tables** — one table per Gmail object (`messages`, `threads`, `labels`, `drafts`, `profile`, `settings`, `filters`, `forwarding_addresses`, `send_as`, `delegates`). Each accepts a small set of filter options (`q`, `labelIds`, `maxResults`, `includeSpamTrash`, `format`). Your tool surface is exactly those tables and options — nothing more.
+The Gmail connector exposes a set of **operations** you invoke one at a time via the `operation` option. The current catalog includes `search_messages` (typed-filter search, headers only), `get_message` (one message with decoded `body_text`/`body_html`, headers, attachment list), `list_attachments` and `download_attachment` (attachment metadata, and bytes to a Volume path), `read_table` and `list_objects` / `get_object_metadata` (read and enumerate Gmail object tables), and `validate_connection`. Each operation takes typed parameters and returns rows with a fixed schema.
+
+**`list_operations` is the authoritative, self-describing catalog — use it, not the list above, to plan reads.** Run it at bootstrap (a step below) and keep the result for the session. Each row gives an operation's `name`, `description`, `kind` (`data` / `metadata`), `parameters_json` (input schema), and `result_schema_json` (output schema). Read those to pick the operation that answers a request, see exactly which parameters it accepts, and tell the user accurately what is and isn't supported. The summary above is illustrative and may drift; the live catalog is truth.
 
 The one explicit carve-out, owned by a sibling skill:
 
 - **Scheduled / continuous ingestion** ("land my inbox in UC hourly") → hand off to the `deploy-connector` skill with `source_name=gmail`. That skill provisions an SDP pipeline via the `community-connector` CLI. Don't loop the read envelope here to fake it.
 
-If the user asks for something the table surface can't do (write actions, byte-level attachment fetch, push notifications), say so plainly.
+If the user wants something no operation in the catalog supports (sending/writing mail, push notifications), say so plainly.
 
 ---
 
 ## How you call into the connector
 
-Every read is a Python snippet executed in a long-lived context on the cluster:
+Every read invokes one operation as a Python snippet executed in a long-lived context on the cluster:
 
 ```python
 df = (spark.read.format("lakeflow_connect")
         .option("databricks.connection", "<CONN>")   # UC injects the OAuth access_token from this connection
-        .option("tableName", "<TABLE_NAME>")
-        .option("<filter_key>", "<value>")    # 0+ from the option set above
+        .option("operation", "<OP_NAME>")            # an operation from the list_operations catalog
+        .option("<param>", "<value>")     # 0+ typed params from that op's parameters_json
         .load()
-        .limit(<N>))                          # always cap rows you don't need
+        .limit(<N>))                      # always cap rows you don't need
 print(json.dumps([r.asDict(recursive=True) for r in df.collect()], default=str))
 ```
 
 The connection option key **must** be `databricks.connection` — that exact string is what Unity Catalog watches for to inject the connection's OAuth `access_token` into the connector options at query time. Other spellings (`connection_name`, `connectionName`) are silently ignored: UC injects nothing and the read fails inside the connector with `Gmail connector requires 'access_token' in options`.
+
+Each returned row carries a `_meta` field (`status` / `code` / `message`); a non-`ok` status flags a per-row failure even when no Spark exception is thrown. Operation names and parameter casing come straight from the catalog — don't guess them.
+
+> Direct table reads still work as a fallback: omit `operation` and pass `tableName=<object>` to read a Gmail object as a Spark table. Prefer operations — they give typed filters, decoded message bodies, and attachment access the raw table reads don't.
 
 ### Bootstrap (do once at the start of a Gmail-shaped conversation)
 
@@ -104,6 +110,16 @@ The connection option key **must** be `databricks.connection` — that exact str
    ```
    Subsequent commands in the same context **must not** re-emit those lines — the registration is cached. Re-registering is wasted overhead, not an error. If you open a new context later (cluster restart, you destroyed the previous one), the first command in *that* context must include them again.
 
+4. **Fetch the operation catalog.** Run `list_operations` and keep the result for the rest of the session — it's what you plan every read against. This can ride on the same first command as the registration above:
+   ```python
+   df = (spark.read.format("lakeflow_connect")
+           .option("databricks.connection", "<CONN>")
+           .option("operation", "list_operations")
+           .load())
+   print(json.dumps([r.asDict(recursive=True) for r in df.collect()], default=str))
+   ```
+   Each row's `parameters_json` and `result_schema_json` tell you how to translate the user's request into an operation + params, and let you answer "can you do X?" from the live surface rather than memory.
+
 ### Execution envelope (every read)
 
 1. **Build the snippet** from the template above, ending with the `print(json.dumps(...))` line so the result comes back parseable.
@@ -128,7 +144,7 @@ The connection option key **must** be `databricks.connection` — that exact str
 
 Quoting notes that bite if you skip them:
 - The `command` field is a JSON string containing Python source — preserve newlines (`\n`) and quote your inner strings.
-- Spark's `CaseInsensitiveStringMap` lowercases option keys, but the connector handles the standard spellings; use the option keys listed in "What this skill is for".
+- Spark's `CaseInsensitiveStringMap` lowercases option keys, but the connector handles the standard spellings; use the parameter names exactly as the operation's `parameters_json` declares them.
 
 ### Teardown
 
@@ -145,24 +161,25 @@ Contexts are a cluster resource — don't leak them across sessions; tear down e
 
 ## Composing reads to satisfy a request
 
-Plan a request as one or more table reads with the filter options listed in "What this skill is for". Examples for orientation only:
+Plan a request as one or more operations, taking parameters from each op's `parameters_json` in the catalog. Examples for orientation only — the catalog is authoritative:
 
-- **"Find emails from Alice last week"** → read `messages` with `q="from:alice@example.com newer_than:7d"`; cap with `.limit(N)`.
-- **"What labels do I have?"** → read `labels`, no filters.
-- **"50 unread inbox messages, headers only"** → read `messages` with `q="is:unread"`, `labelIds="INBOX"`, `format="metadata"`, `.limit(50)`. Gmail charges ~4× more per message for `format="full"`.
-- **"Show my profile"** → read `profile`, no filters.
-- **"Find the latest invoice from Vendor"** → read `messages` with `q="from:vendor@example.com subject:invoice"`, `.limit(5)`, let the user pick by id, then a tighter follow-up read if needed.
+- **"Find emails from Alice last week"** → `search_messages` with `from_address="alice@example.com"`, `newer_than="7d"`.
+- **"50 unread inbox messages"** → `search_messages` with `is_unread="true"`, `label="inbox"`, `limit="50"`. Headers/snippets only, no bodies.
+- **"Read the full text of message `<id>`"** → `get_message` with `message_id="<id>"` (decoded `body_text`/`body_html`, headers, attachment list).
+- **"What's attached to `<id>`, and download the PDF"** → `list_attachments` with `message_id="<id>"`, then `download_attachment` with the returned `attachment_id`+`message_id` (or `drive_file_id`) and a `volume_path`.
+- **"What objects can I read?"** → `list_objects`; describe one with `get_object_metadata`.
+- **"Find the latest invoice from Vendor"** → `search_messages` with `from_address="vendor@example.com"`, `subject="invoice"`, `limit="5"`; let the user pick an id, then `get_message`.
 
 Practical:
-- Always cap rows by chaining `.limit(N)` on the DataFrame; the read path itself enforces no row cap.
-- Prefer `format="metadata"` on the `messages` table when the user only needs headers.
-- The connector internally translates `q` to Gmail's search syntax — pass it through verbatim (e.g. `is:unread`, `has:attachment`, `newer_than:7d`).
+- Always cap rows with `.limit(N)`, and use the op's own `limit` param where it has one (`search_messages` defaults to 50, max 500).
+- `search_messages` returns metadata only — follow up with `get_message` when the user needs body content.
+- Typed filters (`from_address`, `to_address`, `subject`, `newer_than`, `after_date`, `before_date`, `is_unread`, `has_attachment`, `label`) compose via AND; pass any raw Gmail search expression through the `query` param verbatim.
 
 ---
 
 ## Error handling
 
-The deployed connector surfaces failures as Spark exceptions. When `results.resultType == "error"`, parse `results.summary` + `results.cause` and act on the underlying cause:
+The deployed connector surfaces hard failures as Spark exceptions and soft failures in each row's `_meta` envelope (`status` / `code` / `message`). When `results.resultType == "error"`, parse `results.summary` + `results.cause`; when it's `text`, also check `_meta.status` on the returned rows. Act on the underlying cause:
 
 | Symptom | Likely cause | What to do |
 |---|---|---|

--- a/.claude/skills/gmail-connector/SKILL.md
+++ b/.claude/skills/gmail-connector/SKILL.md
@@ -54,9 +54,9 @@ The Databricks Go SDK and the docs.databricks.com pages reference a `2.0` alias 
 
 ## What this skill is for
 
-The Gmail connector exposes a set of **operations** you invoke one at a time via the `operation` option. The current catalog includes `search_messages` (typed-filter search, headers only), `get_message` (one message with decoded `body_text`/`body_html`, headers, attachment list), `list_attachments` and `download_attachment` (attachment metadata, and bytes to a Volume path), `read_table` and `list_objects` / `get_object_metadata` (read and enumerate Gmail object tables), and `validate_connection`. Each operation takes typed parameters and returns rows with a fixed schema.
+The Gmail connector exposes a set of read **operations** — broadly: message search, single-message fetch with decoded body, attachment listing and download, generic table reads, and object/connection introspection. You invoke one at a time via the `operation` option; each takes typed parameters and returns rows with a fixed schema.
 
-**`list_operations` is the authoritative, self-describing catalog — use it, not the list above, to plan reads.** Run it at bootstrap (a step below) and keep the result for the session. Each row gives an operation's `name`, `description`, `kind` (`data` / `metadata`), `parameters_json` (input schema), and `result_schema_json` (output schema). Read those to pick the operation that answers a request, see exactly which parameters it accepts, and tell the user accurately what is and isn't supported. The summary above is illustrative and may drift; the live catalog is truth.
+**`list_operations` is the authoritative, self-describing catalog — fetch it at bootstrap (a step below) and plan every read against it.** Each row gives an operation's `name`, `description`, `kind` (`data` / `metadata`), `parameters_json` (input schema), and `result_schema_json` (output schema). Read those to pick the operation that answers a request, see exactly which parameters it accepts, and tell the user accurately what is and isn't supported.
 
 The one explicit carve-out, owned by a sibling skill:
 

--- a/.claude/skills/gmail-connector/SKILL.md
+++ b/.claude/skills/gmail-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gmail-connector
-description: Tool layer for Gmail tasks. Loads the connector's operation catalogue from a Databricks cluster via the Command Execution REST API and composes operations (search, fetch, attachments) to satisfy the user's intent. Use whenever the user asks the agent to do something with their mailbox.
+description: Tool layer for Gmail tasks. Loads the connector's operation catalogue dynamically from a Databricks cluster via the Command Execution REST API and composes those operations to satisfy the user's intent. The tool surface is whatever `list_operations` returns; scheduled-ingestion requests hand off to `deploy-connector`. Use whenever the user asks the agent to do something with their mailbox.
 args:
   - name: cluster_id
     description: All-purpose cluster the agent runs Gmail operations on (required — must be supplied by the user, never invented).
@@ -12,31 +12,21 @@ args:
 
 # Gmail Connector
 
-This skill turns the project's Gmail Spark APIs into an MCP-style tool surface. You — the agent — translate the user's natural request into a sequence of connector operations, run them on a Databricks cluster, and return the answer.
+This skill turns the project's Gmail Spark APIs into a tool surface the agent can call. You — the agent — translate the user's natural request into a sequence of connector operations, run them on a Databricks cluster, and return the answer.
 
-You **never** invent operations or parameter names. The cluster is the source of truth: load the catalogue once with `list_operations`, then drive everything else from it.
+You **never** invent operations or parameter names, and you don't infer the surface from this file. The cluster is the source of truth: load the catalogue once with `list_operations`, then drive everything from what it reports.
 
 ---
 
-## What the user can ask for
+## What this skill is for
 
-The connector is **read-side only**. Anything in this list is in scope:
+This skill is the **tool layer** for Gmail. Your tool surface is exactly what `list_operations` returns when called against the user's connection — nothing more, nothing less. Each catalogue entry carries a `description` and `parameters_json` written for exactly this purpose: read them to decide whether a request is satisfiable and how to call it. If the catalogue doesn't expose what the user is asking for, say so plainly — don't fake it with an op that isn't a fit.
 
-- "Search / find / show me emails matching X" — typed filters on sender, subject, date window, label, attachments, unread, plus free-form Gmail query syntax.
-- "Open / show / summarise this specific email" — by id, with decoded plain-text and HTML body.
-- "What's attached to this email?" / "Download the attachment / file" — Gmail-native parts and Drive-hosted links, written to a UC Volume.
-- "List my Gmail labels / drafts / filters / forwarding addresses / send-as aliases / delegates / account info."
-- "Ingest my Gmail tables into Unity Catalog on a schedule" — hand off to the `deploy-connector` skill with `source_name=gmail`; do not loop the read path.
+There is one explicit carve-out, because it's owned by a sibling skill rather than the read-side tool surface:
 
-## What the user **cannot** ask for through this skill
+- **Standing up a scheduled / continuous ingestion pipeline** (e.g. "ingest my labels table into UC every hour", "land my inbox in `main.gmail.messages` daily") — hand off to the `deploy-connector` skill with `source_name=gmail`. That skill provisions an SDP pipeline via the `community-connector` CLI, which is the right vehicle for ongoing sync. Do not loop the read envelope in this skill to fake periodic ingestion.
 
-If the user asks for any of the following, stop, explain it isn't supported by this connector, and offer the closest in-scope alternative:
-
-- **Anything that writes to Gmail** — send, reply, draft, archive, delete, mark read, modify labels, create/edit filters or signatures. The connector ships read-only OAuth scopes (`gmail.readonly` + `drive.readonly`).
-- **Mailboxes other than the connection's** — there's no per-call account switching beyond the OAuth subject the connection was created for.
-- **Real-time push / webhooks** — the connector polls; it doesn't receive Gmail push notifications.
-
-If the user asks for something Gmail-shaped but not in the loaded catalogue (e.g. a calendar event, a Drive folder listing), check `list_operations` first; if it isn't there, say so plainly rather than guessing.
+For everything else — including whether write actions, push notifications, multi-mailbox routing, etc. are supported — let `list_operations` answer. The catalogue is the truth; this file is not.
 
 ---
 
@@ -121,28 +111,16 @@ Contexts are a cluster resource — don't leak them.
 
 ## Composing operations to satisfy a request
 
-Walk the catalogue first, then plan. Patterns that tend to work:
+After bootstrap, read the catalogue's entries — their `description` and `parameters_json` fields tell you what each op does and what it needs. Plan a request as a sequence of ops the catalogue actually exposes; an op you don't see is one you can't call.
 
-- **"Find emails from Alice last week"** → `search_messages` with `from_address=alice@…` and `newer_than=7d` (and `limit` if the user wants a small sample). Returns header-only rows — cheap, no bodies fetched.
-- **"Open the latest invoice from Vendor"** → first `search_messages` (`from_address=vendor@…`, `subject=invoice`, `limit=5`) to choose the message id, then `get_message` for full body + attachments + Drive file ids.
-- **"Download the PDF attached to that mail"** → `list_attachments` to read `attachment_id` / `drive_file_id` and the right `kind`, then `download_attachment` with `volume_path` under `/Volumes/<cat>/<schema>/<vol>/<filename>`. For Gmail-native parts pass `message_id` + `attachment_id`; for Drive parts pass `drive_file_id` (optionally `export_mime_type` for Google-native docs).
-- **"Is the connection alive?"** → `validate_connection`. One row, check `_meta.status == "ok"`.
-- **"What can you do?"** → answer from the loaded catalogue, not from this file. Each entry has a `description` written for exactly this.
+A request often decomposes across multiple ops, each one a normal execution-envelope call. For example, "download the latest attachment from Alice" typically becomes: find the candidate messages, pick the right one, enumerate its attachments, fetch the bytes — each step a separate op chosen from the catalogue.
 
-When a request mixes capabilities (e.g. "download the latest attachment from Alice"), you compose: `search_messages` → pick id → `list_attachments` → `download_attachment`. Each is a normal execution-envelope call.
+Two general practices help regardless of which ops the catalogue exposes:
 
-Always cap rows you don't need: `search_messages` honours `limit` (default 50, max 500); `read_table` honours nothing, so chain `.limit(N)` inside the snippet.
+- **Prefer lightweight discovery before heavy fetches.** If the catalogue offers a triage-style op (header-only listing) alongside a full-fetch op, run the triage one first to narrow the set, then fetch full bodies only for what you actually need. Gmail charges roughly 4× more per message for full-format reads than for metadata-only.
+- **Cap rows you don't need.** Some ops accept a `limit` parameter; for ones that don't, chain `.limit(N)` inside the snippet before `.collect()`.
 
----
-
-## Picking the right read path
-
-The catalogue exposes two read shapes; choose by intent:
-
-- `search_messages` — header-only triage. Cheap (Gmail charges ~5 quota units per message vs ~20 for full). Use any time the user wants to *find* messages.
-- `read_table` — full table scan with the table's natural schema. Use when the user wants raw `messages`, `threads`, `labels`, `drafts`, `profile`, `settings`, `filters`, `forwarding_addresses`, `send_as`, or `delegates`. For `messages`/`threads` it accepts the same typed filters as `search_messages` (composed into Gmail's `q` syntax).
-
-When the user wants periodic / scheduled ingestion of full tables into UC, **stop driving the read path** and route to the `deploy-connector` skill with `source_name=gmail`. That spins up an SDP pipeline backed by the same connector, which is the right vehicle for ongoing sync.
+When the request is about *ongoing or scheduled* ingestion rather than an ad-hoc read, stop here and hand off to the `deploy-connector` skill — see the carve-out in the previous section.
 
 ---
 

--- a/.claude/skills/gmail-connector/SKILL.md
+++ b/.claude/skills/gmail-connector/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: gmail-connector
-description: Tool layer for ad-hoc Gmail reads against the project's `lakeflow_connect` table surface. Runs read queries on a user-supplied Databricks cluster via the Command Execution REST API; scheduled-ingestion requests hand off to `deploy-connector`. Use whenever the user asks the agent to read something from their mailbox.
+description: Tool layer for ad-hoc Gmail reads against the project's `lakeflow_connect` table surface. Runs read queries on a fixed Databricks cluster via the Command Execution REST API; scheduled-ingestion requests hand off to `deploy-connector`. Use whenever the user asks the agent to read something from their mailbox.
 args:
-  - name: cluster_id
-    description: All-purpose cluster the agent runs Gmail reads on (required — must be supplied by the user, never invented).
-    required: true
   - name: connection_name
     description: Name of the UC COMMUNITY connection holding the Gmail OAuth grant. Create one (see "Connection prerequisite") if absent.
     required: false
@@ -15,6 +12,18 @@ args:
 This skill turns the project's Gmail tables into a tool surface the agent can call. You — the agent — translate the user's request into table reads with optional filter options, run them on a Databricks cluster via the Command Execution REST API, and return the answer.
 
 You **never** invent table names, option keys, or REST paths. The connector README is the source of truth for the tables; the path table below is the source of truth for the cluster API.
+
+---
+
+## Cluster
+
+This skill runs every Gmail snippet on the fixed cluster:
+
+```
+0528-081139-nh2l2jnu
+```
+
+Use that id verbatim in every Command Execution request. **Do not ask the user for a cluster id** and do not substitute a different one — the connector wheel + Python environment this skill assumes are only known to be present on that cluster. If a request to it fails with a state other than `RUNNING`, ask the user before starting it; do not fall back to another cluster.
 
 ---
 
@@ -65,7 +74,7 @@ If the user asks for something the table surface can't do (write actions, byte-l
 
 ## How you call into the connector
 
-Every read is a Python snippet executed in a long-lived context on the user's cluster:
+Every read is a Python snippet executed in a long-lived context on the fixed cluster (`0528-081139-nh2l2jnu`):
 
 ```python
 df = (spark.read.format("lakeflow_connect")
@@ -82,14 +91,14 @@ print(json.dumps([r.asDict(recursive=True) for r in df.collect()], default=str))
 1. **Confirm the cluster** is `RUNNING`:
    ```bash
    databricks api get /api/2.1/clusters/get \
-     --json "{\"cluster_id\":\"{{cluster_id}}\"}" -o json | jq '{state, spark_version}'
+     --json "{\"cluster_id\":\"0528-081139-nh2l2jnu\"}" -o json | jq '{state, spark_version}'
    ```
    If terminated, ask the user before starting it.
 
 2. **Open a Python context.** Path: `/api/1.2/contexts/create` (not `/api/1.2/commands/contexts/create` — see the path table above):
    ```bash
    databricks api post /api/1.2/contexts/create \
-     --json '{"clusterId":"{{cluster_id}}","language":"python"}' -o json
+     --json '{"clusterId":"0528-081139-nh2l2jnu","language":"python"}' -o json
    ```
    Returns `{"id": "<CONTEXT_ID>"}`. Remember it for the rest of the session.
 
@@ -108,14 +117,14 @@ print(json.dumps([r.asDict(recursive=True) for r in df.collect()], default=str))
 2. **Submit** (path: `/api/1.2/commands/execute`):
    ```bash
    databricks api post /api/1.2/commands/execute \
-     --json '{"clusterId":"{{cluster_id}}","contextId":"<CTX>","language":"python","command":"<SNIPPET>"}' \
+     --json '{"clusterId":"0528-081139-nh2l2jnu","contextId":"<CTX>","language":"python","command":"<SNIPPET>"}' \
      -o json
    ```
 
 3. **Poll** until terminal (path: `/api/1.2/commands/status`):
    ```bash
    databricks api get /api/1.2/commands/status \
-     --json "{\"clusterId\":\"{{cluster_id}}\",\"contextId\":\"<CTX>\",\"commandId\":\"<CMD>\"}" -o json
+     --json "{\"clusterId\":\"0528-081139-nh2l2jnu\",\"contextId\":\"<CTX>\",\"commandId\":\"<CMD>\"}" -o json
    ```
    `status` walks `Queued → Running → Finished | Error | Cancelled`.
 
@@ -133,7 +142,7 @@ Free the context when you're done. Path: `/api/1.2/contexts/destroy`:
 
 ```bash
 databricks api post /api/1.2/contexts/destroy \
-  --json '{"clusterId":"{{cluster_id}}","contextId":"<CTX>"}'
+  --json '{"clusterId":"0528-081139-nh2l2jnu","contextId":"<CTX>"}'
 ```
 
 Contexts are a cluster resource — don't leak them across sessions.
@@ -193,7 +202,7 @@ The deployed connector surfaces failures as Spark exceptions (the agent-dispatch
 
 ## Rules
 
-- The `cluster_id` always comes from the user. Don't reuse a stale one across sessions.
+- The `cluster_id` is **hard-coded** to `0528-081139-nh2l2jnu`. Never ask the user for it and never substitute another id.
 - The **path table** at the top is the source of truth for REST endpoints. Never invent a path. Never paste `/api/2.0/commands/...` or `/api/1.2/commands/contexts/...`.
 - The **README** is the source of truth for the table surface — table names and `table_configuration` keys. Never invent either; don't claim ops (`search_messages`, `download_attachment`, etc.) work today.
 - Register the data source on the first command in every fresh context, never on later commands in the same context.

--- a/.claude/skills/gmail-connector/SKILL.md
+++ b/.claude/skills/gmail-connector/SKILL.md
@@ -54,10 +54,10 @@ Composing a snippet, shipping it to the cluster, and parsing the result is one h
    If terminated, ask the user before starting it.
 2. **Open a Python context** on that cluster and remember the returned `id`:
    ```bash
-   databricks api post /api/2.0/commands/contexts/create \
+   databricks api post /api/1.2/commands/contexts/create \
      --json '{"clusterId":"{{cluster_id}}","language":"python"}' -o json
    ```
-3. **Register the data source and load the catalogue**:
+3. **Register the data source and load the catalogue**. The very first command you ship into a fresh context **must** include the import + `register` lines below — Spark's data-source registry is per-driver-session, so without them `format("lakeflow_connect")` resolves to nothing:
    ```python
    import json
    from databricks.labs.community_connector.sources.gmail import GmailDataSource
@@ -69,7 +69,7 @@ Composing a snippet, shipping it to the cluster, and parsing the result is one h
    ```
    The printed JSON gives you `name`, `description`, `kind`, `result_schema_json`, and `parameters_json` for **every** operation this connection exposes. Cache it for the rest of the session. If `list_operations` fails, the connector isn't installed on the cluster — surface that and stop.
 
-After that, individual user requests don't repeat steps 1–3. They just run more snippets against the same context.
+After this first command lands `Finished`, registration is cached on the cluster for the lifetime of the context. **Do not** re-emit the `import` / `spark.dataSource.register(...)` lines on subsequent commands in the same context — they're noise and slow the snippet down. If you open a new context later (or the user explicitly restarts one), the *first* command in that context must include them again.
 
 ### Execution envelope (the universal "call any operation")
 
@@ -78,12 +78,12 @@ For any one operation:
 1. Build the snippet — pick `OP_NAME` and only the parameters that the catalogue declares for it. End the snippet with `print(json.dumps([r.asDict(recursive=True) for r in df.collect()], default=str))` so the result comes back parseable.
 2. Submit to the cluster:
    ```bash
-   databricks api post /api/2.0/commands/execute \
+   databricks api post /api/1.2/commands/execute \
      --json '{"clusterId":"{{cluster_id}}","contextId":"<CTX>","language":"python","command":"<SNIPPET>"}' -o json
    ```
 3. Poll until terminal status:
    ```bash
-   databricks api get /api/2.0/commands/status \
+   databricks api get /api/1.2/commands/status \
      --json "{\"clusterId\":\"{{cluster_id}}\",\"contextId\":\"<CTX>\",\"commandId\":\"<CMD>\"}" -o json
    ```
    `status` walks `Queued → Running → Finished | Error | Cancelled`.
@@ -91,17 +91,18 @@ For any one operation:
    - `Finished`, `results.resultType == "text"` → `results.data` is the JSON you printed. Parse and use.
    - `Error` → `results.summary` is the one-liner; `results.cause` is the traceback. The dispatcher writes a canonical code into `_meta.code` of the printed row when the error is connector-level (see *Error codes* below).
 
-A few quoting notes that bite if you skip them:
+A few details that bite if you skip them:
+- **Use `/api/1.2/commands/...`, not `/api/2.0/`.** The Command Execution API is served under 1.2. The 2.0 path 404s on the workspaces we run against — if you see `Not Found` from `/api/2.0/commands/...`, you have the wrong version, not a wrong cluster.
 - The `command` field is a JSON string containing Python source — preserve newlines (`\n`) and quote your inner strings.
 - Spark's `CaseInsensitiveStringMap` lowercases option keys, but the connector already handles the standard parameter spellings; just match whatever `list_operations` shows.
-- `spark.dataSource.register(GmailDataSource)` is idempotent inside a context; do it once at bootstrap, not per call.
+- `spark.dataSource.register(GmailDataSource)` runs once per context — only in the first command, never again. If you accidentally open a *new* context (cluster restart, you destroyed the previous one), the next snippet must re-import + re-register; until then, `format("lakeflow_connect")` will not resolve.
 
 ### Teardown
 
 At the end of the session, free the context:
 
 ```bash
-databricks api post /api/2.0/commands/contexts/destroy \
+databricks api post /api/1.2/commands/contexts/destroy \
   --json '{"clusterId":"{{cluster_id}}","contextId":"<CTX>"}'
 ```
 


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/gmail-connector/SKILL.md` — a tool-layer (MCP-style) skill that lets the agent fulfil Gmail user requests by running the project's `lakeflow_connect` Gmail Spark APIs on a user-supplied Databricks cluster via the Command Execution REST API.
- Operation catalogue is loaded dynamically from `list_operations`, not hard-coded — the agent always reflects the connector's true surface.
- Frames capabilities as in-scope/out-of-scope so the agent can decline write-side or off-surface asks (send, modify labels, etc.) cleanly instead of guessing.
- Composes operations (e.g. `search_messages` → `list_attachments` → `download_attachment`) to satisfy natural-language tasks; hands sustained ingestion off to the existing `deploy-connector` skill.

## Why

The Gmail connector (gmail-improvements branch) exposes a rich set of agent operations through `spark.read.format("lakeflow_connect")...`. Without a skill, the agent has no consistent way to dispatch these from user intent. This skill provides the bridge — discovery, invocation, composition, and error handling — without coupling to a fixed op list.

## Test plan

- [ ] Invoke `/gmail-connector` with a running cluster id + an existing UC `COMMUNITY` connection; verify the bootstrap (context create → `list_operations` → catalogue parsed) succeeds.
- [ ] Ask the agent to "search emails from X last week" — verify it composes `search_messages` with `from_address` + `newer_than` and returns header-only rows.
- [ ] Ask the agent to "download the latest attachment from Y" — verify the chain `search_messages` → `list_attachments` → `download_attachment` lands bytes under `/Volumes/...`.
- [ ] Ask the agent to "send an email to Z" — verify it declines as out of scope.
- [ ] Ask for "ingest my Gmail tables on a schedule" — verify it hands off to `deploy-connector`.
- [ ] Confirm the context is destroyed at end of session.

This pull request and its description were written by Isaac.