### PR TITLE
Support cluster_by in table_configuration

### DIFF
--- a/src/databricks/labs/community_connector/libs/spec_parser.py
+++ b/src/databricks/labs/community_connector/libs/spec_parser.py
@@ -18,6 +18,7 @@ from pydantic import (
 SCD_TYPE = "scd_type"
 PRIMARY_KEYS = "primary_keys"
 SEQUENCE_BY = "sequence_by"
+CLUSTER_BY = "cluster_by"
 
 # Valid SCD type values
 SCD_TYPE_1 = "SCD_TYPE_1"
@@ -203,7 +204,7 @@ class SpecParser:
         Returns:
             A dictionary containing the table configuration without special keys.
         """
-        special_keys = {SCD_TYPE, PRIMARY_KEYS, SEQUENCE_BY}
+        special_keys = {SCD_TYPE, PRIMARY_KEYS, SEQUENCE_BY, CLUSTER_BY}
         for obj in self._model.objects:
             if obj.table.source_table == table_name:
                 config = obj.table.table_configuration or {}
@@ -286,6 +287,43 @@ class SpecParser:
                 config = obj.table.table_configuration or {}
                 return config.get(SEQUENCE_BY)
         return None
+
+    def get_cluster_by(self, table_name: str) -> Optional[List[str]]:
+        """
+        Return the cluster_by columns for a specific table.
+
+        cluster_by is a destination-side Delta option that controls the
+        clustering keys of the target table; it is consumed by the pipeline
+        layer and is not forwarded to the source connector.
+
+        Args:
+            table_name: The name of the table.
+
+        Returns:
+            A list of column names, or None if not specified. Accepts a JSON
+            array string, a comma-separated string, a plain string (single
+            column), or a list in the spec.
+        """
+        value: Any = None
+        for obj in self._model.objects:
+            if obj.table.source_table == table_name:
+                value = (obj.table.table_configuration or {}).get(CLUSTER_BY)
+                break
+
+        if value is None:
+            return None
+        if isinstance(value, list):
+            return [str(v) for v in value]
+        if not isinstance(value, str):
+            return [str(value)]
+        stripped = value.strip()
+        if not stripped:
+            return None
+        if stripped.startswith("["):
+            return [str(v) for v in json.loads(stripped)]
+        if "," in stripped:
+            return [item.strip() for item in stripped.split(",") if item.strip()]
+        return [stripped]
 
     def get_full_destination_table_name(self, table_name: str) -> str:
         """

--- a/src/databricks/labs/community_connector/pipeline/ingestion_pipeline.py
+++ b/src/databricks/labs/community_connector/pipeline/ingestion_pipeline.py
@@ -1,7 +1,7 @@
 # pylint: disable=no-member
 import json
-from dataclasses import dataclass
-from typing import List
+from dataclasses import dataclass, field
+from typing import List, Optional
 from pyspark import pipelines as sdp
 from pyspark.sql.functions import col, expr
 from databricks.labs.community_connector.libs.spec_parser import SpecParser
@@ -19,6 +19,15 @@ class SdpTableConfig:  # pylint: disable=too-many-instance-attributes
     sequence_by: str
     scd_type: str
     with_deletes: bool = False
+    cluster_by: Optional[List[str]] = field(default=None)
+
+
+def _create_streaming_table(config: SdpTableConfig) -> None:
+    """Create the destination streaming table, forwarding cluster_by when set."""
+    kwargs: dict = {"name": config.destination_table}
+    if config.cluster_by:
+        kwargs["cluster_by"] = config.cluster_by
+    sdp.create_streaming_table(**kwargs)
 
 
 def _build_view_name(source_table: str, flow_type: str) -> str:
@@ -41,7 +50,7 @@ def _create_cdc_table(
             .load()
         )
 
-    sdp.create_streaming_table(name=config.destination_table)
+    _create_streaming_table(config)
     sdp.apply_changes(
         target=config.destination_table,
         source=config.view_name,
@@ -88,7 +97,7 @@ def _create_snapshot_table(spark, connection_name: str, config: SdpTableConfig) 
             .load()
         )
 
-    sdp.create_streaming_table(name=config.destination_table)
+    _create_streaming_table(config)
     sdp.apply_changes_from_snapshot(
         target=config.destination_table,
         source=config.view_name,
@@ -110,7 +119,7 @@ def _create_append_table(spark, connection_name: str, config: SdpTableConfig) ->
             .load()
         )
 
-    sdp.create_streaming_table(name=config.destination_table)
+    _create_streaming_table(config)
 
     @sdp.append_flow(name=config.view_name + "_flow", target=config.destination_table)
     def af():
@@ -166,6 +175,7 @@ def ingest(spark, pipeline_spec: dict) -> None:
         # Override parameters with spec values if available
         primary_keys = spec.get_primary_keys(table) or primary_keys
         sequence_by = spec.get_sequence_by(table) or cursor_field
+        cluster_by = spec.get_cluster_by(table)
         scd_type_raw = spec.get_scd_type(table)
         if scd_type_raw == "APPEND_ONLY":
             ingestion_type = "append"
@@ -188,6 +198,7 @@ def ingest(spark, pipeline_spec: dict) -> None:
             sequence_by=sequence_by,
             scd_type=scd_type,
             with_deletes=(ingestion_type == "cdc_with_deletes"),
+            cluster_by=cluster_by,
         )
 
         if ingestion_type in ("cdc", "cdc_with_deletes"):

--- a/templates/community_connector_doc_template.md
+++ b/templates/community_connector_doc_template.md
@@ -60,6 +60,7 @@ These are set inside the `table_configuration` map alongside any source-specific
 | `scd_type` | No | `SCD_TYPE_1` (default) or `SCD_TYPE_2`. Only applicable to tables with CDC or SNAPSHOT ingestion mode; APPEND_ONLY tables do not support this option. |
 | `primary_keys` | No | List of columns to override the connector's default primary keys |
 | `sequence_by` | No | Column used to order records for SCD Type 2 change tracking |
+| `cluster_by` | No | List of columns to cluster the destination Delta table by (Liquid Clustering). Consumed by the pipeline; not forwarded to the source. |
 
 Special `table_configuration` options
 <Describe the source specific required and optional configurations needed for each object>

--- a/tests/unit/libs/test_spec_parser.py
+++ b/tests/unit/libs/test_spec_parser.py
@@ -209,6 +209,75 @@ def test_get_table_configurations_returns_all_table_configs():
     assert all_configs["table_c"] == {"option_1": "val1", "option_2": "val2"}
 
 
+def test_cluster_by_is_stripped_from_table_configuration():
+    """cluster_by is a destination-side option and must not be forwarded to the source."""
+    spec = {
+        "connection_name": "test_conn",
+        "objects": [
+            {
+                "table": {
+                    "source_table": "test_table",
+                    "table_configuration": {
+                        "cluster_by": ["customer_id", "event_date"],
+                        "some_option": "value",
+                    },
+                }
+            },
+        ],
+    }
+    parser = SpecParser(spec)
+    config = parser.get_table_configuration("test_table")
+    assert "cluster_by" not in config
+    assert config == {"some_option": "value"}
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (["customer_id", "event_date"], ["customer_id", "event_date"]),
+        ("customer_id", ["customer_id"]),
+        ("customer_id,event_date", ["customer_id", "event_date"]),
+        (" customer_id , event_date ", ["customer_id", "event_date"]),
+        ('["customer_id", "event_date"]', ["customer_id", "event_date"]),
+    ],
+)
+def test_get_cluster_by_accepts_list_or_string(value, expected):
+    """cluster_by accepts list, single string, comma-separated string, or JSON-array string."""
+    spec = {
+        "connection_name": "test_conn",
+        "objects": [
+            {
+                "table": {
+                    "source_table": "test_table",
+                    "table_configuration": {"cluster_by": value},
+                }
+            },
+        ],
+    }
+    parser = SpecParser(spec)
+    assert parser.get_cluster_by("test_table") == expected
+
+
+def test_get_cluster_by_returns_none_when_not_specified():
+    """When cluster_by is not in the spec, get_cluster_by returns None."""
+    spec = {
+        "connection_name": "test_conn",
+        "objects": [
+            {"table": {"source_table": "t1"}},
+            {
+                "table": {
+                    "source_table": "t2",
+                    "table_configuration": {"some_option": "v"},
+                }
+            },
+        ],
+    }
+    parser = SpecParser(spec)
+    assert parser.get_cluster_by("t1") is None
+    assert parser.get_cluster_by("t2") is None
+    assert parser.get_cluster_by("unknown_table") is None
+
+
 def test_scd_type_validation_case_insensitive():
     """Test that SCD type is case-insensitive and normalized to uppercase."""
     spec = {

--- a/tests/unit/pipeline/test_ingestion_pipeline.py
+++ b/tests/unit/pipeline/test_ingestion_pipeline.py
@@ -1138,3 +1138,187 @@ class TestTableConfigFiltering:
             assert passed_options == {"custom_setting": "enabled"}
             assert "scd_type" not in passed_options
             assert "sequence_by" not in passed_options
+
+
+class TestClusterBy:
+    """Test that cluster_by is forwarded to sdp.create_streaming_table and stripped from
+    source options.
+
+    cluster_by is a destination-side Delta option (target table layout). It must be
+    consumed by the pipeline layer and never reach the source's .options() call.
+    """
+
+    def test_cluster_by_forwarded_to_create_streaming_table_for_cdc(
+        self, mock_spark, base_metadata
+    ):
+        """CDC flow: cluster_by is passed to sdp.create_streaming_table."""
+        spec = {
+            "connection_name": "test_connection",
+            "objects": [
+                {
+                    "table": {
+                        "source_table": "users",
+                        "table_configuration": {
+                            "cluster_by": ["user_id", "updated_at"],
+                        },
+                    }
+                }
+            ],
+        }
+
+        with patch(
+            "databricks.labs.community_connector.pipeline.ingestion_pipeline._get_table_metadata",
+            return_value=base_metadata,
+        ):
+            ingest(mock_spark, spec)
+
+            mock_sdp.create_streaming_table.assert_called_once_with(
+                name="users", cluster_by=["user_id", "updated_at"]
+            )
+
+    def test_cluster_by_forwarded_for_snapshot(self, mock_spark, base_metadata):
+        """Snapshot flow: cluster_by is passed to sdp.create_streaming_table."""
+        spec = {
+            "connection_name": "test_connection",
+            "objects": [
+                {
+                    "table": {
+                        "source_table": "orders",
+                        "table_configuration": {
+                            "cluster_by": ["order_id"],
+                        },
+                    }
+                }
+            ],
+        }
+
+        with patch(
+            "databricks.labs.community_connector.pipeline.ingestion_pipeline._get_table_metadata",
+            return_value=base_metadata,
+        ):
+            ingest(mock_spark, spec)
+
+            mock_sdp.create_streaming_table.assert_called_once_with(
+                name="orders", cluster_by=["order_id"]
+            )
+
+    def test_cluster_by_forwarded_for_append(self, mock_spark, base_metadata):
+        """Append flow: cluster_by is passed to sdp.create_streaming_table."""
+        spec = {
+            "connection_name": "test_connection",
+            "objects": [
+                {
+                    "table": {
+                        "source_table": "events",
+                        "table_configuration": {
+                            "cluster_by": ["event_id", "timestamp"],
+                        },
+                    }
+                }
+            ],
+        }
+
+        with patch(
+            "databricks.labs.community_connector.pipeline.ingestion_pipeline._get_table_metadata",
+            return_value=base_metadata,
+        ):
+            ingest(mock_spark, spec)
+
+            mock_sdp.create_streaming_table.assert_called_once_with(
+                name="events", cluster_by=["event_id", "timestamp"]
+            )
+
+    def test_cluster_by_omitted_when_not_specified(self, mock_spark, base_metadata):
+        """When cluster_by is absent, sdp.create_streaming_table receives only `name`."""
+        spec = {
+            "connection_name": "test_connection",
+            "objects": [
+                {
+                    "table": {
+                        "source_table": "users",
+                        "table_configuration": {},
+                    }
+                }
+            ],
+        }
+
+        with patch(
+            "databricks.labs.community_connector.pipeline.ingestion_pipeline._get_table_metadata",
+            return_value=base_metadata,
+        ):
+            ingest(mock_spark, spec)
+
+            mock_sdp.create_streaming_table.assert_called_once_with(name="users")
+
+    def test_cluster_by_string_value_is_parsed(self, mock_spark, base_metadata):
+        """cluster_by as a comma-separated string is parsed into a list."""
+        spec = {
+            "connection_name": "test_connection",
+            "objects": [
+                {
+                    "table": {
+                        "source_table": "users",
+                        "table_configuration": {
+                            "cluster_by": "user_id, updated_at",
+                        },
+                    }
+                }
+            ],
+        }
+
+        with patch(
+            "databricks.labs.community_connector.pipeline.ingestion_pipeline._get_table_metadata",
+            return_value=base_metadata,
+        ):
+            ingest(mock_spark, spec)
+
+            mock_sdp.create_streaming_table.assert_called_once_with(
+                name="users", cluster_by=["user_id", "updated_at"]
+            )
+
+    def test_cluster_by_is_stripped_from_source_options(self, base_metadata):
+        """cluster_by must not be forwarded to the source's .options() call."""
+        captured_view_funcs = []
+
+        def capture_view(name):
+            def decorator(f):
+                captured_view_funcs.append((name, f))
+                return f
+
+            return decorator
+
+        mock_sdp.view = MagicMock(side_effect=capture_view)
+
+        mock_spark = MagicMock()
+
+        spec = {
+            "connection_name": "test_connection",
+            "objects": [
+                {
+                    "table": {
+                        "source_table": "users",
+                        "table_configuration": {
+                            "cluster_by": ["user_id"],
+                            "regular_option": "value",
+                        },
+                    }
+                }
+            ],
+        }
+
+        with patch(
+            "databricks.labs.community_connector.pipeline.ingestion_pipeline._get_table_metadata",
+            return_value=base_metadata,
+        ):
+            ingest(mock_spark, spec)
+
+            assert len(captured_view_funcs) == 1
+            _, view_func = captured_view_funcs[0]
+            view_func()
+
+            stream_chain = mock_spark.readStream.format.return_value.option.return_value
+            options_call = stream_chain.option.return_value.options
+            options_call.assert_called_once()
+            passed_options = options_call.call_args[1]
+            assert passed_options == {"regular_option": "value"}
+            assert "cluster_by" not in passed_options

--- a/tools/community_connector/README.md
+++ b/tools/community_connector/README.md
@@ -266,6 +266,8 @@ objects:
 | `objects[].table.destination_table` | No | Target table name (defaults to source_table) |
 | `objects[].table.table_configuration.scd_type` | No | `SCD_TYPE_1`, `SCD_TYPE_2`, or `APPEND_ONLY` |
 | `objects[].table.table_configuration.primary_keys` | No | List of primary key columns |
+| `objects[].table.table_configuration.sequence_by` | No | Column used to order records for SCD Type 2 change tracking |
+| `objects[].table.table_configuration.cluster_by` | No | List of columns to cluster the destination Delta table by (Liquid Clustering) |
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- Add `cluster_by` as a destination-side special key in `table_configuration`. The pipeline reads it from the spec and passes it through to `sdp.create_streaming_table(name=..., cluster_by=[...])` for CDC, snapshot, and append flows.
- Strip `cluster_by` from `get_table_configuration()` so it is never forwarded to the source's `.options(...)` — same pattern as the existing `scd_type` / `primary_keys` / `sequence_by` keys. As a result, **no per-connector `external_options_allowlist` change is needed**.
- Accept `cluster_by` as a list, a JSON-array string, a comma-separated string, or a single column string.

Example usage in a pipeline spec:

```yaml
objects:
  - table:
      source_table: events
      table_configuration:
        cluster_by: ["customer_id", "event_date"]
```

This produces, at pipeline runtime:

```python
sdp.create_streaming_table(name="events", cluster_by=["customer_id", "event_date"])
```

## Test plan
- [x] `tests/unit/libs/test_spec_parser.py` — `cluster_by` is stripped from `get_table_configuration`; `get_cluster_by` parses list / single string / comma string / JSON-array string; returns `None` when absent.
- [x] `tests/unit/pipeline/test_ingestion_pipeline.py` — `cluster_by` is forwarded to `sdp.create_streaming_table` for CDC, snapshot, and append flows; omitted when not specified; stripped from the source's `.options(...)` call.
- [x] Full suite: `tests/unit/libs` + `tests/unit/pipeline` — 324 passed.

This pull request and its description were written by Isaac.