### PR TITLE
Gmail connector: agent operations + in-code OAuth refresh

### DIFF
--- a/src/databricks/labs/community_connector/sources/actitime/_generated_actitime_python_source.py
+++ b/src/databricks/labs/community_connector/sources/actitime/_generated_actitime_python_source.py
@@ -1115,6 +1115,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/actitime/_generated_actitime_python_source.py
+++ b/src/databricks/labs/community_connector/sources/actitime/_generated_actitime_python_source.py
@@ -5,7 +5,9 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import (
     date,
     datetime,
@@ -13,8 +15,17 @@ from datetime import (
     timezone,
 )
 from decimal import Decimal
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 import json
+import re
 import sys
 import time
 
@@ -595,6 +606,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -1987,6 +2943,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -1995,6 +2956,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -2013,10 +2990,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -2043,6 +3034,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/adme/_generated_adme_python_source.py
+++ b/src/databricks/labs/community_connector/sources/adme/_generated_adme_python_source.py
@@ -5,10 +5,20 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 import json
 import os
 import re
@@ -590,6 +600,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -1885,6 +2840,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -1893,6 +2853,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -1911,10 +2887,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -1941,6 +2931,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/adme/_generated_adme_python_source.py
+++ b/src/databricks/labs/community_connector/sources/adme/_generated_adme_python_source.py
@@ -1109,6 +1109,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/appsflyer/_generated_appsflyer_python_source.py
+++ b/src/databricks/labs/community_connector/sources/appsflyer/_generated_appsflyer_python_source.py
@@ -5,12 +5,23 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 import io
 import json
+import re
 import time
 
 from pyspark.sql import Row
@@ -589,6 +600,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -1533,6 +2489,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -1541,6 +2502,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -1559,10 +2536,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -1589,6 +2580,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/appsflyer/_generated_appsflyer_python_source.py
+++ b/src/databricks/labs/community_connector/sources/appsflyer/_generated_appsflyer_python_source.py
@@ -1109,6 +1109,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/azure_devops/_generated_azure_devops_python_source.py
+++ b/src/databricks/labs/community_connector/sources/azure_devops/_generated_azure_devops_python_source.py
@@ -5,16 +5,23 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from typing import (
     Any,
     Callable,
+    Iterable,
     Iterator,
+    Mapping,
+    Optional,
     Sequence,
+    Tuple,
 )
 import json
+import re
 import time
 
 from pyspark.sql import Row
@@ -593,6 +600,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -2610,6 +3562,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -2618,6 +3575,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -2636,10 +3609,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -2666,6 +3653,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/azure_devops/_generated_azure_devops_python_source.py
+++ b/src/databricks/labs/community_connector/sources/azure_devops/_generated_azure_devops_python_source.py
@@ -1109,6 +1109,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/dicomweb/_generated_dicomweb_python_source.py
+++ b/src/databricks/labs/community_connector/sources/dicomweb/_generated_dicomweb_python_source.py
@@ -1118,6 +1118,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/dicomweb/_generated_dicomweb_python_source.py
+++ b/src/databricks/labs/community_connector/sources/dicomweb/_generated_dicomweb_python_source.py
@@ -5,7 +5,9 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import (
     date,
     datetime,
@@ -13,7 +15,15 @@ from datetime import (
     timezone,
 )
 from decimal import Decimal
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 import json
 import os
 import re
@@ -599,6 +609,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -2449,6 +3404,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -2457,6 +3417,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -2475,10 +3451,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -2505,6 +3495,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/example/_generated_example_python_source.py
+++ b/src/databricks/labs/community_connector/sources/example/_generated_example_python_source.py
@@ -5,11 +5,22 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 import json
+import re
 import time
 
 from databricks.labs.community_connector.libs.simulated_source.api import get_api
@@ -587,6 +598,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -1366,6 +2322,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -1374,6 +2335,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -1392,10 +2369,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -1422,6 +2413,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/example/_generated_example_python_source.py
+++ b/src/databricks/labs/community_connector/sources/example/_generated_example_python_source.py
@@ -1107,6 +1107,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/fhir/_generated_fhir_python_source.py
+++ b/src/databricks/labs/community_connector/sources/fhir/_generated_fhir_python_source.py
@@ -1114,6 +1114,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/fhir/_generated_fhir_python_source.py
+++ b/src/databricks/labs/community_connector/sources/fhir/_generated_fhir_python_source.py
@@ -5,19 +5,25 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import (
     Any,
     Callable,
+    Iterable,
     Iterator,
+    Mapping,
     Optional,
     Sequence,
+    Tuple,
 )
 import argparse
 import json
+import re
 import sys
 import time
 
@@ -599,6 +605,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -2891,6 +3842,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -2899,6 +3855,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -2917,10 +3889,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -2947,6 +3933,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/github/_generated_github_python_source.py
+++ b/src/databricks/labs/community_connector/sources/github/_generated_github_python_source.py
@@ -1106,6 +1106,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/github/_generated_github_python_source.py
+++ b/src/databricks/labs/community_connector/sources/github/_generated_github_python_source.py
@@ -5,12 +5,22 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 import json
+import re
 
 from pyspark.sql import Row
 from pyspark.sql.datasource import (
@@ -587,6 +597,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -2383,6 +3338,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -2391,6 +3351,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -2409,10 +3385,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -2439,6 +3429,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
+++ b/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
@@ -1111,6 +1111,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
+++ b/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
@@ -5,6 +5,7 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import datetime
 from decimal import Decimal
@@ -12,12 +13,16 @@ from typing import (
     Any,
     Dict,
     Generator,
+    Iterable,
     Iterator,
     List,
+    Mapping,
     Optional,
     Sequence,
+    Tuple,
 )
 import json
+import re
 import time
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -599,6 +604,77 @@ def register_lakeflow_source(spark):
 
 
     ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
     # src/databricks/labs/community_connector/sources/gmail/gmail_schemas.py
     ########################################################
 
@@ -939,6 +1015,63 @@ def register_lakeflow_source(spark):
     BATCH_SIZE = 50  # Gmail batch API supports up to 100, using 50 for safety
     MAX_WORKERS = 3  # Concurrent workers for parallel fetching
 
+    # Drive API endpoints. The Gmail connector calls these whenever a message
+    # carries a Drive-hosted attachment (>25 MB or shared via Drive). Requires
+    # the OAuth grant to include ``drive.readonly`` alongside ``gmail.readonly``
+    # at consent time.
+    DRIVE_API_BASE = "https://www.googleapis.com/drive/v3"
+    GOOGLE_NATIVE_MIME_PREFIX = "application/vnd.google-apps."
+
+    # Regex catches the common Drive / Docs / Sheets / Slides URL shapes Gmail
+    # inlines into HTML bodies. The file ID is 25+ chars of [A-Za-z0-9_-].
+    _DRIVE_ID_PATTERN = re.compile(
+        r"(?:drive\.google\.com/(?:file/d/|open\?id=|uc\?[^\"'\s]*?id=)|"
+        r"docs\.google\.com/(?:document|spreadsheets|presentation|drawings)/d/)"
+        r"([A-Za-z0-9_-]{25,})"
+    )
+
+
+    def b64url_decode(data: str) -> bytes:
+        """Decode a base64url string, padding-tolerant.
+
+        Gmail/Drive responses strip ``=`` padding on base64url data; the stdlib
+        decoder rejects unpadded input. Re-pad before calling it.
+        """
+        if not data:
+            return b""
+        padded = data + "=" * (-len(data) % 4)
+        return base64.urlsafe_b64decode(padded)
+
+
+    def extract_drive_file_ids(text: str) -> List[str]:
+        """Extract Drive file IDs from a message body (HTML or plain text).
+
+        Returns IDs in insertion order, deduplicated. Empty list if no Drive
+        URLs are present. Caller is responsible for choosing the right
+        download path (binary via ``alt=media`` vs export for native types).
+        """
+        if not text:
+            return []
+        seen: dict[str, None] = {}
+        for match in _DRIVE_ID_PATTERN.finditer(text):
+            seen.setdefault(match.group(1), None)
+        return list(seen.keys())
+
+
+    class GmailApiError(Exception):
+        """Typed Gmail/Drive API failure carrying the HTTP status.
+
+        Agent ops translate ``status`` to ErrorCode (404→not_found, 403→
+        permission_denied, 401→auth_failed). Plain ``make_request`` callers
+        that previously swallowed 403/404 as ``None`` are unaffected — this
+        type is only raised by paths that opt in (Drive downloads, attachment
+        fetches when ``raise_on_error=True``).
+        """
+
+        def __init__(self, status: int, message: str) -> None:
+            self.status = status
+            super().__init__(f"HTTP {status}: {message}")
+
 
     class GmailApiClient:
         """Gmail HTTP client supporting two OAuth modes.
@@ -953,6 +1086,7 @@ def register_lakeflow_source(spark):
         BASE_URL = "https://gmail.googleapis.com/gmail/v1"
         BATCH_URL = "https://gmail.googleapis.com/batch/gmail/v1"
         TOKEN_URL = "https://oauth2.googleapis.com/token"
+        DRIVE_BASE_URL = DRIVE_API_BASE
 
         def __init__(
             self,
@@ -1136,6 +1270,91 @@ def register_lakeflow_source(spark):
                         # Skip failed fetches, continue with others
                         continue
 
+        # ─── Attachment / Drive download ──────────────────────────────────────
+
+        def get_attachment(
+            self, message_id: str, attachment_id: str
+        ) -> bytes:
+            """Fetch a Gmail attachment by ID and return decoded bytes.
+
+            Calls ``users.messages.attachments.get`` and base64url-decodes the
+            response. Raises :class:`GmailApiError` on 4xx/5xx so callers can
+            map status codes to typed errors.
+            """
+            url = (
+                f"{self.BASE_URL}/users/{self.user_id}"
+                f"/messages/{message_id}/attachments/{attachment_id}"
+            )
+            response = self._session.get(url, headers=self.get_headers(), timeout=120)
+            if response.status_code != 200:
+                raise GmailApiError(response.status_code, response.text)
+            payload = response.json()
+            return b64url_decode(payload.get("data", ""))
+
+        def get_drive_file_metadata(self, file_id: str) -> Dict:
+            """Fetch Drive file metadata (id, name, mimeType, size).
+
+            Needed before downloading to pick between binary download
+            (``alt=media``) and export (Docs/Sheets/Slides). Same access token
+            as Gmail — but only works if the user consented to the
+            ``drive.readonly`` scope at OAuth time.
+            """
+            url = f"{self.DRIVE_BASE_URL}/files/{file_id}"
+            response = self._session.get(
+                url,
+                headers=self.get_headers(),
+                params={"fields": "id,name,mimeType,size"},
+                timeout=60,
+            )
+            if response.status_code != 200:
+                raise GmailApiError(response.status_code, response.text)
+            return response.json()
+
+        def download_drive_file(
+            self,
+            file_id: str,
+            dest_path: str,
+            export_mime_type: Optional[str] = None,
+            chunk_size: int = 1024 * 1024,
+        ) -> Tuple[int, str, str]:
+            """Stream a Drive file to ``dest_path`` and return ``(size, name, mime)``.
+
+            Binary files are fetched via ``files.get?alt=media``. Google-native
+            formats (Docs/Sheets/Slides) require ``files.export`` with a
+            target ``export_mime_type`` — picks ``application/pdf`` if the
+            caller didn't supply one.
+
+            Caller pre-creates the parent directory. Raises
+            :class:`GmailApiError` on 4xx/5xx (use ``status == 403`` to detect
+            the recipient-not-shared case).
+            """
+            metadata = self.get_drive_file_metadata(file_id)
+            mime_type = metadata.get("mimeType", "application/octet-stream")
+            name = metadata.get("name", file_id)
+
+            if mime_type.startswith(GOOGLE_NATIVE_MIME_PREFIX):
+                export_mime = export_mime_type or "application/pdf"
+                url = f"{self.DRIVE_BASE_URL}/files/{file_id}/export"
+                params = {"mimeType": export_mime}
+                effective_mime = export_mime
+            else:
+                url = f"{self.DRIVE_BASE_URL}/files/{file_id}"
+                params = {"alt": "media"}
+                effective_mime = mime_type
+
+            bytes_written = 0
+            with self._session.get(
+                url, headers=self.get_headers(), params=params, timeout=300, stream=True
+            ) as response:
+                if response.status_code != 200:
+                    raise GmailApiError(response.status_code, response.text)
+                with open(dest_path, "wb") as fh:
+                    for chunk in response.iter_content(chunk_size=chunk_size):
+                        if chunk:
+                            fh.write(chunk)
+                            bytes_written += len(chunk)
+            return bytes_written, name, effective_mime
+
 
     ########################################################
     # src/databricks/labs/community_connector/sources/gmail/gmail.py
@@ -1154,7 +1373,39 @@ def register_lakeflow_source(spark):
         return value if value > 0 else 0
 
 
-    class GmailLakeflowConnect(LakeflowConnect):
+    # Gmail API caps maxResults at 500 per page; anything larger is clipped silently.
+    _GMAIL_API_PAGE_MAX = 500
+
+
+    def _parse_max_results(table_options: Dict[str, str] | None) -> tuple[int | None, int]:
+        """Parse ``maxResults`` as the total-result cap for streaming readers.
+
+        Returns ``(total_cap, page_size)`` where:
+
+        - ``total_cap = None`` means no cap — read every matching record.
+          Used when ``maxResults`` is absent or set to a negative value
+          (``-1`` as a documented "unlimited" sentinel).
+        - ``total_cap = <positive int>`` stops pagination once accumulated.
+        - ``page_size`` is the value to send to Gmail's API as its own
+          ``maxResults`` query parameter — bounded by Gmail's 500-row page max.
+        """
+        raw = table_options.get("maxResults") if table_options else None
+        if raw is None:
+            return None, 100
+        try:
+            cap = int(raw)
+        except (TypeError, ValueError):
+            return None, 100
+        if cap < 0:
+            return None, _GMAIL_API_PAGE_MAX
+        if cap == 0:
+            # Treat zero as "no records" — page size doesn't matter, but pick
+            # something valid so the API call doesn't reject the request.
+            return 0, 100
+        return cap, min(cap, _GMAIL_API_PAGE_MAX)
+
+
+    class GmailLakeflowConnect(LakeflowConnect, SupportsIngestionAgent):
         """Gmail connector implementing the LakeflowConnect interface with 100% API coverage."""
 
         def __init__(self, options: dict[str, str]) -> None:
@@ -1225,6 +1476,15 @@ def register_lakeflow_source(spark):
         def list_tables(self) -> list[str]:
             """Return the list of available Gmail tables."""
             return SUPPORTED_TABLES.copy()
+
+        def agent_operations(self):
+            """Expose Gmail-specific agent operations on top of the framework built-ins.
+
+            Replaces ``read_table`` with a filter-aware variant and adds
+            ``search_messages``, ``get_message``, ``list_attachments``,
+            ``download_attachment``. See ``gmail_agent_ops`` for details.
+            """
+            return build_gmail_agent_operations()
 
         def get_table_schema(self, table_name: str, table_options: Dict[str, str]) -> StructType:
             """Fetch the schema of a table."""
@@ -1394,12 +1654,12 @@ def register_lakeflow_source(spark):
             table_options: Dict[str, str],
         ) -> (Iterator[dict], dict):
             """Stream messages with sequential fetching for reliability."""
-            max_results = int(table_options.get("maxResults", "100"))
+            total_cap, page_size = _parse_max_results(table_options)
             query = table_options.get("q")
             label_ids = table_options.get("labelIds")
             include_spam_trash = table_options.get("includeSpamTrash", "false").lower() == "true"
 
-            params = {"maxResults": min(max_results, 500)}
+            params = {"maxResults": page_size}
             if query:
                 params["q"] = query
             if label_ids:
@@ -1421,6 +1681,8 @@ def register_lakeflow_source(spark):
             page_token = None
 
             while True:
+                if total_cap is not None and len(all_messages) >= total_cap:
+                    break
                 if page_token:
                     params["pageToken"] = page_token
 
@@ -1446,11 +1708,15 @@ def register_lakeflow_source(spark):
                             ):
                                 state["latest_history_id"] = msg_detail["historyId"]
                         all_messages.append(msg_detail)
+                        if total_cap is not None and len(all_messages) >= total_cap:
+                            break
 
                 page_token = response.get("nextPageToken")
                 if not page_token:
                     break
 
+            if total_cap is not None:
+                all_messages = all_messages[:total_cap]
             return iter(all_messages), self._pin_to_init_offset(state["latest_history_id"])
 
         def _read_messages_incremental(
@@ -1541,12 +1807,12 @@ def register_lakeflow_source(spark):
             table_options: Dict[str, str],
         ) -> (Iterator[dict], dict):
             """Stream threads with parallel fetching for performance."""
-            max_results = int(table_options.get("maxResults", "100"))
+            total_cap, page_size = _parse_max_results(table_options)
             query = table_options.get("q")
             label_ids = table_options.get("labelIds")
             include_spam_trash = table_options.get("includeSpamTrash", "false").lower() == "true"
 
-            params = {"maxResults": min(max_results, 500)}
+            params = {"maxResults": page_size}
             if query:
                 params["q"] = query
             if label_ids:
@@ -1567,6 +1833,8 @@ def register_lakeflow_source(spark):
                 )
 
             while True:
+                if total_cap is not None and len(all_threads) >= total_cap:
+                    break
                 if page_token:
                     params["pageToken"] = page_token
 
@@ -1590,11 +1858,15 @@ def register_lakeflow_source(spark):
                             ):
                                 state["latest_history_id"] = thread_detail["historyId"]
                         all_threads.append(thread_detail)
+                        if total_cap is not None and len(all_threads) >= total_cap:
+                            break
 
                 page_token = response.get("nextPageToken")
                 if not page_token:
                     break
 
+            if total_cap is not None:
+                all_threads = all_threads[:total_cap]
             return iter(all_threads), self._pin_to_init_offset(state["latest_history_id"])
 
         def _read_threads_incremental(
@@ -1697,13 +1969,16 @@ def register_lakeflow_source(spark):
             self, start_offset: dict, table_options: Dict[str, str]
         ) -> (Iterator[dict], dict):
             """Read all drafts (snapshot mode) with parallel fetching."""
-            params = {"maxResults": int(table_options.get("maxResults", "100"))}
+            total_cap, page_size = _parse_max_results(table_options)
+            params = {"maxResults": page_size}
 
             all_drafts = []
             page_token = None
             format_type = table_options.get("format", "full")
 
             while True:
+                if total_cap is not None and len(all_drafts) >= total_cap:
+                    break
                 if page_token:
                     params["pageToken"] = page_token
 
@@ -1724,12 +1999,18 @@ def register_lakeflow_source(spark):
 
                 with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
                     results = list(executor.map(fetch_draft, draft_ids))
-                    all_drafts.extend([r for r in results if r])
+                    for draft in results:
+                        if draft:
+                            all_drafts.append(draft)
+                            if total_cap is not None and len(all_drafts) >= total_cap:
+                                break
 
                 page_token = response.get("nextPageToken")
                 if not page_token:
                     break
 
+            if total_cap is not None:
+                all_drafts = all_drafts[:total_cap]
             return iter(all_drafts), {}
 
         def _read_profile(

--- a/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
+++ b/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
@@ -2093,7 +2093,19 @@ def register_lakeflow_source(spark):
                 # Fall back to sequential requests on batch failure
                 return self._fetch_sequential(endpoints, params_list)
 
-            return self._parse_batch_response(response.text, boundary)
+            parsed = self._parse_batch_response(response.text, boundary)
+
+            # A 200 is not proof the batch succeeded. Gmail's global batch endpoint
+            # can answer 200 with a body our multipart parser cannot read, yielding
+            # zero rows with no exception — which silently empties every batch-backed
+            # operation (search_messages, search_threads, mailbox_overview, and the
+            # incremental message/thread reads). Treat an empty parse against a
+            # non-empty request as a batch failure and fall back to the per-request
+            # path the table reads already rely on.
+            if not parsed:
+                return self._fetch_sequential(endpoints, params_list)
+
+            return parsed
 
         def _parse_batch_response(self, response_text: str, boundary: str) -> List[Dict]:
             """Parse multipart batch response."""

--- a/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
+++ b/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from typing import (
@@ -604,6 +605,82 @@ def register_lakeflow_source(spark):
 
 
     ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
     # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
     ########################################################
 
@@ -672,6 +749,804 @@ def register_lakeflow_source(spark):
             default for this connector.
             """
             return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -1481,10 +2356,21 @@ def register_lakeflow_source(spark):
             """Expose Gmail-specific agent operations on top of the framework built-ins.
 
             Replaces ``read_table`` with a filter-aware variant and adds
-            ``search_messages``, ``get_message``, ``list_attachments``,
-            ``download_attachment``. See ``gmail_agent_ops`` for details.
+            ``search_messages``, ``search_threads``, ``get_message``,
+            ``get_thread``, ``list_attachments``, ``download_attachment``, and
+            ``mailbox_overview``. See ``gmail_agent_ops`` for details.
+
+            ``gmail_agent_ops`` is intentionally excluded from the SDP merged
+            single-file (it's the wheel-served agent surface), so in that build
+            ``build_gmail_agent_operations`` is undefined — degrade to the
+            framework built-ins rather than raising. The wheel path has it
+            imported and returns the full set.
             """
-            return build_gmail_agent_operations()
+            try:
+                builder = build_gmail_agent_operations
+            except NameError:
+                return {}
+            return builder()
 
         def get_table_schema(self, table_name: str, table_options: Dict[str, str]) -> StructType:
             """Fetch the schema of a table."""
@@ -2403,6 +3289,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -2411,6 +3302,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -2429,10 +3336,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -2459,6 +3380,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/gmail/connector_spec.yaml
+++ b/src/databricks/labs/community_connector/sources/gmail/connector_spec.yaml
@@ -65,8 +65,14 @@ connection:
 # These table-specific options must be included in the externalOptionsAllowList
 # parameter of the UC connection to allow them to be passed through.
 # Use a comma-separated string of option names.
+#
+# The first group is table-read options; the rest are the ingestion-agent
+# operation parameters: typed read_table/search_messages filters
+# (after_date..query) and the get_message/list_attachments/download_attachment
+# inputs (message_id, attachment_id, drive_file_id, volume_path,
+# export_mime_type).
 # ============================================================================
-external_options_allowlist: "q,labelIds,maxResults,includeSpamTrash,format,max_records_per_batch"
+external_options_allowlist: "q,labelIds,maxResults,includeSpamTrash,format,max_records_per_batch,after_date,before_date,newer_than,subject,from_address,to_address,label,has_attachment,is_unread,query,message_id,attachment_id,drive_file_id,volume_path,export_mime_type"
 
 # ============================================================================
 # Supported Tables (10 tables - 100% Gmail API coverage)

--- a/src/databricks/labs/community_connector/sources/gmail/connector_spec.yaml
+++ b/src/databricks/labs/community_connector/sources/gmail/connector_spec.yaml
@@ -67,12 +67,20 @@ connection:
 # Use a comma-separated string of option names.
 #
 # The first group is table-read options; the rest are the ingestion-agent
-# operation parameters: typed read_table/search_messages filters
-# (after_date..query) and the get_message/list_attachments/download_attachment
-# inputs (message_id, attachment_id, drive_file_id, volume_path,
-# export_mime_type).
+# operation parameters:
+#   - typed read_table / search_messages / search_threads filters
+#     (after_date..query) plus `limit`
+#   - get_message / get_thread inputs (message_id, thread_id)
+#   - list_attachments / download_attachment inputs (attachment_id,
+#     drive_file_id, volume_path, export_mime_type)
+# mailbox_overview takes no parameters.
+#
+# Ingestion-agent operations (dispatched via operation=<name> on the
+# lakeflow_connect format): read_table (filtered override), search_messages,
+# search_threads, get_message, get_thread, list_attachments,
+# download_attachment, mailbox_overview.
 # ============================================================================
-external_options_allowlist: "q,labelIds,maxResults,includeSpamTrash,format,max_records_per_batch,after_date,before_date,newer_than,subject,from_address,to_address,label,has_attachment,is_unread,query,message_id,attachment_id,drive_file_id,volume_path,export_mime_type"
+external_options_allowlist: "q,labelIds,maxResults,includeSpamTrash,format,max_records_per_batch,after_date,before_date,newer_than,subject,from_address,to_address,label,has_attachment,is_unread,query,limit,message_id,thread_id,attachment_id,drive_file_id,volume_path,export_mime_type"
 
 # ============================================================================
 # Supported Tables (10 tables - 100% Gmail API coverage)

--- a/src/databricks/labs/community_connector/sources/gmail/gmail.py
+++ b/src/databricks/labs/community_connector/sources/gmail/gmail.py
@@ -146,10 +146,21 @@ class GmailLakeflowConnect(LakeflowConnect, SupportsIngestionAgent):
         """Expose Gmail-specific agent operations on top of the framework built-ins.
 
         Replaces ``read_table`` with a filter-aware variant and adds
-        ``search_messages``, ``get_message``, ``list_attachments``,
-        ``download_attachment``. See ``gmail_agent_ops`` for details.
+        ``search_messages``, ``search_threads``, ``get_message``,
+        ``get_thread``, ``list_attachments``, ``download_attachment``, and
+        ``mailbox_overview``. See ``gmail_agent_ops`` for details.
+
+        ``gmail_agent_ops`` is intentionally excluded from the SDP merged
+        single-file (it's the wheel-served agent surface), so in that build
+        ``build_gmail_agent_operations`` is undefined — degrade to the
+        framework built-ins rather than raising. The wheel path has it
+        imported and returns the full set.
         """
-        return build_gmail_agent_operations()
+        try:
+            builder = build_gmail_agent_operations
+        except NameError:
+            return {}
+        return builder()
 
     def get_table_schema(self, table_name: str, table_options: Dict[str, str]) -> StructType:
         """Fetch the schema of a table."""

--- a/src/databricks/labs/community_connector/sources/gmail/gmail.py
+++ b/src/databricks/labs/community_connector/sources/gmail/gmail.py
@@ -7,6 +7,12 @@ from concurrent.futures import ThreadPoolExecutor
 from pyspark.sql.types import StructType
 
 from databricks.labs.community_connector.interface.lakeflow_connect import LakeflowConnect
+from databricks.labs.community_connector.interface.supports_ingestion_agent import (
+    SupportsIngestionAgent,
+)
+from databricks.labs.community_connector.sources.gmail.gmail_agent_ops import (
+    build_gmail_agent_operations,
+)
 from databricks.labs.community_connector.sources.gmail.gmail_schemas import (
     TABLE_SCHEMAS,
     TABLE_METADATA,
@@ -32,7 +38,39 @@ def _parse_max_per_batch(table_options: Dict[str, str] | None) -> int:
     return value if value > 0 else 0
 
 
-class GmailLakeflowConnect(LakeflowConnect):
+# Gmail API caps maxResults at 500 per page; anything larger is clipped silently.
+_GMAIL_API_PAGE_MAX = 500
+
+
+def _parse_max_results(table_options: Dict[str, str] | None) -> tuple[int | None, int]:
+    """Parse ``maxResults`` as the total-result cap for streaming readers.
+
+    Returns ``(total_cap, page_size)`` where:
+
+    - ``total_cap = None`` means no cap — read every matching record.
+      Used when ``maxResults`` is absent or set to a negative value
+      (``-1`` as a documented "unlimited" sentinel).
+    - ``total_cap = <positive int>`` stops pagination once accumulated.
+    - ``page_size`` is the value to send to Gmail's API as its own
+      ``maxResults`` query parameter — bounded by Gmail's 500-row page max.
+    """
+    raw = table_options.get("maxResults") if table_options else None
+    if raw is None:
+        return None, 100
+    try:
+        cap = int(raw)
+    except (TypeError, ValueError):
+        return None, 100
+    if cap < 0:
+        return None, _GMAIL_API_PAGE_MAX
+    if cap == 0:
+        # Treat zero as "no records" — page size doesn't matter, but pick
+        # something valid so the API call doesn't reject the request.
+        return 0, 100
+    return cap, min(cap, _GMAIL_API_PAGE_MAX)
+
+
+class GmailLakeflowConnect(LakeflowConnect, SupportsIngestionAgent):
     """Gmail connector implementing the LakeflowConnect interface with 100% API coverage."""
 
     def __init__(self, options: dict[str, str]) -> None:
@@ -103,6 +141,15 @@ class GmailLakeflowConnect(LakeflowConnect):
     def list_tables(self) -> list[str]:
         """Return the list of available Gmail tables."""
         return SUPPORTED_TABLES.copy()
+
+    def agent_operations(self):
+        """Expose Gmail-specific agent operations on top of the framework built-ins.
+
+        Replaces ``read_table`` with a filter-aware variant and adds
+        ``search_messages``, ``get_message``, ``list_attachments``,
+        ``download_attachment``. See ``gmail_agent_ops`` for details.
+        """
+        return build_gmail_agent_operations()
 
     def get_table_schema(self, table_name: str, table_options: Dict[str, str]) -> StructType:
         """Fetch the schema of a table."""
@@ -272,12 +319,12 @@ class GmailLakeflowConnect(LakeflowConnect):
         table_options: Dict[str, str],
     ) -> (Iterator[dict], dict):
         """Stream messages with sequential fetching for reliability."""
-        max_results = int(table_options.get("maxResults", "100"))
+        total_cap, page_size = _parse_max_results(table_options)
         query = table_options.get("q")
         label_ids = table_options.get("labelIds")
         include_spam_trash = table_options.get("includeSpamTrash", "false").lower() == "true"
 
-        params = {"maxResults": min(max_results, 500)}
+        params = {"maxResults": page_size}
         if query:
             params["q"] = query
         if label_ids:
@@ -299,6 +346,8 @@ class GmailLakeflowConnect(LakeflowConnect):
         page_token = None
 
         while True:
+            if total_cap is not None and len(all_messages) >= total_cap:
+                break
             if page_token:
                 params["pageToken"] = page_token
 
@@ -324,11 +373,15 @@ class GmailLakeflowConnect(LakeflowConnect):
                         ):
                             state["latest_history_id"] = msg_detail["historyId"]
                     all_messages.append(msg_detail)
+                    if total_cap is not None and len(all_messages) >= total_cap:
+                        break
 
             page_token = response.get("nextPageToken")
             if not page_token:
                 break
 
+        if total_cap is not None:
+            all_messages = all_messages[:total_cap]
         return iter(all_messages), self._pin_to_init_offset(state["latest_history_id"])
 
     def _read_messages_incremental(
@@ -419,12 +472,12 @@ class GmailLakeflowConnect(LakeflowConnect):
         table_options: Dict[str, str],
     ) -> (Iterator[dict], dict):
         """Stream threads with parallel fetching for performance."""
-        max_results = int(table_options.get("maxResults", "100"))
+        total_cap, page_size = _parse_max_results(table_options)
         query = table_options.get("q")
         label_ids = table_options.get("labelIds")
         include_spam_trash = table_options.get("includeSpamTrash", "false").lower() == "true"
 
-        params = {"maxResults": min(max_results, 500)}
+        params = {"maxResults": page_size}
         if query:
             params["q"] = query
         if label_ids:
@@ -445,6 +498,8 @@ class GmailLakeflowConnect(LakeflowConnect):
             )
 
         while True:
+            if total_cap is not None and len(all_threads) >= total_cap:
+                break
             if page_token:
                 params["pageToken"] = page_token
 
@@ -468,11 +523,15 @@ class GmailLakeflowConnect(LakeflowConnect):
                         ):
                             state["latest_history_id"] = thread_detail["historyId"]
                     all_threads.append(thread_detail)
+                    if total_cap is not None and len(all_threads) >= total_cap:
+                        break
 
             page_token = response.get("nextPageToken")
             if not page_token:
                 break
 
+        if total_cap is not None:
+            all_threads = all_threads[:total_cap]
         return iter(all_threads), self._pin_to_init_offset(state["latest_history_id"])
 
     def _read_threads_incremental(
@@ -575,13 +634,16 @@ class GmailLakeflowConnect(LakeflowConnect):
         self, start_offset: dict, table_options: Dict[str, str]
     ) -> (Iterator[dict], dict):
         """Read all drafts (snapshot mode) with parallel fetching."""
-        params = {"maxResults": int(table_options.get("maxResults", "100"))}
+        total_cap, page_size = _parse_max_results(table_options)
+        params = {"maxResults": page_size}
 
         all_drafts = []
         page_token = None
         format_type = table_options.get("format", "full")
 
         while True:
+            if total_cap is not None and len(all_drafts) >= total_cap:
+                break
             if page_token:
                 params["pageToken"] = page_token
 
@@ -602,12 +664,18 @@ class GmailLakeflowConnect(LakeflowConnect):
 
             with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
                 results = list(executor.map(fetch_draft, draft_ids))
-                all_drafts.extend([r for r in results if r])
+                for draft in results:
+                    if draft:
+                        all_drafts.append(draft)
+                        if total_cap is not None and len(all_drafts) >= total_cap:
+                            break
 
             page_token = response.get("nextPageToken")
             if not page_token:
                 break
 
+        if total_cap is not None:
+            all_drafts = all_drafts[:total_cap]
         return iter(all_drafts), {}
 
     def _read_profile(

--- a/src/databricks/labs/community_connector/sources/gmail/gmail_agent_ops.py
+++ b/src/databricks/labs/community_connector/sources/gmail/gmail_agent_ops.py
@@ -336,24 +336,6 @@ def _attachment_parts(payload: Mapping[str, Any]):
         }
 
 
-def _payload_has_attachment(payload: Mapping[str, Any]) -> bool:
-    """True if the message carries an attachment, format-agnostic.
-
-    A MIME part with a non-empty ``filename`` is the canonical attachment
-    signal and is present in both ``format=full`` and ``format=metadata``
-    responses. ``_attachment_parts`` keys on ``body.attachmentId``, which
-    Gmail omits under ``format=metadata`` — so search_messages (metadata
-    format) must use the filename signal instead, falling back to
-    ``attachmentId`` when present.
-    """
-    for part in _walk_parts(payload):
-        if (part.get("filename") or "").strip():
-            return True
-        if (part.get("body") or {}).get("attachmentId"):
-            return True
-    return False
-
-
 def _safe_int(value: Any) -> Optional[int]:
     if value is None:
         return None
@@ -488,8 +470,9 @@ class SearchMessagesOp(AgentOperation):
 
         limit = self._int_limit(options)
         composed_q = _compose_query(options)
+        capped = min(max(limit, 1), 500)
 
-        params: dict = {"maxResults": min(max(limit, 1), 500)}
+        params: dict = {"maxResults": capped}
         if composed_q:
             params["q"] = composed_q
 
@@ -499,6 +482,16 @@ class SearchMessagesOp(AgentOperation):
             return iter([])
 
         message_ids = [m["id"] for m in listing.get("messages", [])][:limit]
+
+        # has_attachment: ``format=metadata`` returns only id/labels/headers —
+        # no MIME part tree — so attachments can't be read off the per-message
+        # response. Instead run the same search constrained to ``has:attachment``
+        # and intersect the ids. One extra (cheap) list call, and accurate: a
+        # message at position k of the main result has at most k-1 messages
+        # ahead of it, so any attachment-bearing match in our window is within
+        # the top ``capped`` attachment results too.
+        attachment_ids = self._attachment_ids(api, user_id, composed_q, capped, message_ids)
+
         endpoints = [f"/users/{user_id}/messages/{mid}" for mid in message_ids]
         meta_params = [{"format": "metadata"}] * len(message_ids)
         results = api.make_batch_request(endpoints, meta_params)
@@ -519,13 +512,27 @@ class SearchMessagesOp(AgentOperation):
                     "date": _header_value(payload, "Date"),
                     "snippet": msg.get("snippet"),
                     "labelIds": label_ids,
-                    "has_attachment": "true"
-                    if _payload_has_attachment(payload)
-                    else "false",
+                    "has_attachment": "true" if msg.get("id") in attachment_ids else "false",
                     "size_estimate": _safe_int(msg.get("sizeEstimate")),
                 }
             )
         return iter(rows)
+
+    @staticmethod
+    def _attachment_ids(api, user_id, composed_q, max_results, candidate_ids):
+        """Return the subset of message ids (among this search) that carry an
+        attachment, via a companion ``has:attachment`` search."""
+        # If the caller already constrained the search to attachments, every
+        # match has one — skip the extra round trip.
+        if composed_q and "has:attachment" in composed_q:
+            return set(candidate_ids)
+        q = f"{composed_q} has:attachment" if composed_q else "has:attachment"
+        listing = api.make_request(
+            "GET", f"/users/{user_id}/messages", params={"maxResults": max_results, "q": q}
+        )
+        if not listing or "messages" not in listing:
+            return set()
+        return {m["id"] for m in listing.get("messages", [])}
 
     @staticmethod
     def _int_limit(options: Mapping[str, str]) -> int:

--- a/src/databricks/labs/community_connector/sources/gmail/gmail_agent_ops.py
+++ b/src/databricks/labs/community_connector/sources/gmail/gmail_agent_ops.py
@@ -336,6 +336,24 @@ def _attachment_parts(payload: Mapping[str, Any]):
         }
 
 
+def _payload_has_attachment(payload: Mapping[str, Any]) -> bool:
+    """True if the message carries an attachment, format-agnostic.
+
+    A MIME part with a non-empty ``filename`` is the canonical attachment
+    signal and is present in both ``format=full`` and ``format=metadata``
+    responses. ``_attachment_parts`` keys on ``body.attachmentId``, which
+    Gmail omits under ``format=metadata`` — so search_messages (metadata
+    format) must use the filename signal instead, falling back to
+    ``attachmentId`` when present.
+    """
+    for part in _walk_parts(payload):
+        if (part.get("filename") or "").strip():
+            return True
+        if (part.get("body") or {}).get("attachmentId"):
+            return True
+    return False
+
+
 def _safe_int(value: Any) -> Optional[int]:
     if value is None:
         return None
@@ -502,7 +520,7 @@ class SearchMessagesOp(AgentOperation):
                     "snippet": msg.get("snippet"),
                     "labelIds": label_ids,
                     "has_attachment": "true"
-                    if any(_attachment_parts(payload))
+                    if _payload_has_attachment(payload)
                     else "false",
                     "size_estimate": _safe_int(msg.get("sizeEstimate")),
                 }

--- a/src/databricks/labs/community_connector/sources/gmail/gmail_agent_ops.py
+++ b/src/databricks/labs/community_connector/sources/gmail/gmail_agent_ops.py
@@ -777,6 +777,41 @@ _DOWNLOAD_ATTACHMENT_SCHEMA = StructType(
 )
 
 
+def _safe_basename(name: Optional[str]) -> Optional[str]:
+    """Strip any directory components from a filename so a downloaded
+    attachment can't escape its target directory."""
+    if not name:
+        return None
+    base = os.path.basename(name.strip())
+    return base or None
+
+
+def _resolve_volume_dest(volume_path: str, filename: Optional[str], fallback: str) -> str:
+    """Resolve the destination file path for a download.
+
+    ``volume_path`` may be a full file path *or* a directory. It is treated
+    as a directory when it ends with ``/`` or already exists as one, in which
+    case the attachment's own ``filename`` (``fallback`` when unknown) is
+    appended. Otherwise it is used verbatim as the destination file.
+    """
+    if volume_path.endswith("/") or os.path.isdir(volume_path):
+        return os.path.join(volume_path.rstrip("/") or "/", _safe_basename(filename) or fallback)
+    return volume_path
+
+
+def _ensure_parent_dir(dest: str) -> None:
+    parent = os.path.dirname(dest)
+    if not parent:
+        return
+    try:
+        os.makedirs(parent, exist_ok=True)
+    except OSError as exc:
+        raise AgentError(
+            ErrorCode.PERMISSION_DENIED,
+            f"Cannot create parent directory '{parent}': {exc}",
+        ) from exc
+
+
 class DownloadAttachmentOp(AgentOperation):
     """Download an attachment to a Databricks Volume path.
 
@@ -789,13 +824,13 @@ class DownloadAttachmentOp(AgentOperation):
         ``export_mime_type`` overrides the default ``application/pdf``
         export target.
 
-    ``volume_path`` must be a writable path the executor can ``open()``
-    in write-binary mode. The canonical shape is
-    ``/Volumes/<catalog>/<schema>/<volume>/<filename>`` — the op
-    creates the parent directory if needed but does not create the
-    volume itself. The path is required to start with ``/Volumes/`` so
-    the op can't accidentally write outside Unity Catalog (override
-    intentionally via the framework's option dict only).
+    ``volume_path`` may be either a full destination file path
+    (``/Volumes/<catalog>/<schema>/<volume>/invoice.pdf``) or an existing
+    directory (``/Volumes/<catalog>/<schema>/<volume>/``) — in the directory
+    case the attachment's own filename is appended. The op creates the parent
+    directory if needed but does not create the volume itself, and requires
+    the path to start with ``/Volumes/`` so it can't write outside Unity
+    Catalog. The resolved path is returned in the ``volume_path`` column.
     """
 
     name = "download_attachment"
@@ -811,8 +846,9 @@ class DownloadAttachmentOp(AgentOperation):
             name="volume_path",
             required=True,
             description=(
-                "Destination path under /Volumes/<catalog>/<schema>/<volume>/. "
-                "The parent directory is created if missing."
+                "Destination under /Volumes/<catalog>/<schema>/<volume>/. "
+                "Either a full file path, or a directory (the attachment's "
+                "own filename is appended). Parent dirs are created if missing."
             ),
         ),
         Parameter(
@@ -874,16 +910,6 @@ class DownloadAttachmentOp(AgentOperation):
                 "message_id is required when attachment_id is supplied.",
             )
 
-        parent = os.path.dirname(volume_path)
-        if parent:
-            try:
-                os.makedirs(parent, exist_ok=True)
-            except OSError as exc:
-                raise AgentError(
-                    ErrorCode.PERMISSION_DENIED,
-                    f"Cannot create parent directory '{parent}': {exc}",
-                ) from exc
-
         if attachment_id:
             return iter([self._download_gmail(connector, message_id, attachment_id, volume_path)])
         return iter([self._download_drive(connector, drive_file_id, volume_path, options)])
@@ -896,8 +922,7 @@ class DownloadAttachmentOp(AgentOperation):
             raise _agent_error_from_status(exc) from exc
 
         # Look up filename + mime from the parent message payload so the
-        # row carries it. One extra API call (format=metadata is cheap at
-        # 5 quota units) — worth it for downstream UX.
+        # row carries it (and so a directory volume_path can be named).
         filename = None
         mime_type = None
         meta = connector.api.make_request(
@@ -912,30 +937,43 @@ class DownloadAttachmentOp(AgentOperation):
                     mime_type = part["mime_type"]
                     break
 
-        with open(volume_path, "wb") as fh:
+        dest = _resolve_volume_dest(volume_path, filename, fallback=attachment_id)
+        _ensure_parent_dir(dest)
+        with open(dest, "wb") as fh:
             fh.write(data)
 
         return {
-            "volume_path": volume_path,
+            "volume_path": dest,
             "size_bytes": len(data),
             "mime_type": mime_type,
-            "filename": filename,
+            "filename": filename or _safe_basename(dest),
             "source": "gmail",
         }
 
     @staticmethod
     def _download_drive(connector, drive_file_id, volume_path, options):
+        # When volume_path is a directory, resolve the filename up front from
+        # Drive metadata so the file lands inside it with its real name.
+        dest = volume_path
+        if volume_path.endswith("/") or os.path.isdir(volume_path):
+            try:
+                meta = connector.api.get_drive_file_metadata(drive_file_id)
+            except GmailApiError as exc:
+                raise _agent_error_from_status(exc) from exc
+            dest = _resolve_volume_dest(volume_path, meta.get("name"), fallback=drive_file_id)
+        _ensure_parent_dir(dest)
+
         try:
             size, name, mime = connector.api.download_drive_file(
                 drive_file_id,
-                volume_path,
+                dest,
                 export_mime_type=options.get("export_mime_type") or None,
             )
         except GmailApiError as exc:
             raise _agent_error_from_status(exc) from exc
 
         return {
-            "volume_path": volume_path,
+            "volume_path": dest,
             "size_bytes": size,
             "mime_type": mime,
             "filename": name,

--- a/src/databricks/labs/community_connector/sources/gmail/gmail_agent_ops.py
+++ b/src/databricks/labs/community_connector/sources/gmail/gmail_agent_ops.py
@@ -345,6 +345,36 @@ def _safe_int(value: Any) -> Optional[int]:
         return None
 
 
+def _int_option(options: Mapping[str, str], name: str, default: int) -> int:
+    """Parse an integer option, raising ``bad_request`` on a non-integer."""
+    raw = options.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError) as exc:
+        raise AgentError(
+            ErrorCode.BAD_REQUEST,
+            f"Option {name!r} must be an integer, got {raw!r}.",
+        ) from exc
+
+
+def _thread_participants_and_labels(messages):
+    """Return (participants, label_ids) deduped in first-seen order across
+    every message in a thread."""
+    participants: dict = {}
+    labels: dict = {}
+    for msg in messages:
+        payload = msg.get("payload") or {}
+        for header_name in ("From", "To", "Cc"):
+            value = _header_value(payload, header_name)
+            if value:
+                participants.setdefault(value, None)
+        for label_id in msg.get("labelIds") or []:
+            labels.setdefault(label_id, None)
+    return list(participants.keys()), list(labels.keys())
+
+
 # ---------------------------------------------------------------------------
 # read_table override: apply typed filters to messages / threads
 # ---------------------------------------------------------------------------
@@ -888,6 +918,277 @@ class DownloadAttachmentOp(AgentOperation):
         }
 
 
+# ---------------------------------------------------------------------------
+# get_thread: fetch a full conversation with decoded message bodies
+# ---------------------------------------------------------------------------
+
+_THREAD_MESSAGE_STRUCT = StructType(
+    [
+        StructField("id", StringType(), True),
+        StructField("from_address", StringType(), True),
+        StructField("to_address", StringType(), True),
+        StructField("cc_address", StringType(), True),
+        StructField("subject", StringType(), True),
+        StructField("date", StringType(), True),
+        StructField("snippet", StringType(), True),
+        StructField("body_text", StringType(), True),
+        StructField("labelIds", ArrayType(StringType()), True),
+        StructField("size_estimate", LongType(), True),
+    ]
+)
+
+_GET_THREAD_SCHEMA = StructType(
+    [
+        StructField("thread_id", StringType(), False),
+        StructField("history_id", StringType(), True),
+        StructField("subject", StringType(), True),
+        StructField("message_count", LongType(), True),
+        StructField("participants", ArrayType(StringType()), True),
+        StructField("labelIds", ArrayType(StringType()), True),
+        StructField("messages", ArrayType(_THREAD_MESSAGE_STRUCT), True),
+    ]
+)
+
+
+class GetThreadOp(AgentOperation):
+    """Fetch a full conversation thread by id with decoded message bodies.
+
+    Returns one row: the thread, with a ``messages`` array in Gmail's
+    chronological order. Each message carries decoded ``body_text`` (plain
+    text — call ``get_message`` for HTML or attachment IDs).
+    ``participants`` is the de-duplicated set of From/To/Cc addresses across
+    the thread. The conversation is the natural unit for analysis, so this
+    pairs with ``search_threads`` (find threads) the way ``get_message``
+    pairs with ``search_messages``.
+    """
+
+    name = "get_thread"
+    description = (
+        "Fetch one conversation thread by thread_id: every message in order "
+        "with decoded body_text, plus the thread's subject, participants, "
+        "message_count, and labels."
+    )
+    kind = "data"
+    schema = _GET_THREAD_SCHEMA
+    parameters = (
+        Parameter(
+            name="thread_id",
+            required=True,
+            description="Gmail thread id to fetch (e.g. from search_threads).",
+        ),
+    )
+
+    def pull(self, connector, options):
+        thread_id = options["thread_id"]
+        api = connector.api
+        user_id = connector.user_id
+
+        thread = api.make_request(
+            "GET", f"/users/{user_id}/threads/{thread_id}", {"format": "full"}
+        )
+        if not thread:
+            raise AgentError(
+                ErrorCode.NOT_FOUND,
+                f"Thread '{thread_id}' not found or inaccessible.",
+            )
+
+        messages = thread.get("messages") or []
+        participants, labels = _thread_participants_and_labels(messages)
+
+        message_rows = []
+        for msg in messages:
+            payload = msg.get("payload") or {}
+            message_rows.append(
+                {
+                    "id": msg.get("id"),
+                    "from_address": _header_value(payload, "From"),
+                    "to_address": _header_value(payload, "To"),
+                    "cc_address": _header_value(payload, "Cc"),
+                    "subject": _header_value(payload, "Subject"),
+                    "date": _header_value(payload, "Date"),
+                    "snippet": msg.get("snippet"),
+                    "body_text": _decode_body_text(payload, "text/plain"),
+                    "labelIds": msg.get("labelIds") or [],
+                    "size_estimate": _safe_int(msg.get("sizeEstimate")),
+                }
+            )
+
+        first_payload = (messages[0].get("payload") if messages else {}) or {}
+        return iter(
+            [
+                {
+                    "thread_id": thread.get("id") or thread_id,
+                    "history_id": thread.get("historyId"),
+                    "subject": _header_value(first_payload, "Subject"),
+                    "message_count": len(message_rows),
+                    "participants": participants,
+                    "labelIds": labels,
+                    "messages": message_rows,
+                }
+            ]
+        )
+
+
+# ---------------------------------------------------------------------------
+# search_threads: thread-level triage (one row per conversation)
+# ---------------------------------------------------------------------------
+
+_SEARCH_THREADS_SCHEMA = StructType(
+    [
+        StructField("id", StringType(), False),
+        StructField("subject", StringType(), True),
+        StructField("snippet", StringType(), True),
+        StructField("message_count", LongType(), True),
+        StructField("participants", ArrayType(StringType()), True),
+        StructField("last_date", StringType(), True),
+        StructField("labelIds", ArrayType(StringType()), True),
+        StructField("history_id", StringType(), True),
+    ]
+)
+
+
+class SearchThreadsOp(AgentOperation):
+    """Search conversations and return one row per thread.
+
+    The thread-level companion to ``search_messages`` — use it when the
+    unit of analysis is the conversation, not the individual message.
+    Composes the same typed filters into Gmail ``q`` syntax, lists matching
+    threads, then fetches each (``format=metadata``, header-only) to derive
+    subject, participants, message_count, last activity, and labels.
+    Bounded by ``limit``.
+    """
+
+    name = "search_threads"
+    description = (
+        "Search conversation threads and return one row per thread with id, "
+        "subject, snippet, message_count, participants, last_date, labels. "
+        "Accepts the same typed filters as search_messages."
+    )
+    kind = "data"
+    schema = _SEARCH_THREADS_SCHEMA
+    parameters = (
+        Parameter(
+            name="limit",
+            type="integer",
+            default=50,
+            description="Maximum threads to return (default 50, max 500).",
+        ),
+    ) + _FILTER_PARAMETERS
+
+    def pull(self, connector, options):
+        api = connector.api
+        user_id = connector.user_id
+
+        limit = _int_option(options, "limit", 50)
+        composed_q = _compose_query(options)
+        params: dict = {"maxResults": min(max(limit, 1), 500)}
+        if composed_q:
+            params["q"] = composed_q
+
+        listing = api.make_request("GET", f"/users/{user_id}/threads", params=params)
+        if not listing or "threads" not in listing:
+            return iter([])
+
+        threads = listing.get("threads", [])[:limit]
+        snippet_by_id = {t["id"]: t.get("snippet") for t in threads}
+        thread_ids = [t["id"] for t in threads]
+        endpoints = [f"/users/{user_id}/threads/{tid}" for tid in thread_ids]
+        meta_params = [{"format": "metadata"}] * len(thread_ids)
+        results = api.make_batch_request(endpoints, meta_params)
+
+        rows = []
+        for thread in results:
+            if not thread:
+                continue
+            messages = thread.get("messages") or []
+            participants, labels = _thread_participants_and_labels(messages)
+            first_payload = (messages[0].get("payload") if messages else {}) or {}
+            last_payload = (messages[-1].get("payload") if messages else {}) or {}
+            tid = thread.get("id")
+            rows.append(
+                {
+                    "id": tid,
+                    "subject": _header_value(first_payload, "Subject"),
+                    "snippet": snippet_by_id.get(tid),
+                    "message_count": len(messages),
+                    "participants": participants,
+                    "last_date": _header_value(last_payload, "Date"),
+                    "labelIds": labels,
+                    "history_id": thread.get("historyId"),
+                }
+            )
+        return iter(rows)
+
+
+# ---------------------------------------------------------------------------
+# mailbox_overview: per-label message/thread counts for orientation
+# ---------------------------------------------------------------------------
+
+_MAILBOX_OVERVIEW_SCHEMA = StructType(
+    [
+        StructField("label_id", StringType(), False),
+        StructField("name", StringType(), True),
+        StructField("type", StringType(), True),
+        StructField("messages_total", LongType(), True),
+        StructField("messages_unread", LongType(), True),
+        StructField("threads_total", LongType(), True),
+        StructField("threads_unread", LongType(), True),
+    ]
+)
+
+
+class MailboxOverviewOp(AgentOperation):
+    """Per-label message/thread counts, so the agent can see the mailbox's
+    shape before drilling in.
+
+    Lists every label and fetches each one's counts (``users.labels.get``
+    returns messagesTotal / messagesUnread / threadsTotal / threadsUnread).
+    One row per label — system labels (INBOX, SENT, SPAM, ...) alongside
+    user labels — useful for "where is the volume?" orientation before a
+    targeted ``search_messages`` / ``read_table``.
+    """
+
+    name = "mailbox_overview"
+    description = (
+        "List every Gmail label with its message and thread counts (total "
+        "and unread). One row per label; orientation before querying."
+    )
+    kind = "data"
+    schema = _MAILBOX_OVERVIEW_SCHEMA
+    parameters = ()
+
+    def pull(self, connector, options):
+        del options
+        api = connector.api
+        user_id = connector.user_id
+
+        listing = api.make_request("GET", f"/users/{user_id}/labels")
+        labels = (listing or {}).get("labels", [])
+        if not labels:
+            return iter([])
+
+        label_ids = [lb["id"] for lb in labels if lb.get("id")]
+        endpoints = [f"/users/{user_id}/labels/{lid}" for lid in label_ids]
+        details = api.make_batch_request(endpoints)
+
+        rows = []
+        for detail in details:
+            if not detail:
+                continue
+            rows.append(
+                {
+                    "label_id": detail.get("id"),
+                    "name": detail.get("name"),
+                    "type": detail.get("type"),
+                    "messages_total": _safe_int(detail.get("messagesTotal")),
+                    "messages_unread": _safe_int(detail.get("messagesUnread")),
+                    "threads_total": _safe_int(detail.get("threadsTotal")),
+                    "threads_unread": _safe_int(detail.get("threadsUnread")),
+                }
+            )
+        return iter(rows)
+
+
 def _agent_error_from_status(exc: GmailApiError) -> AgentError:
     """Map HTTP status to a canonical agent ErrorCode."""
     if exc.status == 401:
@@ -920,8 +1221,11 @@ def build_gmail_agent_operations() -> dict:
     ops = [
         GmailReadTableOp(),
         SearchMessagesOp(),
+        SearchThreadsOp(),
         GetMessageOp(),
+        GetThreadOp(),
         ListAttachmentsOp(),
         DownloadAttachmentOp(),
+        MailboxOverviewOp(),
     ]
     return {op.name: op for op in ops}

--- a/src/databricks/labs/community_connector/sources/gmail/gmail_agent_ops.py
+++ b/src/databricks/labs/community_connector/sources/gmail/gmail_agent_ops.py
@@ -1,0 +1,927 @@
+# Gmail agent operations: typed filter read + per-message tools.
+#
+# Exposed via ``GmailLakeflowConnect.agent_operations`` and dispatched
+# through the lakeflow_connect format with ``operation=<name>``. Agents
+# call ``list_operations`` to discover names, parameters, and result
+# schemas.
+#
+# Five operations:
+#   - read_table (override): adds typed filters that compose into Gmail's
+#     ``q`` syntax (after_date, before_date, newer_than, subject, from_address,
+#     to_address, label, has_attachment, is_unread, query). Other tables use
+#     the framework default. Caller chains ``.limit(N)`` on the DataFrame.
+#   - search_messages: lightweight triage — id/threadId/from/subject/date/snippet
+#     without fetching message bodies. Same typed filters as read_table.
+#   - get_message: fetch one message by id with decoded plain-text + HTML.
+#   - list_attachments: enumerate attachments on a message (gmail-native plus
+#     Drive-hosted links extracted from the body).
+#   - download_attachment: write attachment bytes to a Databricks volume path.
+#     Routes through Gmail's attachments.get or the Drive API depending on
+#     which ID is supplied. Requires the OAuth refresh token to have been
+#     granted both gmail.readonly and drive.readonly at consent time.
+
+from __future__ import annotations
+
+import os
+from typing import Any, Iterable, Mapping, Optional
+
+from pyspark.sql.types import (
+    ArrayType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+from databricks.labs.community_connector.interface import (
+    AgentError,
+    AgentOperation,
+    ErrorCode,
+    Parameter,
+)
+from databricks.labs.community_connector.sparkpds.ingestion_agent_datasource import (
+    ReadTableOp,
+    _connector_options,
+)
+from databricks.labs.community_connector.sources.gmail.gmail_utils import (
+    GmailApiError,
+    b64url_decode,
+    extract_drive_file_ids,
+)
+
+
+class CaseInsensitiveDict(dict):
+    """A ``dict`` with case-insensitive string-key lookups (``[]``, ``get``,
+    ``in``, ``pop``).
+
+    Defined here (not in ``libs/utils``) so it stays out of the SDP merged
+    single-file: this module is the ingestion-agent surface, served from the
+    installed wheel, and is excluded from ``merge_python_source.py``.
+
+    Some Spark option-delivery paths (notebook reads via
+    ``databricks.connection`` → UC injection) lowercase option keys before
+    they reach Python, so ``options["tableName"]`` would ``KeyError`` even
+    though the caller wrote ``.option("tableName", ...)``. Other paths
+    preserve case. Wrapping the option dict here lets camelCase lookups keep
+    working regardless. No private instance state — cloudpickle reconstructs
+    dict subclasses via ``__new__`` + ``__setitem__`` (bypassing
+    ``__init__``), so any cached index would be unset on the executor; we
+    scan keys per lookup instead (fine for small option dicts).
+    """
+
+    def __getitem__(self, key):
+        return super().__getitem__(self._resolve(key))
+
+    def __contains__(self, key) -> bool:
+        if isinstance(key, str):
+            return self._find(key) is not None
+        return super().__contains__(key)
+
+    def get(self, key, default=None):
+        if isinstance(key, str):
+            actual = self._find(key)
+            return super().__getitem__(actual) if actual is not None else default
+        return super().get(key, default)
+
+    def pop(self, key, *args):
+        if isinstance(key, str):
+            actual = self._find(key)
+            if actual is not None:
+                return super().pop(actual)
+            if args:
+                return args[0]
+            raise KeyError(key)
+        return super().pop(key, *args)
+
+    def __delitem__(self, key):
+        super().__delitem__(self._resolve(key))
+
+    def _find(self, key: str):
+        lowered = key.lower()
+        for existing in super().keys():
+            if isinstance(existing, str) and existing.lower() == lowered:
+                return existing
+        return None
+
+    def _resolve(self, key):
+        if isinstance(key, str):
+            actual = self._find(key)
+            if actual is None:
+                raise KeyError(key)
+            return actual
+        return key
+
+
+# ---------------------------------------------------------------------------
+# Filter composition: typed agent params → Gmail q syntax
+# ---------------------------------------------------------------------------
+
+# Tables that accept Gmail search filters. Anything outside this set is
+# previewed with the framework default (full table snapshot).
+_FILTERABLE_TABLES = frozenset({"messages", "threads"})
+
+# Typed filter parameters shared by read_table override and search_messages.
+# Each tuple is (param, render_fn) where render_fn(value) → q fragment.
+def _q_quote(value: str) -> str:
+    """Wrap a multi-word value in parentheses so Gmail treats it as one operand."""
+    value = value.strip()
+    if not value:
+        return ""
+    if " " in value and not (value.startswith("(") and value.endswith(")")):
+        return f"({value})"
+    return value
+
+
+def _render_after(v: str) -> str:
+    return f"after:{v}"
+
+
+def _render_before(v: str) -> str:
+    return f"before:{v}"
+
+
+def _render_newer_than(v: str) -> str:
+    return f"newer_than:{v}"
+
+
+def _render_subject(v: str) -> str:
+    return f"subject:{_q_quote(v)}"
+
+
+def _render_from(v: str) -> str:
+    return f"from:{v}"
+
+
+def _render_to(v: str) -> str:
+    return f"to:{v}"
+
+
+def _render_label(v: str) -> str:
+    return f"label:{v}"
+
+
+def _render_has_attachment(v: str) -> str:
+    return "has:attachment" if v.lower() == "true" else ""
+
+
+def _render_is_unread(v: str) -> str:
+    return "is:unread" if v.lower() == "true" else ""
+
+
+def _render_passthrough(v: str) -> str:
+    # Free-form query — let the caller author Gmail syntax directly.
+    return v.strip()
+
+
+_FILTER_RENDERERS = (
+    ("after_date", _render_after),
+    ("before_date", _render_before),
+    ("newer_than", _render_newer_than),
+    ("subject", _render_subject),
+    ("from_address", _render_from),
+    ("to_address", _render_to),
+    ("label", _render_label),
+    ("has_attachment", _render_has_attachment),
+    ("is_unread", _render_is_unread),
+    ("query", _render_passthrough),
+)
+
+
+_FILTER_PARAMETERS = (
+    Parameter(
+        name="after_date",
+        description="Date filter — messages on or after YYYY/MM/DD (day granularity).",
+    ),
+    Parameter(
+        name="before_date",
+        description="Date filter — messages strictly before YYYY/MM/DD (day granularity).",
+    ),
+    Parameter(
+        name="newer_than",
+        description="Relative window like '7d', '2m', '1y' (no hours/seconds).",
+    ),
+    Parameter(name="subject", description="Subject keyword or phrase."),
+    Parameter(name="from_address", description="Sender email or substring."),
+    Parameter(name="to_address", description="Recipient email or substring."),
+    Parameter(
+        name="label",
+        description="Gmail label name (e.g. 'inbox', 'work/urgent'). Spaces become '-'.",
+    ),
+    Parameter(
+        name="has_attachment",
+        type="boolean",
+        description="If true, restrict to messages with attachments.",
+    ),
+    Parameter(
+        name="is_unread",
+        type="boolean",
+        description="If true, restrict to unread messages.",
+    ),
+    Parameter(
+        name="query",
+        description=(
+            "Free-form Gmail search expression appended verbatim. "
+            "Combined with the typed filters via AND."
+        ),
+    ),
+)
+
+
+def _compose_query(options: Mapping[str, str]) -> Optional[str]:
+    """Compose typed filter params into a Gmail ``q`` string.
+
+    Returns ``None`` when no filters were supplied (preserves the
+    connector's default listing behaviour). Multiple typed filters are
+    joined with implicit AND, which is Gmail's default conjunction.
+    """
+    fragments: list[str] = []
+    for name, render in _FILTER_RENDERERS:
+        raw = options.get(name)
+        if raw is None or raw == "":
+            continue
+        fragment = render(raw)
+        if fragment:
+            fragments.append(fragment)
+    # Caller's pre-existing q passthrough on the connector — preserve it.
+    raw_q = options.get("q")
+    if raw_q:
+        fragments.append(raw_q)
+    if not fragments:
+        return None
+    return " ".join(fragments)
+
+
+def _table_options_with_query(
+    options: Mapping[str, str], table_name: str
+) -> "CaseInsensitiveDict":
+    """Return connector-side options with the composed ``q`` injected.
+
+    Stripped of the typed filter keys (consumed here) and the agent-reserved
+    keys; the connector sees only its own option namespace plus the merged
+    ``q``. Keeps the ``CaseInsensitiveDict`` wrapper so the connector's
+    camelCase option lookups (``maxResults``, ``labelIds``,
+    ``includeSpamTrash``) keep working when Spark delivered the keys
+    lowercased.
+    """
+    base = CaseInsensitiveDict(_connector_options(options))
+    typed_keys = {name for name, _ in _FILTER_RENDERERS}
+    for key in typed_keys:
+        base.pop(key, None)
+    if table_name in _FILTERABLE_TABLES:
+        composed = _compose_query(options)
+        if composed:
+            base["q"] = composed
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Header extraction helpers
+# ---------------------------------------------------------------------------
+
+def _header_value(payload: Mapping[str, Any], name: str) -> Optional[str]:
+    """Look up a header by case-insensitive name on a parsed payload."""
+    if not payload:
+        return None
+    target = name.lower()
+    for header in payload.get("headers", []) or []:
+        if (header.get("name") or "").lower() == target:
+            return header.get("value")
+    return None
+
+
+def _walk_parts(payload: Mapping[str, Any]):
+    """Depth-first iterate every MessagePart in a parsed payload."""
+    if not payload:
+        return
+    stack = [payload]
+    while stack:
+        part = stack.pop()
+        yield part
+        for child in part.get("parts", []) or []:
+            stack.append(child)
+
+
+def _decode_body_text(payload: Mapping[str, Any], mime_target: str) -> Optional[str]:
+    """Decode the first body part matching ``mime_target`` to text.
+
+    Gmail returns part bodies as base64url; we decode then UTF-8 with
+    ``errors='replace'`` so caller never crashes on legacy encodings.
+    """
+    for part in _walk_parts(payload):
+        if part.get("mimeType") != mime_target:
+            continue
+        body = part.get("body") or {}
+        data = body.get("data")
+        if not data:
+            continue
+        try:
+            return b64url_decode(data).decode("utf-8", errors="replace")
+        except Exception:  # pylint: disable=broad-except
+            return None
+    return None
+
+
+def _attachment_parts(payload: Mapping[str, Any]):
+    """Yield (filename, mimeType, attachmentId, size) for parts with attachments."""
+    for part in _walk_parts(payload):
+        body = part.get("body") or {}
+        attachment_id = body.get("attachmentId")
+        if not attachment_id:
+            continue
+        yield {
+            "filename": part.get("filename") or "",
+            "mime_type": part.get("mimeType") or "application/octet-stream",
+            "attachment_id": attachment_id,
+            "size_bytes": int(body.get("size") or 0),
+        }
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# read_table override: apply typed filters to messages / threads
+# ---------------------------------------------------------------------------
+
+class GmailReadTableOp(ReadTableOp):
+    """read_table that composes typed filters into Gmail's ``q`` syntax.
+
+    For ``messages`` and ``threads``, the typed parameters below are joined
+    via AND and become the ``q`` option the connector sends to Gmail. For
+    every other table, behaviour matches the framework default.
+
+    Default row cap is **50** so notebook ``display(df)`` calls return
+    quickly against busy mailboxes. Pass ``maxResults=N`` to raise the cap,
+    or ``maxResults=-1`` for unlimited (the full table is streamed). The
+    cap is enforced inside the connector's pagination loop, so we don't
+    fetch pages we'll throw away.
+    """
+
+    _DEFAULT_MAX_RESULTS = "50"
+
+    description = (
+        "Read a tabular object. For messages/threads, accepts typed "
+        "filters (after_date, before_date, newer_than, subject, "
+        "from_address, to_address, label, has_attachment, is_unread, "
+        "query) that compose into Gmail search syntax. "
+        "Default cap is 50 rows; set maxResults=N to change, or "
+        "maxResults=-1 for unlimited."
+    )
+    parameters = ReadTableOp.parameters + _FILTER_PARAMETERS
+
+    def pull(self, connector, options):
+        table_name = options["tableName"]
+        gmail_options = _table_options_with_query(options, table_name)
+        # Inject the default cap if the caller didn't specify one.
+        # ``in`` is case-insensitive on the CaseInsensitiveDict that
+        # ``_table_options_with_query`` returns, so any casing of
+        # ``maxResults`` the caller passed will be detected.
+        if "maxResults" not in gmail_options:
+            gmail_options["maxResults"] = self._DEFAULT_MAX_RESULTS
+        records, _offset = connector.read_table(table_name, None, gmail_options)
+        return records
+
+
+# ---------------------------------------------------------------------------
+# search_messages: lightweight triage view (no body, no payload)
+# ---------------------------------------------------------------------------
+
+_SEARCH_MESSAGES_SCHEMA = StructType(
+    [
+        StructField("id", StringType(), False),
+        StructField("threadId", StringType(), True),
+        StructField("from_address", StringType(), True),
+        StructField("to_address", StringType(), True),
+        StructField("subject", StringType(), True),
+        StructField("date", StringType(), True),
+        StructField("snippet", StringType(), True),
+        StructField("labelIds", ArrayType(StringType()), True),
+        StructField("has_attachment", StringType(), True),
+        StructField("size_estimate", LongType(), True),
+    ]
+)
+
+
+class SearchMessagesOp(AgentOperation):
+    """Lightweight search returning header-level info, no message bodies.
+
+    Designed for agent triage flows where the planner wants to scan many
+    messages cheaply, then call ``get_message`` only on the ones it picks.
+    Uses Gmail's ``format=metadata`` so each message costs 5 quota units
+    instead of 20 for ``format=full``.
+    """
+
+    name = "search_messages"
+    description = (
+        "Search messages and return one row per match with id, threadId, "
+        "from, to, subject, date, snippet, labels, has_attachment, "
+        "size_estimate. No message bodies."
+    )
+    kind = "data"
+    schema = _SEARCH_MESSAGES_SCHEMA
+    parameters = (
+        Parameter(
+            name="limit",
+            type="integer",
+            default=50,
+            description="Maximum messages to return (default 50, max 500).",
+        ),
+    ) + _FILTER_PARAMETERS
+
+    def pull(self, connector, options):
+        api = connector.api
+        user_id = connector.user_id
+
+        limit = self._int_limit(options)
+        composed_q = _compose_query(options)
+
+        params: dict = {"maxResults": min(max(limit, 1), 500)}
+        if composed_q:
+            params["q"] = composed_q
+
+        # First list to get IDs, then fetch metadata-format for headers only.
+        listing = api.make_request("GET", f"/users/{user_id}/messages", params=params)
+        if not listing or "messages" not in listing:
+            return iter([])
+
+        message_ids = [m["id"] for m in listing.get("messages", [])][:limit]
+        endpoints = [f"/users/{user_id}/messages/{mid}" for mid in message_ids]
+        meta_params = [{"format": "metadata"}] * len(message_ids)
+        results = api.make_batch_request(endpoints, meta_params)
+
+        rows = []
+        for msg in results:
+            if not msg:
+                continue
+            payload = msg.get("payload") or {}
+            label_ids = msg.get("labelIds") or []
+            rows.append(
+                {
+                    "id": msg.get("id"),
+                    "threadId": msg.get("threadId"),
+                    "from_address": _header_value(payload, "From"),
+                    "to_address": _header_value(payload, "To"),
+                    "subject": _header_value(payload, "Subject"),
+                    "date": _header_value(payload, "Date"),
+                    "snippet": msg.get("snippet"),
+                    "labelIds": label_ids,
+                    "has_attachment": "true"
+                    if any(_attachment_parts(payload))
+                    else "false",
+                    "size_estimate": _safe_int(msg.get("sizeEstimate")),
+                }
+            )
+        return iter(rows)
+
+    @staticmethod
+    def _int_limit(options: Mapping[str, str]) -> int:
+        raw = options.get("limit")
+        if raw is None or raw == "":
+            return 50
+        try:
+            return int(raw)
+        except (TypeError, ValueError) as exc:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Option 'limit' must be an integer, got {raw!r}.",
+            ) from exc
+
+
+# ---------------------------------------------------------------------------
+# get_message: fetch a single message with decoded plain + html bodies
+# ---------------------------------------------------------------------------
+
+_GET_MESSAGE_SCHEMA = StructType(
+    [
+        StructField("id", StringType(), False),
+        StructField("threadId", StringType(), True),
+        StructField("from_address", StringType(), True),
+        StructField("to_address", StringType(), True),
+        StructField("cc_address", StringType(), True),
+        StructField("subject", StringType(), True),
+        StructField("date", StringType(), True),
+        StructField("snippet", StringType(), True),
+        StructField("labelIds", ArrayType(StringType()), True),
+        StructField("body_text", StringType(), True),
+        StructField("body_html", StringType(), True),
+        StructField("size_estimate", LongType(), True),
+        StructField(
+            "attachments",
+            ArrayType(
+                StructType(
+                    [
+                        StructField("filename", StringType(), True),
+                        StructField("mime_type", StringType(), True),
+                        StructField("attachment_id", StringType(), True),
+                        StructField("size_bytes", LongType(), True),
+                    ]
+                )
+            ),
+            True,
+        ),
+        StructField("drive_file_ids", ArrayType(StringType()), True),
+    ]
+)
+
+
+class GetMessageOp(AgentOperation):
+    """Fetch one message by id with decoded plain-text and HTML bodies.
+
+    Returns a single row. Body parts arrive base64url-encoded from Gmail;
+    this op decodes them so the agent sees ready-to-read text. Drive-
+    hosted attachment IDs are extracted from the HTML body and surfaced
+    in ``drive_file_ids`` so the agent can chain ``download_attachment``.
+    """
+
+    name = "get_message"
+    description = (
+        "Fetch one message by id with decoded body_text/body_html, "
+        "headers, attachments list, and any Drive file IDs referenced "
+        "in the body."
+    )
+    kind = "data"
+    schema = _GET_MESSAGE_SCHEMA
+    parameters = (
+        Parameter(
+            name="message_id",
+            required=True,
+            description="Gmail message id to fetch.",
+        ),
+    )
+
+    def pull(self, connector, options):
+        message_id = options["message_id"]
+        api = connector.api
+        user_id = connector.user_id
+
+        msg = api.make_request(
+            "GET",
+            f"/users/{user_id}/messages/{message_id}",
+            {"format": "full"},
+        )
+        if not msg:
+            raise AgentError(
+                ErrorCode.NOT_FOUND,
+                f"Message '{message_id}' not found or inaccessible.",
+            )
+        payload = msg.get("payload") or {}
+        body_text = _decode_body_text(payload, "text/plain")
+        body_html = _decode_body_text(payload, "text/html")
+        drive_ids = extract_drive_file_ids(body_html or body_text or "")
+
+        return iter(
+            [
+                {
+                    "id": msg.get("id"),
+                    "threadId": msg.get("threadId"),
+                    "from_address": _header_value(payload, "From"),
+                    "to_address": _header_value(payload, "To"),
+                    "cc_address": _header_value(payload, "Cc"),
+                    "subject": _header_value(payload, "Subject"),
+                    "date": _header_value(payload, "Date"),
+                    "snippet": msg.get("snippet"),
+                    "labelIds": msg.get("labelIds") or [],
+                    "body_text": body_text,
+                    "body_html": body_html,
+                    "size_estimate": _safe_int(msg.get("sizeEstimate")),
+                    "attachments": list(_attachment_parts(payload)),
+                    "drive_file_ids": drive_ids,
+                }
+            ]
+        )
+
+
+# ---------------------------------------------------------------------------
+# list_attachments: enumerate gmail-native + Drive-hosted attachments
+# ---------------------------------------------------------------------------
+
+_LIST_ATTACHMENTS_SCHEMA = StructType(
+    [
+        StructField("message_id", StringType(), False),
+        StructField("kind", StringType(), False),  # "gmail" or "drive"
+        StructField("attachment_id", StringType(), True),
+        StructField("drive_file_id", StringType(), True),
+        StructField("filename", StringType(), True),
+        StructField("mime_type", StringType(), True),
+        StructField("size_bytes", LongType(), True),
+    ]
+)
+
+
+class ListAttachmentsOp(AgentOperation):
+    """List attachments for a message.
+
+    Surfaces two kinds in the same result set:
+      - ``kind = "gmail"``: parts with an ``attachment_id`` from the
+        message payload. Fetch via ``download_attachment`` with
+        ``attachment_id``.
+      - ``kind = "drive"``: file IDs extracted from Drive/Docs links in
+        the message body. Fetch via ``download_attachment`` with
+        ``drive_file_id``. Filename / size enriched via Drive metadata.
+    """
+
+    name = "list_attachments"
+    description = (
+        "List Gmail-native and Drive-hosted attachments for a message id. "
+        "Returns one row per attachment with the IDs the "
+        "download_attachment op needs."
+    )
+    kind = "data"
+    schema = _LIST_ATTACHMENTS_SCHEMA
+    parameters = (
+        Parameter(
+            name="message_id",
+            required=True,
+            description="Gmail message id whose attachments to enumerate.",
+        ),
+    )
+
+    def pull(self, connector, options):
+        message_id = options["message_id"]
+        api = connector.api
+        user_id = connector.user_id
+
+        msg = api.make_request(
+            "GET",
+            f"/users/{user_id}/messages/{message_id}",
+            {"format": "full"},
+        )
+        if not msg:
+            raise AgentError(
+                ErrorCode.NOT_FOUND,
+                f"Message '{message_id}' not found or inaccessible.",
+            )
+        payload = msg.get("payload") or {}
+
+        rows: list[dict] = []
+        for part in _attachment_parts(payload):
+            rows.append(
+                {
+                    "message_id": message_id,
+                    "kind": "gmail",
+                    "attachment_id": part["attachment_id"],
+                    "drive_file_id": None,
+                    "filename": part["filename"],
+                    "mime_type": part["mime_type"],
+                    "size_bytes": part["size_bytes"],
+                }
+            )
+
+        body_html = _decode_body_text(payload, "text/html")
+        body_text = _decode_body_text(payload, "text/plain")
+        drive_ids = extract_drive_file_ids(body_html or body_text or "")
+        for file_id in drive_ids:
+            # Drive metadata lookup is best-effort; permission errors
+            # surface in the row's mime_type so the agent sees them.
+            try:
+                meta = api.get_drive_file_metadata(file_id)
+                rows.append(
+                    {
+                        "message_id": message_id,
+                        "kind": "drive",
+                        "attachment_id": None,
+                        "drive_file_id": file_id,
+                        "filename": meta.get("name"),
+                        "mime_type": meta.get("mimeType"),
+                        "size_bytes": _safe_int(meta.get("size")),
+                    }
+                )
+            except GmailApiError as exc:
+                rows.append(
+                    {
+                        "message_id": message_id,
+                        "kind": "drive",
+                        "attachment_id": None,
+                        "drive_file_id": file_id,
+                        "filename": None,
+                        "mime_type": f"error:http_{exc.status}",
+                        "size_bytes": None,
+                    }
+                )
+        return iter(rows)
+
+
+# ---------------------------------------------------------------------------
+# download_attachment: write bytes to a Databricks volume path
+# ---------------------------------------------------------------------------
+
+_DOWNLOAD_ATTACHMENT_SCHEMA = StructType(
+    [
+        StructField("volume_path", StringType(), False),
+        StructField("size_bytes", LongType(), True),
+        StructField("mime_type", StringType(), True),
+        StructField("filename", StringType(), True),
+        StructField("source", StringType(), False),  # "gmail" or "drive"
+    ]
+)
+
+
+class DownloadAttachmentOp(AgentOperation):
+    """Download an attachment to a Databricks Volume path.
+
+    Two input shapes; exactly one ID must be supplied:
+      - ``attachment_id`` + ``message_id`` → Gmail's
+        ``users.messages.attachments.get``. Decoded bytes are written
+        to ``volume_path``.
+      - ``drive_file_id`` → Drive ``files.get?alt=media`` (binary) or
+        ``files.export`` (Google-native types: Docs/Sheets/Slides).
+        ``export_mime_type`` overrides the default ``application/pdf``
+        export target.
+
+    ``volume_path`` must be a writable path the executor can ``open()``
+    in write-binary mode. The canonical shape is
+    ``/Volumes/<catalog>/<schema>/<volume>/<filename>`` — the op
+    creates the parent directory if needed but does not create the
+    volume itself. The path is required to start with ``/Volumes/`` so
+    the op can't accidentally write outside Unity Catalog (override
+    intentionally via the framework's option dict only).
+    """
+
+    name = "download_attachment"
+    description = (
+        "Download a Gmail or Drive-hosted attachment to a Databricks "
+        "Volume path. Supply attachment_id+message_id for Gmail or "
+        "drive_file_id for Drive."
+    )
+    kind = "metadata"
+    schema = _DOWNLOAD_ATTACHMENT_SCHEMA
+    parameters = (
+        Parameter(
+            name="volume_path",
+            required=True,
+            description=(
+                "Destination path under /Volumes/<catalog>/<schema>/<volume>/. "
+                "The parent directory is created if missing."
+            ),
+        ),
+        Parameter(
+            name="message_id",
+            description=(
+                "Gmail message id. Required when attachment_id is supplied."
+            ),
+        ),
+        Parameter(
+            name="attachment_id",
+            description=(
+                "Gmail attachment id (from list_attachments where kind=gmail)."
+            ),
+        ),
+        Parameter(
+            name="drive_file_id",
+            description=(
+                "Drive file id (from list_attachments where kind=drive)."
+            ),
+        ),
+        Parameter(
+            name="export_mime_type",
+            description=(
+                "For Google-native Drive files, the export MIME type "
+                "(default 'application/pdf'). Ignored for binary files."
+            ),
+        ),
+    )
+
+    _VOLUME_PREFIX = "/Volumes/"
+
+    def pull(self, connector, options):
+        volume_path = options["volume_path"]
+        if not volume_path.startswith(self._VOLUME_PREFIX):
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"volume_path must start with '{self._VOLUME_PREFIX}'; "
+                f"got {volume_path!r}.",
+            )
+
+        attachment_id = options.get("attachment_id") or None
+        message_id = options.get("message_id") or None
+        drive_file_id = options.get("drive_file_id") or None
+
+        if attachment_id and drive_file_id:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                "Supply attachment_id OR drive_file_id, not both.",
+            )
+        if not attachment_id and not drive_file_id:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                "Either attachment_id (with message_id) or drive_file_id "
+                "is required.",
+            )
+        if attachment_id and not message_id:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                "message_id is required when attachment_id is supplied.",
+            )
+
+        parent = os.path.dirname(volume_path)
+        if parent:
+            try:
+                os.makedirs(parent, exist_ok=True)
+            except OSError as exc:
+                raise AgentError(
+                    ErrorCode.PERMISSION_DENIED,
+                    f"Cannot create parent directory '{parent}': {exc}",
+                ) from exc
+
+        if attachment_id:
+            return iter([self._download_gmail(connector, message_id, attachment_id, volume_path)])
+        return iter([self._download_drive(connector, drive_file_id, volume_path, options)])
+
+    @staticmethod
+    def _download_gmail(connector, message_id, attachment_id, volume_path):
+        try:
+            data = connector.api.get_attachment(message_id, attachment_id)
+        except GmailApiError as exc:
+            raise _agent_error_from_status(exc) from exc
+
+        # Look up filename + mime from the parent message payload so the
+        # row carries it. One extra API call (format=metadata is cheap at
+        # 5 quota units) — worth it for downstream UX.
+        filename = None
+        mime_type = None
+        meta = connector.api.make_request(
+            "GET",
+            f"/users/{connector.user_id}/messages/{message_id}",
+            {"format": "full"},
+        )
+        if meta:
+            for part in _attachment_parts(meta.get("payload") or {}):
+                if part["attachment_id"] == attachment_id:
+                    filename = part["filename"] or None
+                    mime_type = part["mime_type"]
+                    break
+
+        with open(volume_path, "wb") as fh:
+            fh.write(data)
+
+        return {
+            "volume_path": volume_path,
+            "size_bytes": len(data),
+            "mime_type": mime_type,
+            "filename": filename,
+            "source": "gmail",
+        }
+
+    @staticmethod
+    def _download_drive(connector, drive_file_id, volume_path, options):
+        try:
+            size, name, mime = connector.api.download_drive_file(
+                drive_file_id,
+                volume_path,
+                export_mime_type=options.get("export_mime_type") or None,
+            )
+        except GmailApiError as exc:
+            raise _agent_error_from_status(exc) from exc
+
+        return {
+            "volume_path": volume_path,
+            "size_bytes": size,
+            "mime_type": mime,
+            "filename": name,
+            "source": "drive",
+        }
+
+
+def _agent_error_from_status(exc: GmailApiError) -> AgentError:
+    """Map HTTP status to a canonical agent ErrorCode."""
+    if exc.status == 401:
+        return AgentError(
+            ErrorCode.AUTH_FAILED,
+            f"Authentication failed: {exc}",
+        )
+    if exc.status == 403:
+        return AgentError(
+            ErrorCode.PERMISSION_DENIED,
+            f"Permission denied (does the OAuth token include drive.readonly?): {exc}",
+        )
+    if exc.status == 404:
+        return AgentError(ErrorCode.NOT_FOUND, str(exc))
+    if exc.status == 429:
+        return AgentError(ErrorCode.RATE_LIMITED, str(exc))
+    return AgentError(ErrorCode.INTERNAL_ERROR, str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Entry point — what GmailLakeflowConnect.agent_operations returns
+# ---------------------------------------------------------------------------
+
+def build_gmail_agent_operations() -> dict:
+    """Return the agent-operation map for the Gmail connector.
+
+    Wired in via :meth:`GmailLakeflowConnect.agent_operations`. The
+    ``read_table`` entry overrides the framework built-in.
+    """
+    ops = [
+        GmailReadTableOp(),
+        SearchMessagesOp(),
+        GetMessageOp(),
+        ListAttachmentsOp(),
+        DownloadAttachmentOp(),
+    ]
+    return {op.name: op for op in ops}

--- a/src/databricks/labs/community_connector/sources/gmail/gmail_utils.py
+++ b/src/databricks/labs/community_connector/sources/gmail/gmail_utils.py
@@ -230,7 +230,19 @@ class GmailApiClient:
             # Fall back to sequential requests on batch failure
             return self._fetch_sequential(endpoints, params_list)
 
-        return self._parse_batch_response(response.text, boundary)
+        parsed = self._parse_batch_response(response.text, boundary)
+
+        # A 200 is not proof the batch succeeded. Gmail's global batch endpoint
+        # can answer 200 with a body our multipart parser cannot read, yielding
+        # zero rows with no exception — which silently empties every batch-backed
+        # operation (search_messages, search_threads, mailbox_overview, and the
+        # incremental message/thread reads). Treat an empty parse against a
+        # non-empty request as a batch failure and fall back to the per-request
+        # path the table reads already rely on.
+        if not parsed:
+            return self._fetch_sequential(endpoints, params_list)
+
+        return parsed
 
     def _parse_batch_response(self, response_text: str, boundary: str) -> List[Dict]:
         """Parse multipart batch response."""

--- a/src/databricks/labs/community_connector/sources/gmail/gmail_utils.py
+++ b/src/databricks/labs/community_connector/sources/gmail/gmail_utils.py
@@ -13,9 +13,11 @@
 #    refresh token for short-lived access tokens at Google's token endpoint
 #    and caches them. Keeps those older connections working.
 
+import base64
 import json
+import re
 import time
-from typing import Dict, List, Optional, Generator
+from typing import Dict, List, Optional, Generator, Tuple
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
@@ -24,6 +26,63 @@ import requests
 # Batch API settings
 BATCH_SIZE = 50  # Gmail batch API supports up to 100, using 50 for safety
 MAX_WORKERS = 3  # Concurrent workers for parallel fetching
+
+# Drive API endpoints. The Gmail connector calls these whenever a message
+# carries a Drive-hosted attachment (>25 MB or shared via Drive). Requires
+# the OAuth grant to include ``drive.readonly`` alongside ``gmail.readonly``
+# at consent time.
+DRIVE_API_BASE = "https://www.googleapis.com/drive/v3"
+GOOGLE_NATIVE_MIME_PREFIX = "application/vnd.google-apps."
+
+# Regex catches the common Drive / Docs / Sheets / Slides URL shapes Gmail
+# inlines into HTML bodies. The file ID is 25+ chars of [A-Za-z0-9_-].
+_DRIVE_ID_PATTERN = re.compile(
+    r"(?:drive\.google\.com/(?:file/d/|open\?id=|uc\?[^\"'\s]*?id=)|"
+    r"docs\.google\.com/(?:document|spreadsheets|presentation|drawings)/d/)"
+    r"([A-Za-z0-9_-]{25,})"
+)
+
+
+def b64url_decode(data: str) -> bytes:
+    """Decode a base64url string, padding-tolerant.
+
+    Gmail/Drive responses strip ``=`` padding on base64url data; the stdlib
+    decoder rejects unpadded input. Re-pad before calling it.
+    """
+    if not data:
+        return b""
+    padded = data + "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(padded)
+
+
+def extract_drive_file_ids(text: str) -> List[str]:
+    """Extract Drive file IDs from a message body (HTML or plain text).
+
+    Returns IDs in insertion order, deduplicated. Empty list if no Drive
+    URLs are present. Caller is responsible for choosing the right
+    download path (binary via ``alt=media`` vs export for native types).
+    """
+    if not text:
+        return []
+    seen: dict[str, None] = {}
+    for match in _DRIVE_ID_PATTERN.finditer(text):
+        seen.setdefault(match.group(1), None)
+    return list(seen.keys())
+
+
+class GmailApiError(Exception):
+    """Typed Gmail/Drive API failure carrying the HTTP status.
+
+    Agent ops translate ``status`` to ErrorCode (404→not_found, 403→
+    permission_denied, 401→auth_failed). Plain ``make_request`` callers
+    that previously swallowed 403/404 as ``None`` are unaffected — this
+    type is only raised by paths that opt in (Drive downloads, attachment
+    fetches when ``raise_on_error=True``).
+    """
+
+    def __init__(self, status: int, message: str) -> None:
+        self.status = status
+        super().__init__(f"HTTP {status}: {message}")
 
 
 class GmailApiClient:
@@ -39,6 +98,7 @@ class GmailApiClient:
     BASE_URL = "https://gmail.googleapis.com/gmail/v1"
     BATCH_URL = "https://gmail.googleapis.com/batch/gmail/v1"
     TOKEN_URL = "https://oauth2.googleapis.com/token"
+    DRIVE_BASE_URL = DRIVE_API_BASE
 
     def __init__(
         self,
@@ -221,3 +281,88 @@ class GmailApiClient:
                 except Exception:
                     # Skip failed fetches, continue with others
                     continue
+
+    # ─── Attachment / Drive download ──────────────────────────────────────
+
+    def get_attachment(
+        self, message_id: str, attachment_id: str
+    ) -> bytes:
+        """Fetch a Gmail attachment by ID and return decoded bytes.
+
+        Calls ``users.messages.attachments.get`` and base64url-decodes the
+        response. Raises :class:`GmailApiError` on 4xx/5xx so callers can
+        map status codes to typed errors.
+        """
+        url = (
+            f"{self.BASE_URL}/users/{self.user_id}"
+            f"/messages/{message_id}/attachments/{attachment_id}"
+        )
+        response = self._session.get(url, headers=self.get_headers(), timeout=120)
+        if response.status_code != 200:
+            raise GmailApiError(response.status_code, response.text)
+        payload = response.json()
+        return b64url_decode(payload.get("data", ""))
+
+    def get_drive_file_metadata(self, file_id: str) -> Dict:
+        """Fetch Drive file metadata (id, name, mimeType, size).
+
+        Needed before downloading to pick between binary download
+        (``alt=media``) and export (Docs/Sheets/Slides). Same access token
+        as Gmail — but only works if the user consented to the
+        ``drive.readonly`` scope at OAuth time.
+        """
+        url = f"{self.DRIVE_BASE_URL}/files/{file_id}"
+        response = self._session.get(
+            url,
+            headers=self.get_headers(),
+            params={"fields": "id,name,mimeType,size"},
+            timeout=60,
+        )
+        if response.status_code != 200:
+            raise GmailApiError(response.status_code, response.text)
+        return response.json()
+
+    def download_drive_file(
+        self,
+        file_id: str,
+        dest_path: str,
+        export_mime_type: Optional[str] = None,
+        chunk_size: int = 1024 * 1024,
+    ) -> Tuple[int, str, str]:
+        """Stream a Drive file to ``dest_path`` and return ``(size, name, mime)``.
+
+        Binary files are fetched via ``files.get?alt=media``. Google-native
+        formats (Docs/Sheets/Slides) require ``files.export`` with a
+        target ``export_mime_type`` — picks ``application/pdf`` if the
+        caller didn't supply one.
+
+        Caller pre-creates the parent directory. Raises
+        :class:`GmailApiError` on 4xx/5xx (use ``status == 403`` to detect
+        the recipient-not-shared case).
+        """
+        metadata = self.get_drive_file_metadata(file_id)
+        mime_type = metadata.get("mimeType", "application/octet-stream")
+        name = metadata.get("name", file_id)
+
+        if mime_type.startswith(GOOGLE_NATIVE_MIME_PREFIX):
+            export_mime = export_mime_type or "application/pdf"
+            url = f"{self.DRIVE_BASE_URL}/files/{file_id}/export"
+            params = {"mimeType": export_mime}
+            effective_mime = export_mime
+        else:
+            url = f"{self.DRIVE_BASE_URL}/files/{file_id}"
+            params = {"alt": "media"}
+            effective_mime = mime_type
+
+        bytes_written = 0
+        with self._session.get(
+            url, headers=self.get_headers(), params=params, timeout=300, stream=True
+        ) as response:
+            if response.status_code != 200:
+                raise GmailApiError(response.status_code, response.text)
+            with open(dest_path, "wb") as fh:
+                for chunk in response.iter_content(chunk_size=chunk_size):
+                    if chunk:
+                        fh.write(chunk)
+                        bytes_written += len(chunk)
+        return bytes_written, name, effective_mime

--- a/src/databricks/labs/community_connector/sources/google_analytics_aggregated/_generated_google_analytics_aggregated_python_source.py
+++ b/src/databricks/labs/community_connector/sources/google_analytics_aggregated/_generated_google_analytics_aggregated_python_source.py
@@ -5,12 +5,23 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 import json
+import re
 import time
 
 from pyspark.sql import Row
@@ -588,6 +599,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -1801,6 +2757,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -1809,6 +2770,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -1827,10 +2804,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -1857,6 +2848,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/google_analytics_aggregated/_generated_google_analytics_aggregated_python_source.py
+++ b/src/databricks/labs/community_connector/sources/google_analytics_aggregated/_generated_google_analytics_aggregated_python_source.py
@@ -1108,6 +1108,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/google_sheets_docs/_generated_google_sheets_docs_python_source.py
+++ b/src/databricks/labs/community_connector/sources/google_sheets_docs/_generated_google_sheets_docs_python_source.py
@@ -5,10 +5,20 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 import json
 import re
 import time
@@ -589,6 +599,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -1517,6 +2472,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -1525,6 +2485,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -1543,10 +2519,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -1573,6 +2563,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/google_sheets_docs/_generated_google_sheets_docs_python_source.py
+++ b/src/databricks/labs/community_connector/sources/google_sheets_docs/_generated_google_sheets_docs_python_source.py
@@ -1108,6 +1108,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/hl7_v2/_generated_hl7_v2_python_source.py
+++ b/src/databricks/labs/community_connector/sources/hl7_v2/_generated_hl7_v2_python_source.py
@@ -7,9 +7,18 @@
 
 from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 import json
 import os
 import re
@@ -594,6 +603,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -6120,6 +7074,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -6128,6 +7087,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -6146,10 +7121,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -6176,6 +7165,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/hl7_v2/_generated_hl7_v2_python_source.py
+++ b/src/databricks/labs/community_connector/sources/hl7_v2/_generated_hl7_v2_python_source.py
@@ -1112,6 +1112,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
+++ b/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
@@ -5,18 +5,24 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import (
     Any,
     Dict,
+    Iterable,
     Iterator,
     List,
+    Mapping,
+    Optional,
     Sequence,
     Tuple,
 )
 import json
+import re
 import time
 
 from pyspark.sql import Row
@@ -577,6 +583,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -1606,6 +2557,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -1614,6 +2570,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -1632,10 +2604,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -1662,6 +2648,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
+++ b/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
@@ -1092,6 +1092,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/microsoft_teams/_generated_microsoft_teams_python_source.py
+++ b/src/databricks/labs/community_connector/sources/microsoft_teams/_generated_microsoft_teams_python_source.py
@@ -1108,6 +1108,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/microsoft_teams/_generated_microsoft_teams_python_source.py
+++ b/src/databricks/labs/community_connector/sources/microsoft_teams/_generated_microsoft_teams_python_source.py
@@ -5,11 +5,22 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 import json
+import re
 import time
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -588,6 +599,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -2301,6 +3257,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -2309,6 +3270,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -2327,10 +3304,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -2357,6 +3348,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/mixpanel/_generated_mixpanel_python_source.py
+++ b/src/databricks/labs/community_connector/sources/mixpanel/_generated_mixpanel_python_source.py
@@ -1089,6 +1089,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/mixpanel/_generated_mixpanel_python_source.py
+++ b/src/databricks/labs/community_connector/sources/mixpanel/_generated_mixpanel_python_source.py
@@ -5,11 +5,22 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 import json
+import re
 import time
 
 from pyspark.sql import Row
@@ -569,6 +580,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -1573,6 +2529,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -1581,6 +2542,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -1599,10 +2576,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -1629,6 +2620,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/osipi/_generated_osipi_python_source.py
+++ b/src/databricks/labs/community_connector/sources/osipi/_generated_osipi_python_source.py
@@ -5,19 +5,24 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import (
     Any,
     Dict,
+    Iterable,
     Iterator,
     List,
+    Mapping,
     Optional,
     Sequence,
     Tuple,
 )
 import json
+import re
 
 from pyspark.sql import Row
 from pyspark.sql.datasource import (
@@ -594,6 +599,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -4424,6 +5374,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -4432,6 +5387,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -4450,10 +5421,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -4480,6 +5465,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/osipi/_generated_osipi_python_source.py
+++ b/src/databricks/labs/community_connector/sources/osipi/_generated_osipi_python_source.py
@@ -1108,6 +1108,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/palantir/_generated_palantir_python_source.py
+++ b/src/databricks/labs/community_connector/sources/palantir/_generated_palantir_python_source.py
@@ -5,19 +5,24 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import (
     Any,
     Dict,
+    Iterable,
     Iterator,
     List,
+    Mapping,
     Optional,
     Sequence,
     Tuple,
 )
 import json
+import re
 import time
 
 from pyspark.sql import Row
@@ -597,6 +602,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -1958,6 +2908,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -1966,6 +2921,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -1984,10 +2955,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -2014,6 +2999,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/palantir/_generated_palantir_python_source.py
+++ b/src/databricks/labs/community_connector/sources/palantir/_generated_palantir_python_source.py
@@ -1111,6 +1111,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/qualtrics/_generated_qualtrics_python_source.py
+++ b/src/databricks/labs/community_connector/sources/qualtrics/_generated_qualtrics_python_source.py
@@ -5,10 +5,20 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 import io
 import json
 import re
@@ -593,6 +603,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -2621,6 +3576,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -2629,6 +3589,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -2647,10 +3623,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -2677,6 +3667,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/qualtrics/_generated_qualtrics_python_source.py
+++ b/src/databricks/labs/community_connector/sources/qualtrics/_generated_qualtrics_python_source.py
@@ -1112,6 +1112,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/sap_successfactors/_generated_sap_successfactors_python_source.py
+++ b/src/databricks/labs/community_connector/sources/sap_successfactors/_generated_sap_successfactors_python_source.py
@@ -1111,6 +1111,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/sap_successfactors/_generated_sap_successfactors_python_source.py
+++ b/src/databricks/labs/community_connector/sources/sap_successfactors/_generated_sap_successfactors_python_source.py
@@ -5,14 +5,18 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import (
     Any,
     Dict,
+    Iterable,
     Iterator,
     List,
+    Mapping,
     Optional,
     Sequence,
     Tuple,
@@ -598,6 +602,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -8164,6 +9113,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -8172,6 +9126,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -8190,10 +9160,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -8220,6 +9204,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/shopify/_generated_shopify_python_source.py
+++ b/src/databricks/labs/community_connector/sources/shopify/_generated_shopify_python_source.py
@@ -1108,6 +1108,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/shopify/_generated_shopify_python_source.py
+++ b/src/databricks/labs/community_connector/sources/shopify/_generated_shopify_python_source.py
@@ -5,10 +5,20 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 import json
 import re
 import time
@@ -589,6 +599,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -1878,6 +2833,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -1886,6 +2846,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -1904,10 +2880,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -1934,6 +2924,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/surveymonkey/_generated_surveymonkey_python_source.py
+++ b/src/databricks/labs/community_connector/sources/surveymonkey/_generated_surveymonkey_python_source.py
@@ -1109,6 +1109,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/surveymonkey/_generated_surveymonkey_python_source.py
+++ b/src/databricks/labs/community_connector/sources/surveymonkey/_generated_surveymonkey_python_source.py
@@ -5,18 +5,24 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import (
     Any,
     Dict,
+    Iterable,
     Iterator,
     List,
+    Mapping,
+    Optional,
     Sequence,
     Tuple,
 )
 import json
+import re
 import time
 
 from pyspark.sql import Row
@@ -594,6 +600,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -2343,6 +3294,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -2351,6 +3307,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -2369,10 +3341,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -2399,6 +3385,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/zendesk/_generated_zendesk_python_source.py
+++ b/src/databricks/labs/community_connector/sources/zendesk/_generated_zendesk_python_source.py
@@ -1091,6 +1091,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/zendesk/_generated_zendesk_python_source.py
+++ b/src/databricks/labs/community_connector/sources/zendesk/_generated_zendesk_python_source.py
@@ -5,17 +5,24 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from typing import (
     Any,
     Dict,
+    Iterable,
     Iterator,
     List,
+    Mapping,
+    Optional,
     Sequence,
+    Tuple,
 )
 import json
+import re
 import time
 
 from pyspark.sql import Row
@@ -575,6 +582,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -1403,6 +2355,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -1411,6 +2368,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -1429,10 +2402,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -1459,6 +2446,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sources/zoho_crm/_generated_zoho_crm_python_source.py
+++ b/src/databricks/labs/community_connector/sources/zoho_crm/_generated_zoho_crm_python_source.py
@@ -1108,6 +1108,10 @@ def register_lakeflow_source(spark):
         def pull(self, connector, options):
             del options
             for op in _resolve_operation_catalog(connector).values():
+                # Don't advertise list_operations itself — a caller already has to
+                # invoke it to get here, so listing it adds no discovery value.
+                if op.name == OP_LIST_OPERATIONS:
+                    continue
                 yield {
                     "name": op.name,
                     "description": op.description,

--- a/src/databricks/labs/community_connector/sources/zoho_crm/_generated_zoho_crm_python_source.py
+++ b/src/databricks/labs/community_connector/sources/zoho_crm/_generated_zoho_crm_python_source.py
@@ -5,14 +5,19 @@
 # Do not edit manually. Make changes to the source files instead.
 # ==============================================================================
 
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import (
     Any,
+    Iterable,
     Iterator,
+    Mapping,
     Optional,
     Sequence,
+    Tuple,
 )
 import json
 import re
@@ -594,6 +599,951 @@ def register_lakeflow_source(spark):
                 framework from the namespace the caller already supplied, so
                 the connector does not need to echo it back.
             """
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/agent_protocol.py
+    ########################################################
+
+    class ErrorCode:
+        """Canonical error codes for ``_meta.code``.
+
+        Use one of these strings when raising :class:`AgentError` from an
+        :class:`AgentOperation`. The framework defaults to ``internal_error``
+        for uncategorised exceptions and ``bad_request`` for its own
+        detected option errors.
+
+        ``CONNECTION_FAILED`` is the conventional code that
+        :class:`ValidateConnectionOp` implementations raise on a failed
+        health check — keep it consistent across sources so agents can
+        dispatch on it.
+        """
+
+        AUTH_FAILED = "auth_failed"
+        NOT_FOUND = "not_found"
+        PERMISSION_DENIED = "permission_denied"
+        RATE_LIMITED = "rate_limited"
+        BAD_REQUEST = "bad_request"
+        UNSUPPORTED = "unsupported"
+        INTERNAL_ERROR = "internal_error"
+        CONNECTION_FAILED = "connection_failed"
+
+
+    class AgentError(Exception):
+        """Connector-raised error with a canonical agent error code.
+
+        Raise from :meth:`AgentOperation.pull` to communicate a typed error
+        code to the agent. The framework populates ``_meta.code`` from
+        ``self.code`` and ``_meta.message`` from the exception message.
+
+        Args:
+            code: One of the :class:`ErrorCode` constants.
+            message: Human-readable detail; falls back to ``code`` if empty.
+        """
+
+        def __init__(self, code: str, message: str = ""):
+            self.code = code
+            super().__init__(message or code)
+
+
+    @dataclass(frozen=True)
+    class Parameter:
+        """Typed declaration of an :class:`AgentOperation` input option.
+
+        Exposed via ``list_operations.parameters_json`` so agents can plan
+        calls without reading source code. The framework validates required
+        parameters before invoking the op.
+
+        Attributes:
+            name: The option key callers pass on the Spark options dict.
+            type: One of ``"string"``, ``"integer"``, ``"boolean"``, ``"json"``.
+                Spark options arrive as strings; the op is responsible for
+                parsing per the declared type. ``"json"`` indicates the
+                value is a JSON-encoded list/dict packed into the
+                string-typed option.
+            description: One-line text shown to the agent planner.
+            required: If True, the framework rejects calls missing this key
+                with ``bad_request`` before invoking the op.
+            default: Default value when the key is absent. Type-erased; the
+                op interprets it.
+            enum: If set, the value must be one of these strings.
+        """
+
+        name: str
+        type: str = "string"
+        description: str = ""
+        required: bool = False
+        default: Optional[Any] = None
+        enum: Optional[tuple[str, ...]] = None
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    ########################################################
+
+    _VALID_KINDS = frozenset({"metadata", "data"})
+
+
+    class AgentOperation(ABC):
+        """One operation the ingestion agent can dispatch.
+
+        Set :attr:`name`, :attr:`description`, :attr:`kind`, and either
+        :attr:`schema` or :meth:`resolve_schema`; implement :meth:`pull`.
+
+        ``kind = "metadata"`` auto-appends a ``_meta`` column and converts
+        ``pull`` exceptions into a single error row. ``kind = "data"``
+        passes rows through unchanged and lets exceptions propagate.
+        """
+
+        name: str = ""
+        description: str = ""
+        kind: str = "metadata"
+        schema: Optional[StructType] = None
+        #: Typed declaration of accepted input options. Exposed via
+        #: ``list_operations.parameters_json`` so agents can plan calls.
+        #: The framework validates required parameters before invoking
+        #: ``pull``; undeclared options pass through untouched.
+        parameters: Tuple[Parameter, ...] = ()
+
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            if getattr(cls, "__abstractmethods__", None):
+                return
+            if not isinstance(cls.name, str) or not cls.name:
+                raise TypeError(f"{cls.__name__} must set a non-empty `name`.")
+            if cls.kind not in _VALID_KINDS:
+                raise TypeError(
+                    f"{cls.__name__}.kind must be one of "
+                    f"{sorted(_VALID_KINDS)}, got {cls.kind!r}."
+                )
+
+        def resolve_schema(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> StructType:
+            """Return the result schema. Override for option-dependent schemas."""
+            del connector, options
+            if self.schema is None:
+                raise NotImplementedError(
+                    f"{type(self).__name__} must set `schema` or override "
+                    f"`resolve_schema`."
+                )
+            return self.schema
+
+        @abstractmethod
+        def pull(
+            self, connector: Any, options: Mapping[str, str]
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield result rows as dicts."""
+
+
+    class SupportsIngestionAgent:
+        """Connector mixin: contribute :class:`AgentOperation` instances."""
+
+        def agent_operations(self) -> Mapping[str, AgentOperation]:
+            """Return ``{name: AgentOperation}``.
+
+            Entries whose name matches a built-in replace the framework
+            default for this connector.
+            """
+            return {}
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    ########################################################
+
+    OPERATION = "operation"
+    SEARCH = "search"
+    PATH = "path"
+    NAME = "name"
+    METADATA_KEY = "metadataKey"
+    TABLE_NAME = "tableName"
+    CATALOG_NAME = "catalogName"
+    SCHEMA_NAME = "schemaName"
+
+    # Built-in operation names exposed for callers and tests.
+    OP_LIST_OBJECTS = "list_objects"
+    OP_READ_TABLE = "read_table"
+    OP_GET_OBJECT_METADATA = "get_object_metadata"
+    OP_VALIDATE_CONNECTION = "validate_connection"
+    OP_LIST_OPERATIONS = "list_operations"
+
+    # Operation kinds.
+    KIND_METADATA = "metadata"
+    KIND_DATA = "data"
+
+    # Operations that can dispatch even when the connector failed to build
+    # (e.g. bad creds). Today this is only `list_operations` — it can yield
+    # the framework's built-in catalog without touching the connector.
+    _CONNECTOR_OPTIONAL_OPS = frozenset({OP_LIST_OPERATIONS})
+
+
+    def _requires_connector(op: AgentOperation) -> bool:
+        return op.name not in _CONNECTOR_OPTIONAL_OPS
+
+    # Reserved keys the agent layer owns. Stripped from the dict passed into
+    # LakeflowConnect.__init__ so the connector can't accidentally interpret an
+    # agent option as one of its own. The user's request options keep these
+    # keys; ops read them via the AgentOperation.pull options dict.
+    _AGENT_RESERVED_KEYS = frozenset(
+        {OPERATION, SEARCH, PATH, NAME, METADATA_KEY}
+    )
+
+
+    def _agent_options(options: Mapping[str, str]) -> dict:
+        """Options visible to ``AgentOperation.pull`` / ``resolve_schema``.
+
+        Strips only the framework-owned ``operation`` key.
+        """
+        return {k: v for k, v in options.items() if k != OPERATION}
+
+
+    def _connector_options(options: Mapping[str, str]) -> dict:
+        """Options passed to ``LakeflowConnect.__init__`` and to read-side calls
+        (``read_table``, ``get_table_schema``, ``read_table_metadata``).
+
+        Strips ``operation`` plus the agent-reserved keys so the connector sees
+        only its own option namespace.
+        """
+        return {k: v for k, v in options.items() if k not in _AGENT_RESERVED_KEYS}
+
+
+    # ---------------------------------------------------------------------------
+    # Schemas
+    # ---------------------------------------------------------------------------
+
+    _META_STRUCT = StructType(
+        [
+            StructField("status", StringType(), False),
+            StructField("code", StringType(), True),
+            StructField("message", StringType(), True),
+        ]
+    )
+
+
+    def _meta_field(nullable: bool) -> StructField:
+        return StructField("_meta", _META_STRUCT, nullable)
+
+
+    _LIST_OBJECTS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), True),
+            StructField("type", StringType(), True),
+            StructField("full_path", StringType(), True),
+        ]
+    )
+
+    _GET_OBJECT_METADATA_BASE_SCHEMA = StructType(
+        [
+            StructField("key", StringType(), True),
+            StructField("value", StringType(), True),
+        ]
+    )
+
+    _VALIDATE_CONNECTION_BASE_SCHEMA = StructType([])
+
+    _LIST_OPERATIONS_BASE_SCHEMA = StructType(
+        [
+            StructField("name", StringType(), False),
+            StructField("description", StringType(), True),
+            StructField("kind", StringType(), True),
+            StructField("result_schema_json", StringType(), True),
+            StructField("parameters_json", StringType(), True),
+        ]
+    )
+
+
+    def _meta(
+        status: str = "ok",
+        code: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> dict:
+        return {"status": status, "code": code, "message": message}
+
+
+    def _error_str(exc: BaseException) -> str:
+        return f"{type(exc).__name__}: {exc}"
+
+
+    # ---------------------------------------------------------------------------
+    # Built-in AgentOperation subclasses.
+    #
+    # Each fixes ``name``, ``description``, ``kind``, ``schema`` and ``pull``.
+    # ``pull`` parses the request options into typed kwargs and delegates to
+    # ``produce`` — the single override point for sources that want a richer
+    # implementation. ``produce`` is the only method a source customising a
+    # built-in should override.
+    # ---------------------------------------------------------------------------
+
+    class ListObjectsOp(AgentOperation):
+        """Built-in: hierarchical listing of objects under an optional parent."""
+
+        name = OP_LIST_OBJECTS
+        description = (
+            "Hierarchical listing of objects. Returns rows of (name, type, full_path). "
+            "`type` is source-defined; conventional values are `schema` / `table` / "
+            "`view` / `synonym`."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OBJECTS_BASE_SCHEMA
+        parameters = (
+            Parameter(
+                name=PATH,
+                description="Parent path to list under. Empty / missing = top level. "
+                "Format is source-defined.",
+            ),
+            Parameter(
+                name=SEARCH,
+                description="Regex filter applied to result names.",
+            ),
+        )
+
+        def pull(self, connector, options):
+            path = options.get(PATH) or None
+            search = options.get(SEARCH) or None
+            return self.produce(connector, path=path, search=search)
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            search: Optional[str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield rows of ``(name, type, full_path)``.
+
+            Default flat listing derived from ``list_tables``. Override to
+            return hierarchical results or to bind to a source-native
+            listing API.
+            """
+            return _default_list_objects(connector, path, search)
+
+
+    class GetObjectMetadataOp(AgentOperation):
+        """Built-in: per-object metadata as ``(key, value)`` rows.
+
+        Conventional keys (sources are free to add more, but using these
+        for the shared concerns keeps results consistent across sources):
+
+        - ``primary_key`` — comma-joined ordered column list of the PK.
+        - ``table_size`` — source-reported size in bytes (string-encoded).
+        - ``index_columns`` — JSON array of ordered column lists, one per
+          index, e.g. ``[["id"], ["first_name", "last_name"]]``.
+
+        The framework applies the ``metadataKey`` filter case-insensitively
+        after ``produce`` emits, so sources don't need to handle it.
+        """
+
+        name = OP_GET_OBJECT_METADATA
+        description = "Per-object metadata as (key, value) rows."
+        kind = KIND_METADATA
+        schema = _GET_OBJECT_METADATA_BASE_SCHEMA
+        parameters = (
+            Parameter(name=NAME, required=True, description="Object name to describe."),
+            Parameter(
+                name=PATH,
+                description="Parent path of the target object (source-defined).",
+            ),
+            Parameter(
+                name=METADATA_KEY,
+                description=(
+                    "Case-insensitive filter; if set, only rows whose `key` "
+                    "matches are returned."
+                ),
+            ),
+        )
+
+        def pull(self, connector, options):
+            name = options[NAME]  # framework validated required.
+            path = options.get(PATH) or None
+            rows = self.produce(
+                connector,
+                path=path,
+                name=name,
+                table_options=_connector_options(options),
+            )
+            key_filter = options.get(METADATA_KEY)
+            if key_filter:
+                needle = key_filter.lower()
+                rows = (r for r in rows if str(r.get("key", "")).lower() == needle)
+            return rows
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            path: Optional[str],
+            name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield ``(key, value)`` rows describing the named object.
+
+            Default flattens ``read_table_metadata`` and maps connector
+            keys to the standard ingestion-agent vocabulary
+            (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+            ``cursor_field``).
+            """
+            del path
+            return _default_get_object_metadata(
+                connector,
+                table_name=name,
+                table_options=table_options,
+            )
+
+
+    class ReadTableOp(AgentOperation):
+        """Built-in: read a tabular object in its native schema.
+
+        Data-kind — rows pass through with the table's natural schema (no
+        ``_meta`` column) and errors surface as Spark exceptions. The
+        operation does not enforce a row cap of its own; callers wanting
+        a sample chain ``.limit(N)`` on the resulting DataFrame.
+
+        Override :meth:`produce` to wire to a source-native read path.
+        """
+
+        name = OP_READ_TABLE
+        description = "Read a tabular object. Returns the table's natural schema and rows."
+        kind = KIND_DATA
+        parameters = (
+            Parameter(name=TABLE_NAME, required=True, description="Target object name."),
+            Parameter(
+                name=SCHEMA_NAME,
+                description="Schema within the parent path (source-defined).",
+            ),
+            Parameter(
+                name=CATALOG_NAME,
+                description=(
+                    "Top-level catalog (source-defined). Two-level sources should "
+                    "reject this rather than silently dropping it."
+                ),
+            ),
+        )
+
+        def resolve_schema(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return connector.get_table_schema(table_name, _connector_options(options))
+
+        def pull(self, connector, options):
+            table_name = options[TABLE_NAME]
+            return self.produce(
+                connector,
+                table_name=table_name,
+                table_options=_connector_options(options),
+            )
+
+        def produce(
+            self,
+            connector: LakeflowConnect,
+            *,
+            table_name: str,
+            table_options: Mapping[str, str],
+        ) -> Iterable[Mapping[str, Any]]:
+            """Yield records from ``table_name``.
+
+            Default reads through ``LakeflowConnect.read_table``. Override
+            to bind to a source-native scan.
+            """
+            return _default_read_records(connector, table_name, table_options)
+
+
+    class ValidateConnectionOp(AgentOperation):
+        """Built-in: connection-level health check.
+
+        Returns one row with the standard ``_meta`` struct. Override
+        :meth:`produce` to use a source-native ping; the default attempts
+        ``connector.list_tables()`` and reports any raised exception.
+
+        Sources reporting a failed health check should raise
+        ``AgentError(ErrorCode.CONNECTION_FAILED, ...)`` rather than the
+        generic ``internal_error`` so consumers can dispatch on a dedicated
+        code.
+        """
+
+        name = OP_VALIDATE_CONNECTION
+        description = (
+            "Connection-level health check. Returns one row with _meta only."
+        )
+        kind = KIND_METADATA
+        schema = _VALIDATE_CONNECTION_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            return [{"_meta": _normalize_meta(self.produce(connector))}]
+
+        def produce(self, connector: LakeflowConnect) -> Mapping[str, Optional[str]]:
+            """Return ``{status, code, message}`` for the connection.
+
+            Default: try ``list_tables``; report exceptions as
+            ``connection_failed``.
+            """
+            try:
+                connector.list_tables()
+            except Exception as exc:  # pylint: disable=broad-except
+                return _meta(
+                    status="error",
+                    code=ErrorCode.CONNECTION_FAILED,
+                    message=_error_str(exc),
+                )
+            return _meta(status="ok")
+
+
+    class ListOperationsOp(AgentOperation):
+        """Built-in: list operations supported by this connection.
+
+        Framework-owned. Runs even when the connector failed to build —
+        returns the framework's built-in catalog, minus any source-defined
+        operations the connector would have contributed. Each row carries
+        the schema and parameter metadata an agent needs to plan a call.
+        """
+
+        name = OP_LIST_OPERATIONS
+        description = (
+            "List operations supported by this connection, with their "
+            "parameter declarations and result schemas."
+        )
+        kind = KIND_METADATA
+        schema = _LIST_OPERATIONS_BASE_SCHEMA
+
+        def pull(self, connector, options):
+            del options
+            for op in _resolve_operation_catalog(connector).values():
+                yield {
+                    "name": op.name,
+                    "description": op.description,
+                    "kind": op.kind,
+                    "result_schema_json": op.schema.json() if op.schema is not None else None,
+                    "parameters_json": _parameters_to_json(getattr(op, "parameters", ())),
+                }
+
+
+    # Ordered map of built-in operations. Source-defined operations with the same
+    # name replace these (see :func:`_resolve_operation_catalog`).
+    _BUILTIN_OPERATIONS: dict[str, AgentOperation] = {
+        op.name: op
+        for op in (
+            ListObjectsOp(),
+            ReadTableOp(),
+            GetObjectMetadataOp(),
+            ValidateConnectionOp(),
+            ListOperationsOp(),
+        )
+    }
+
+
+    # ---------------------------------------------------------------------------
+    # Dispatcher (plain class, not a DataSource)
+    # ---------------------------------------------------------------------------
+
+    # pylint: disable=invalid-name,missing-function-docstring
+    class IngestionAgentDispatcher:
+        """Dispatches ingestion-agent operations onto a pre-built connector.
+
+        Constructed by :class:`LakeflowSource` when the ``operation`` option
+        is set. The connector is built by ``LakeflowSource`` and passed in
+        — the dispatcher never instantiates it itself.
+
+        - ``schema()`` resolves the operation and asks it for its schema.
+          Metadata-kind ops automatically include a ``_meta`` column;
+          data-kind ops return the schema unchanged.
+        - ``reader()`` returns an :class:`IngestionAgentReader` that
+          applies ``_meta`` defaults and converts errors to a single
+          error row (metadata kind) or lets them propagate (data kind).
+
+        Init-error policy: when the connector failed to build, ``connector``
+        is ``None`` and ``init_error`` holds the exception. The reader uses
+        the operation's :attr:`AgentOperation.requires_connector` flag —
+        ops that don't need a connector (e.g. ``list_operations``) still
+        run; metadata-kind ops that do need one emit an error row;
+        data-kind ops re-raise.
+        """
+
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException] = None,
+        ) -> None:
+            self.options = dict(options)
+            self.connector = connector
+            self.init_error = init_error
+            self.operation_name = self.options.get(OPERATION)
+            if not self.operation_name:
+                raise ValueError(
+                    f"ingestion-agent dispatch requires an '{OPERATION}' option."
+                )
+            self.operation = _resolve_operation(connector, self.operation_name)
+
+        def schema(self) -> StructType:
+            if self.operation is None:
+                raise ValueError(
+                    f"Unknown ingestion-agent operation: {self.operation_name}"
+                )
+            # If the connector failed to init and the op needs it, we can't
+            # safely call resolve_schema (it may dereference the connector).
+            # Fall back to the op's static `schema` attribute and rely on the
+            # reader to emit an error row. Data-kind ops in this state can't
+            # produce a valid schema at all, so we raise the init error.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                base = self.operation.schema or StructType([])
+            else:
+                # Data-kind ops compute their schema from request options
+                # (e.g. preview_table needs `tableName`). Validate required
+                # parameters now so resolve_schema doesn't trip over missing
+                # keys. Metadata-kind ops use a static schema; their parameter
+                # validation runs at read time and surfaces as an error row.
+                if self.operation.kind == KIND_DATA:
+                    _validate_required_parameters(self.operation, self.options)
+                base = self.operation.resolve_schema(self.connector, self.options)
+            if self.operation.kind == KIND_METADATA:
+                # Metadata-kind ops emit a single error row carrying only _meta
+                # when pull() raises. Relax data-column nullability so that
+                # error row validates against the schema.
+                return _ensure_meta_field(_relax_nullability(base))
+            return base
+
+        def reader(self, schema: StructType) -> "IngestionAgentReader":
+            return IngestionAgentReader(
+                options=self.options,
+                schema=schema,
+                operation=self.operation,
+                operation_name=self.operation_name,
+                connector=self.connector,
+                init_error=self.init_error,
+            )
+
+
+    # ---------------------------------------------------------------------------
+    # Reader
+    # ---------------------------------------------------------------------------
+
+    class IngestionAgentReader(DataSourceReader):
+        def __init__(
+            self,
+            options: Mapping[str, str],
+            schema: StructType,
+            operation: Optional[AgentOperation],
+            operation_name: str,
+            connector: Optional[LakeflowConnect],
+            init_error: Optional[BaseException],
+        ) -> None:
+            self.options = dict(options)
+            self.schema = schema
+            self.operation = operation
+            self.operation_name = operation_name
+            self.connector = connector
+            self.init_error = init_error
+
+        def partitions(self):
+            # All ingestion-agent operations are small, single-partition reads.
+            return [InputPartition(None)]
+
+        def read(self, _partition):
+            if self.operation is None:
+                yield from self._yield_error_rows(
+                    ValueError(
+                        f"Unknown ingestion-agent operation: {self.operation_name}"
+                    )
+                )
+                return
+
+            # If the connector failed and this op needs it, route by kind:
+            # metadata-kind → error row, data-kind → re-raise. validate_connection
+            # treats the init failure as the health-check answer and uses the
+            # canonical CONNECTION_FAILED code.
+            if self.init_error is not None and _requires_connector(self.operation):
+                if self.operation.kind == KIND_DATA:
+                    raise self.init_error
+                if self.operation.name == OP_VALIDATE_CONNECTION:
+                    yield from self._yield_error_rows(
+                        self.init_error, code=ErrorCode.CONNECTION_FAILED
+                    )
+                else:
+                    yield from self._yield_error_rows(self.init_error)
+                return
+
+            request_options = _agent_options(self.options)
+
+            if self.operation.kind == KIND_DATA:
+                # Data-kind ops surface exceptions as Spark exceptions and don't
+                # carry a _meta column.
+                for record in self.operation.pull(self.connector, request_options):
+                    yield parse_value(record, self.schema)
+                return
+
+            # Metadata-kind: framework wraps pull() exceptions into a single
+            # error row and setdefaults _meta on every row to {status: ok}.
+            try:
+                _validate_required_parameters(self.operation, request_options)
+                rows = self.operation.pull(self.connector, request_options)
+                # Materialise so generator-time errors are caught and converted to
+                # a single error row instead of escaping mid-iteration. Acceptable
+                # because all metadata ops produce small results.
+                rows = list(rows) if not isinstance(rows, list) else rows
+            except Exception as exc:  # pylint: disable=broad-except
+                rows = [self._error_row(exc)]
+            for row in rows:
+                yield parse_value(_with_default_meta(row), self.schema)
+
+        def _yield_error_rows(
+            self, exc: BaseException, code: Optional[str] = None
+        ):
+            yield parse_value(
+                _with_default_meta(self._error_row(exc, code=code)), self.schema
+            )
+
+        def _error_row(
+            self, exc: BaseException, code: Optional[str] = None
+        ) -> dict:
+            if code is None:
+                if isinstance(exc, AgentError):
+                    code = exc.code
+                elif isinstance(exc, ValueError):
+                    # Framework-detected input errors (legacy code paths still raise
+                    # ValueError for missing options).
+                    code = ErrorCode.BAD_REQUEST
+                else:
+                    code = ErrorCode.INTERNAL_ERROR
+            if isinstance(exc, (AgentError, ValueError)):
+                message = str(exc)
+            else:
+                message = _error_str(exc)
+            return {"_meta": _meta(status="error", code=code, message=message)}
+
+
+    # ---------------------------------------------------------------------------
+    # Operation catalog
+    # ---------------------------------------------------------------------------
+
+    def _source_operations(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        if not isinstance(connector, SupportsIngestionAgent):
+            return {}
+        try:
+            ops = connector.agent_operations()
+        except Exception:  # pylint: disable=broad-except
+            return {}
+        if not ops:
+            return {}
+        out: dict[str, AgentOperation] = {}
+        for op_name, op in ops.items():
+            if not isinstance(op, AgentOperation):
+                raise TypeError(
+                    f"agent_operations()[{op_name!r}] must be an AgentOperation "
+                    f"instance, got {type(op).__name__}."
+                )
+            out[op_name] = op
+        return out
+
+
+    def _resolve_operation_catalog(
+        connector: Optional[LakeflowConnect],
+    ) -> Mapping[str, AgentOperation]:
+        """Built-ins plus source-defined operations.
+
+        Source-defined entries replace built-ins with the same name. Ordering:
+        built-ins first (canonical order), then any new source-defined
+        operations (sorted by name for determinism).
+        """
+        source_ops = _source_operations(connector)
+        catalog: dict[str, AgentOperation] = {}
+        for name, op in _BUILTIN_OPERATIONS.items():
+            catalog[name] = source_ops.get(name, op)
+        extras = {n: o for n, o in source_ops.items() if n not in _BUILTIN_OPERATIONS}
+        for name in sorted(extras):
+            catalog[name] = extras[name]
+        return catalog
+
+
+    def _resolve_operation(
+        connector: Optional[LakeflowConnect], operation_name: str
+    ) -> Optional[AgentOperation]:
+        return _resolve_operation_catalog(connector).get(operation_name)
+
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _required_option(
+        options: Mapping[str, str], key: str, operation: str
+    ) -> str:
+        value = options.get(key)
+        if not value:
+            raise AgentError(
+                ErrorCode.BAD_REQUEST,
+                f"Operation '{operation}' requires option '{key}'.",
+            )
+        return value
+
+
+    def _validate_required_parameters(
+        op: AgentOperation, options: Mapping[str, str]
+    ) -> None:
+        """Reject calls missing a required :class:`Parameter`.
+
+        Raises :class:`AgentError` with ``bad_request`` when a required
+        parameter is absent. Called by the dispatcher before
+        ``resolve_schema`` (data-kind) and before ``pull`` (metadata-kind),
+        so ops can rely on declared required inputs being present.
+        """
+        for param in getattr(op, "parameters", ()):
+            if param.required and not options.get(param.name):
+                raise AgentError(
+                    ErrorCode.BAD_REQUEST,
+                    f"Operation '{op.name}' requires option '{param.name}'.",
+                )
+
+
+    def _parameters_to_json(params: Iterable[Parameter]) -> str:
+        """JSON-serialise a tuple of :class:`Parameter` declarations.
+
+        Surfaced by ``list_operations.parameters_json`` so agents can plan
+        calls. Fields with ``None`` default / enum are kept in the JSON for
+        a stable schema.
+        """
+        return json.dumps(
+            [
+                {
+                    "name": p.name,
+                    "type": p.type,
+                    "description": p.description,
+                    "required": p.required,
+                    "default": p.default,
+                    "enum": list(p.enum) if p.enum else None,
+                }
+                for p in params
+            ]
+        )
+
+
+    def _with_default_meta(row: Mapping[str, Any]) -> dict:
+        out = dict(row)
+        out.setdefault("_meta", _meta(status="ok"))
+        return out
+
+
+    def _normalize_meta(value: Any) -> dict:
+        if value is None:
+            return _meta(status="ok")
+        if isinstance(value, Mapping):
+            return {
+                "status": str(value.get("status", "ok")),
+                "code": _str_or_none(value.get("code")),
+                "message": _str_or_none(value.get("message")),
+            }
+        raise TypeError(
+            f"validate_connection produce() must return a mapping, "
+            f"got {type(value).__name__}."
+        )
+
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+
+    def _ensure_meta_field(schema: StructType) -> StructType:
+        if any(f.name == "_meta" for f in schema.fields):
+            return schema
+        return StructType(list(schema.fields) + [_meta_field(nullable=True)])
+
+
+    def _relax_nullability(schema: StructType) -> StructType:
+        """Return a copy of ``schema`` with every non-``_meta`` field nullable.
+
+        Used for metadata-kind operations so the framework's error row (which
+        carries only ``_meta``) parses cleanly even when the operation
+        declared its data columns as non-nullable.
+        """
+        return StructType(
+            [
+                StructField(f.name, f.dataType, True, f.metadata)
+                if f.name != "_meta"
+                else f
+                for f in schema.fields
+            ]
+        )
+
+
+    # ---------------------------------------------------------------------------
+    # Default implementations of the built-in operations
+    # ---------------------------------------------------------------------------
+
+    def _default_list_objects(
+        connector: LakeflowConnect,
+        parent: Optional[str],
+        search: Optional[str],
+    ) -> Iterator[dict]:
+        """Flat listing of ``list_tables()`` — every table at the source root."""
+        if parent:
+            # The default connector has no hierarchy. A non-empty parent that
+            # isn't the source root is treated as "no children" rather than an
+            # error so the agent can probe paths without crashing.
+            return iter([])
+        pattern = re.compile(search) if search else None
+        return (
+            {"name": name, "type": "table", "full_path": name}
+            for name in connector.list_tables()
+            if pattern is None or pattern.search(name)
+        )
+
+
+    def _default_get_object_metadata(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[dict]:
+        """Flatten ``read_table_metadata`` into ``(key, value)`` rows.
+
+        Maps the connector's metadata keys to the standardised ingestion-agent
+        keys (``primary_key`` from ``primary_keys``, ``cursor_column`` from
+        ``cursor_field``) and preserves the others verbatim. The framework
+        applies the ``metadataKey`` filter case-insensitively above this.
+        """
+        raw = connector.read_table_metadata(table_name, table_options)
+
+        standardized: list[Tuple[str, Any]] = []
+        if "primary_keys" in raw:
+            standardized.append(("primary_key", raw["primary_keys"]))
+        if "cursor_field" in raw:
+            standardized.append(("cursor_column", raw["cursor_field"]))
+        if "ingestion_type" in raw:
+            standardized.append(("ingestion_type", raw["ingestion_type"]))
+        seen = {"primary_keys", "cursor_field", "ingestion_type"}
+        for key, value in raw.items():
+            if key in seen:
+                continue
+            standardized.append((key, value))
+
+        return ({"key": k, "value": _to_str_value(v)} for k, v in standardized)
+
+
+    def _default_read_records(
+        connector: LakeflowConnect,
+        table_name: str,
+        table_options: Mapping[str, str],
+    ) -> Iterator[Mapping[str, Any]]:
+        """Pull all records from ``connector.read_table`` and yield them."""
+        records, _offset = connector.read_table(table_name, None, dict(table_options))
+        return records
+
+
+    def _to_str_value(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple, dict, set)):
+            try:
+                return json.dumps(list(value) if isinstance(value, set) else value)
+            except (TypeError, ValueError):
+                return str(value)
+        return str(value)
 
 
     ########################################################
@@ -2439,6 +3389,11 @@ def register_lakeflow_source(spark):
         # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
         _lakeflow_connect_cls = None
 
+        # Set per-instance in __init__ when the ``operation`` option is present.
+        # Declared at class level so code paths that construct the source without
+        # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+        _agent_dispatcher = None
+
         # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
         # connection-option injection looks for that exact string. A per-source
         # subclass may override this with its source name once it no longer relies
@@ -2447,6 +3402,22 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options):
             self.options = options
+
+            # Ingestion-agent dispatch: when the ``operation`` option is present,
+            # this source serves an agent operation (search_messages,
+            # list_operations, ...) instead of a table read — so ``tableName`` is
+            # not required. The connector is built tolerantly: connector-optional
+            # ops (e.g. ``list_operations``) still run when credentials are
+            # missing, and the dispatcher converts a build failure into an error
+            # row for metadata-kind ops.
+            self._agent_dispatcher = None
+            if options.get(OPERATION):
+                connector, init_error = self._build_connector_tolerant(options)
+                self._agent_dispatcher = IngestionAgentDispatcher(
+                    options, connector=connector, init_error=init_error
+                )
+                return
+
             table = options.get(TABLE_NAME)
             # Catch typos against the framework's reserved virtual-table namespace
             # early — falling through to the connector with an unknown
@@ -2465,10 +3436,24 @@ def register_lakeflow_source(spark):
             self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
+        def _build_connector_tolerant(cls, options):
+            """Build the connector for an agent operation, returning
+            ``(connector, init_error)``. A construction failure (e.g. missing
+            credentials) is captured rather than raised so connector-optional
+            operations still work and the dispatcher can emit a typed error row."""
+            connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+            try:
+                return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+            except Exception as exc:  # pylint: disable=broad-except
+                return None, exc
+
+        @classmethod
         def name(cls):
             return cls._format_name
 
         def schema(self):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.schema()
             table = self.options[TABLE_NAME]
             if table == METADATA_TABLE:
                 return StructType(
@@ -2495,6 +3480,8 @@ def register_lakeflow_source(spark):
             return self.lakeflow_connect.get_table_schema(table, self.options)
 
         def reader(self, schema: StructType):
+            if self._agent_dispatcher is not None:
+                return self._agent_dispatcher.reader(schema)
             return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
         def streamReader(self, schema: StructType):

--- a/src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+++ b/src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
@@ -413,6 +413,10 @@ class ListOperationsOp(AgentOperation):
     def pull(self, connector, options):
         del options
         for op in _resolve_operation_catalog(connector).values():
+            # Don't advertise list_operations itself — a caller already has to
+            # invoke it to get here, so listing it adds no discovery value.
+            if op.name == OP_LIST_OPERATIONS:
+                continue
             yield {
                 "name": op.name,
                 "description": op.description,

--- a/src/databricks/labs/community_connector/sparkpds/lakeflow_datasource.py
+++ b/src/databricks/labs/community_connector/sparkpds/lakeflow_datasource.py
@@ -19,6 +19,10 @@ from databricks.labs.community_connector.interface import (
     SupportsPartitionedStream,
 )
 from databricks.labs.community_connector.libs.utils import parse_value
+from databricks.labs.community_connector.sparkpds.ingestion_agent_datasource import (
+    IngestionAgentDispatcher,
+    OPERATION,
+)
 
 
 # =============================================================================
@@ -336,6 +340,11 @@ class LakeflowSource(DataSource):
     # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
     _lakeflow_connect_cls = None
 
+    # Set per-instance in __init__ when the ``operation`` option is present.
+    # Declared at class level so code paths that construct the source without
+    # __init__ (e.g. virtual-table unit tests via __new__) still see ``None``.
+    _agent_dispatcher = None
+
     # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
     # connection-option injection looks for that exact string. A per-source
     # subclass may override this with its source name once it no longer relies
@@ -344,6 +353,22 @@ class LakeflowSource(DataSource):
 
     def __init__(self, options):
         self.options = options
+
+        # Ingestion-agent dispatch: when the ``operation`` option is present,
+        # this source serves an agent operation (search_messages,
+        # list_operations, ...) instead of a table read — so ``tableName`` is
+        # not required. The connector is built tolerantly: connector-optional
+        # ops (e.g. ``list_operations``) still run when credentials are
+        # missing, and the dispatcher converts a build failure into an error
+        # row for metadata-kind ops.
+        self._agent_dispatcher = None
+        if options.get(OPERATION):
+            connector, init_error = self._build_connector_tolerant(options)
+            self._agent_dispatcher = IngestionAgentDispatcher(
+                options, connector=connector, init_error=init_error
+            )
+            return
+
         table = options.get(TABLE_NAME)
         # Catch typos against the framework's reserved virtual-table namespace
         # early — falling through to the connector with an unknown
@@ -362,10 +387,24 @@ class LakeflowSource(DataSource):
         self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
     @classmethod
+    def _build_connector_tolerant(cls, options):
+        """Build the connector for an agent operation, returning
+        ``(connector, init_error)``. A construction failure (e.g. missing
+        credentials) is captured rather than raised so connector-optional
+        operations still work and the dispatcher can emit a typed error row."""
+        connect_cls = cls._lakeflow_connect_cls or LakeflowConnectImpl
+        try:
+            return connect_cls(options), None  # pylint: disable=abstract-class-instantiated
+        except Exception as exc:  # pylint: disable=broad-except
+            return None, exc
+
+    @classmethod
     def name(cls):
         return cls._format_name
 
     def schema(self):
+        if self._agent_dispatcher is not None:
+            return self._agent_dispatcher.schema()
         table = self.options[TABLE_NAME]
         if table == METADATA_TABLE:
             return StructType(
@@ -392,6 +431,8 @@ class LakeflowSource(DataSource):
         return self.lakeflow_connect.get_table_schema(table, self.options)
 
     def reader(self, schema: StructType):
+        if self._agent_dispatcher is not None:
+            return self._agent_dispatcher.reader(schema)
         return LakeflowBatchReader(self.options, schema, self.lakeflow_connect)
 
     def streamReader(self, schema: StructType):

--- a/tests/unit/sources/gmail/test_gmail_agent_ops.py
+++ b/tests/unit/sources/gmail/test_gmail_agent_ops.py
@@ -262,6 +262,10 @@ def test_search_messages_typed_filters_drive_listing_q(connector, monkeypatch):
     def fake_make_request(self, method, path, params=None, **_):
         requests_log.append((method, path, dict(params or {})))
         if path.endswith("/messages"):
+            # The companion has:attachment search returns only m1; the main
+            # list returns both. has_attachment is derived from that intersect.
+            if "has:attachment" in (params or {}).get("q", ""):
+                return {"messages": [{"id": "m1"}]}
             return {"messages": [{"id": "m1"}, {"id": "m2"}]}
         return None
 
@@ -911,50 +915,35 @@ def test_mailbox_overview_returns_per_label_counts(connector, monkeypatch):
     assert by_id["Label_1"]["threads_total"] == 25
 
 
-def test_search_messages_has_attachment_under_metadata_format(connector, monkeypatch):
-    """Regression: format=metadata omits body.attachmentId, so has_attachment
-    must be derived from the part filename, not attachmentId."""
+def test_search_messages_has_attachment_via_companion_query(connector, monkeypatch):
+    """Regression: format=metadata returns no MIME part tree, so has_attachment
+    is derived from a companion ``has:attachment`` search, not the payload.
+
+    The metadata payloads below deliberately carry NO part info — proving the
+    flag does not come from the per-message response."""
+    companion_qs: list = []
 
     def fake_make_request(self, method, path, params=None, **_):
         if path.endswith("/messages"):
+            q = (params or {}).get("q", "")
+            if "has:attachment" in q:
+                companion_qs.append(q)
+                return {"messages": [{"id": "m1"}]}  # only m1 has an attachment
             return {"messages": [{"id": "m1"}, {"id": "m2"}]}
         return None
 
     def fake_batch(self, endpoints, params_list=None):
-        # m1: attachment part has a filename but NO attachmentId (metadata shape)
-        with_attach = {
-            "id": "m1",
-            "threadId": "t1",
-            "labelIds": ["INBOX"],
-            "snippet": "has a pdf",
-            "sizeEstimate": 5000,
-            "payload": {
-                "mimeType": "multipart/mixed",
-                "headers": [{"name": "Subject", "value": "report"}],
-                "parts": [
-                    {"mimeType": "text/plain", "body": {"size": 10}},
-                    {
-                        "mimeType": "application/pdf",
-                        "filename": "report.pdf",
-                        "body": {"size": 1024},  # note: no attachmentId
-                    },
-                ],
-            },
-        }
-        # m2: no attachment parts at all
-        without_attach = {
-            "id": "m2",
-            "threadId": "t2",
-            "labelIds": ["INBOX"],
-            "snippet": "plain note",
-            "sizeEstimate": 200,
-            "payload": {
-                "mimeType": "text/plain",
-                "headers": [{"name": "Subject", "value": "note"}],
-                "body": {"size": 20},
-            },
-        }
-        return [with_attach, without_attach]
+        # Metadata-shaped: headers only, no parts/body — can't reveal attachments.
+        return [
+            {"id": "m1", "threadId": "t1", "labelIds": ["INBOX"], "snippet": "report",
+             "sizeEstimate": 5000,
+             "payload": {"mimeType": "text/plain",
+                         "headers": [{"name": "Subject", "value": "report"}]}},
+            {"id": "m2", "threadId": "t2", "labelIds": ["INBOX"], "snippet": "note",
+             "sizeEstimate": 200,
+             "payload": {"mimeType": "text/plain",
+                         "headers": [{"name": "Subject", "value": "note"}]}},
+        ]
 
     monkeypatch.setattr(
         "databricks.labs.community_connector.sources.gmail.gmail_utils."
@@ -969,5 +958,46 @@ def test_search_messages_has_attachment_under_metadata_format(connector, monkeyp
 
     rows = _dispatch("search_messages", connector, query="report")
     by_id = {r["id"]: r for r in rows}
-    assert by_id["m1"]["has_attachment"] == "true"   # filename present, no attachmentId
+    assert by_id["m1"]["has_attachment"] == "true"
     assert by_id["m2"]["has_attachment"] == "false"
+    # The companion query appended has:attachment to the composed q.
+    assert companion_qs and "has:attachment" in companion_qs[0]
+    assert "report" in companion_qs[0]
+
+
+def test_search_messages_skips_companion_query_when_filtering_attachments(connector, monkeypatch):
+    """When the caller already filters has_attachment=true, every match has an
+    attachment — no extra companion query is issued."""
+    message_lists: list = []
+
+    def fake_make_request(self, method, path, params=None, **_):
+        if path.endswith("/messages"):
+            message_lists.append((params or {}).get("q", ""))
+            return {"messages": [{"id": "m1"}, {"id": "m2"}]}
+        return None
+
+    def fake_batch(self, endpoints, params_list=None):
+        return [
+            {"id": "m1", "threadId": "t1", "labelIds": [], "snippet": "a",
+             "payload": {"headers": []}},
+            {"id": "m2", "threadId": "t2", "labelIds": [], "snippet": "b",
+             "payload": {"headers": []}},
+        ]
+
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        fake_make_request,
+    )
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_batch_request",
+        fake_batch,
+    )
+
+    rows = _dispatch("search_messages", connector, has_attachment="true")
+    by_id = {r["id"]: r for r in rows}
+    assert by_id["m1"]["has_attachment"] == "true"
+    assert by_id["m2"]["has_attachment"] == "true"
+    # Exactly one /messages list call — no companion round trip.
+    assert len(message_lists) == 1

--- a/tests/unit/sources/gmail/test_gmail_agent_ops.py
+++ b/tests/unit/sources/gmail/test_gmail_agent_ops.py
@@ -592,6 +592,52 @@ def test_download_attachment_gmail_writes_bytes(connector, tmp_path, monkeypatch
     assert target.read_bytes() == b"hello world"
 
 
+def test_download_attachment_gmail_accepts_directory_volume_path(connector, tmp_path, monkeypatch):
+    """When volume_path is an existing directory, the attachment's own filename
+    is appended (regression: open() on a directory raised IsADirectoryError)."""
+    payload = {
+        "payload": {
+            "headers": [],
+            "parts": [
+                {
+                    "mimeType": "application/pdf",
+                    "filename": "report.pdf",
+                    "body": {"attachmentId": "att1", "size": 5},
+                }
+            ],
+        }
+    }
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        lambda self, method, path, params=None, **_: payload,
+    )
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.get_attachment",
+        lambda self, mid, aid: b"bytes",
+    )
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_agent_ops."
+        "DownloadAttachmentOp._VOLUME_PREFIX",
+        str(tmp_path) + "/",
+    )
+    dest_dir = tmp_path / "temp_files"
+    dest_dir.mkdir()  # volume_path points at this existing directory
+    rows = _dispatch(
+        "download_attachment",
+        connector,
+        volume_path=str(dest_dir),  # a directory, not a file
+        attachment_id="att1",
+        message_id="m1",
+    )
+    assert rows[0]["_meta"]["status"] == "ok"
+    written = dest_dir / "report.pdf"
+    assert written.read_bytes() == b"bytes"
+    assert rows[0]["volume_path"] == str(written)
+    assert rows[0]["filename"] == "report.pdf"
+
+
 def test_download_attachment_drive_streams_and_returns_metadata(
     connector, tmp_path, monkeypatch
 ):

--- a/tests/unit/sources/gmail/test_gmail_agent_ops.py
+++ b/tests/unit/sources/gmail/test_gmail_agent_ops.py
@@ -909,3 +909,65 @@ def test_mailbox_overview_returns_per_label_counts(connector, monkeypatch):
     assert by_id["Label_1"]["name"] == "Work"
     assert by_id["Label_1"]["type"] == "user"
     assert by_id["Label_1"]["threads_total"] == 25
+
+
+def test_search_messages_has_attachment_under_metadata_format(connector, monkeypatch):
+    """Regression: format=metadata omits body.attachmentId, so has_attachment
+    must be derived from the part filename, not attachmentId."""
+
+    def fake_make_request(self, method, path, params=None, **_):
+        if path.endswith("/messages"):
+            return {"messages": [{"id": "m1"}, {"id": "m2"}]}
+        return None
+
+    def fake_batch(self, endpoints, params_list=None):
+        # m1: attachment part has a filename but NO attachmentId (metadata shape)
+        with_attach = {
+            "id": "m1",
+            "threadId": "t1",
+            "labelIds": ["INBOX"],
+            "snippet": "has a pdf",
+            "sizeEstimate": 5000,
+            "payload": {
+                "mimeType": "multipart/mixed",
+                "headers": [{"name": "Subject", "value": "report"}],
+                "parts": [
+                    {"mimeType": "text/plain", "body": {"size": 10}},
+                    {
+                        "mimeType": "application/pdf",
+                        "filename": "report.pdf",
+                        "body": {"size": 1024},  # note: no attachmentId
+                    },
+                ],
+            },
+        }
+        # m2: no attachment parts at all
+        without_attach = {
+            "id": "m2",
+            "threadId": "t2",
+            "labelIds": ["INBOX"],
+            "snippet": "plain note",
+            "sizeEstimate": 200,
+            "payload": {
+                "mimeType": "text/plain",
+                "headers": [{"name": "Subject", "value": "note"}],
+                "body": {"size": 20},
+            },
+        }
+        return [with_attach, without_attach]
+
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        fake_make_request,
+    )
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_batch_request",
+        fake_batch,
+    )
+
+    rows = _dispatch("search_messages", connector, query="report")
+    by_id = {r["id"]: r for r in rows}
+    assert by_id["m1"]["has_attachment"] == "true"   # filename present, no attachmentId
+    assert by_id["m2"]["has_attachment"] == "false"

--- a/tests/unit/sources/gmail/test_gmail_agent_ops.py
+++ b/tests/unit/sources/gmail/test_gmail_agent_ops.py
@@ -1,0 +1,720 @@
+"""Unit tests for the Gmail ingestion-agent operations.
+
+Covers the five Gmail-specific operations dispatched through
+``IngestionAgentDispatcher``:
+
+  - read_table (override): typed filters compose into Gmail q syntax
+  - search_messages: triage view, metadata-format messages
+  - get_message: single-message fetch with decoded bodies + drive IDs
+  - list_attachments: gmail-native + Drive-hosted enumeration
+  - download_attachment: Volume-path writes for both kinds
+
+Mocks ``GmailApiClient`` so tests stay offline.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+
+import pytest
+
+from databricks.labs.community_connector.interface import AgentError, ErrorCode
+from databricks.labs.community_connector.sources.gmail.gmail import GmailLakeflowConnect
+from databricks.labs.community_connector.sources.gmail.gmail_agent_ops import (
+    _compose_query,
+    extract_drive_file_ids,
+)
+from databricks.labs.community_connector.sources.gmail.gmail_utils import GmailApiError
+from databricks.labs.community_connector.sparkpds.ingestion_agent_datasource import (
+    IngestionAgentDispatcher,
+    OP_LIST_OPERATIONS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _b64u(text: str) -> str:
+    return base64.urlsafe_b64encode(text.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+@pytest.fixture
+def connector(monkeypatch):
+    """Gmail connector with the make_request entrypoint stubbed offline."""
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        lambda self, method, path, **kwargs: {"historyId": "1"},
+    )
+    return GmailLakeflowConnect(
+        {
+            "access_token": "x",
+        }
+    )
+
+
+def _dispatch(operation: str, connector, **options):
+    opts = {"operation": operation, **{k: str(v) for k, v in options.items()}}
+    dispatcher = IngestionAgentDispatcher(options=opts, connector=connector)
+    schema = dispatcher.schema()
+    reader = dispatcher.reader(schema)
+    return list(reader.read(next(iter(reader.partitions()))))
+
+
+# ---------------------------------------------------------------------------
+# Query composition
+# ---------------------------------------------------------------------------
+
+def test_compose_query_combines_typed_filters_with_and():
+    q = _compose_query(
+        {
+            "after_date": "2024/01/15",
+            "before_date": "2024/02/01",
+            "from_address": "alice@example.com",
+            "has_attachment": "true",
+        }
+    )
+    assert "after:2024/01/15" in q
+    assert "before:2024/02/01" in q
+    assert "from:alice@example.com" in q
+    assert "has:attachment" in q
+
+
+def test_compose_query_returns_none_when_no_filters():
+    assert _compose_query({}) is None
+    assert _compose_query({"unrelated": "x"}) is None
+
+
+def test_compose_query_quotes_multi_word_subject():
+    q = _compose_query({"subject": "quarterly report"})
+    assert q == "subject:(quarterly report)"
+
+
+def test_compose_query_passes_through_query_param_and_existing_q():
+    q = _compose_query({"query": "AROUND 5 holiday", "q": "label:work"})
+    # Order: typed filters first, then raw q
+    assert q == "AROUND 5 holiday label:work"
+
+
+def test_compose_query_skips_false_boolean_flags():
+    q = _compose_query({"has_attachment": "false", "is_unread": "false"})
+    assert q is None
+
+
+def test_extract_drive_file_ids_finds_common_url_shapes():
+    body = """
+    Check this: https://drive.google.com/file/d/1AbCdEf_GhIjKlMnOpQrStUvWxYz12345/view
+    And this Doc: https://docs.google.com/document/d/0BzABCDEFghijKLMNopqrstu1234567890XY/edit
+    Same as above: https://drive.google.com/open?id=1AbCdEf_GhIjKlMnOpQrStUvWxYz12345
+    """
+    ids = extract_drive_file_ids(body)
+    assert ids == [
+        "1AbCdEf_GhIjKlMnOpQrStUvWxYz12345",
+        "0BzABCDEFghijKLMNopqrstu1234567890XY",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# list_operations exposes the gmail-specific catalog
+# ---------------------------------------------------------------------------
+
+def test_list_operations_includes_gmail_specific_ops(connector):
+    rows = _dispatch(OP_LIST_OPERATIONS, connector)
+    names = {r["name"] for r in rows}
+    assert {
+        "read_table",
+        "search_messages",
+        "get_message",
+        "list_attachments",
+        "download_attachment",
+    }.issubset(names)
+
+
+def test_read_table_description_mentions_gmail_filters(connector):
+    rows = _dispatch(OP_LIST_OPERATIONS, connector)
+    op = next(r for r in rows if r["name"] == "read_table")
+    assert "Gmail search syntax" in op["description"]
+    # Typed filter params show up in parameters_json
+    assert "after_date" in op["parameters_json"]
+    assert "from_address" in op["parameters_json"]
+
+
+# ---------------------------------------------------------------------------
+# read_table override: routes typed filters into the connector q option
+# ---------------------------------------------------------------------------
+
+def test_read_table_messages_routes_typed_filters_into_q(connector, monkeypatch):
+    captured: dict = {}
+
+    def fake_read_table(table_name, start_offset, table_options):
+        captured["table_name"] = table_name
+        captured["table_options"] = dict(table_options)
+        return iter([]), {}
+
+    monkeypatch.setattr(connector, "read_table", fake_read_table)
+    rows = _dispatch(
+        "read_table",
+        connector,
+        tableName="messages",
+        after_date="2024/01/15",
+        subject="invoice",
+        has_attachment="true",
+    )
+    assert rows == []
+    assert captured["table_name"] == "messages"
+    q = captured["table_options"].get("q")
+    assert q is not None
+    assert "after:2024/01/15" in q
+    assert "subject:invoice" in q
+    assert "has:attachment" in q
+    # Typed filter keys should not leak through to the connector.
+    # ``tableName`` is allowed through by the framework's ``connector_options``;
+    # only operation-layer reserved keys (operation/search/path/etc.) are stripped.
+    for stripped in (
+        "after_date",
+        "subject",
+        "has_attachment",
+        "operation",
+    ):
+        assert stripped not in captured["table_options"]
+
+
+def test_read_table_non_filterable_table_ignores_filters(connector, monkeypatch):
+    captured: dict = {}
+
+    def fake_read_table(table_name, start_offset, table_options):
+        captured["q"] = table_options.get("q")
+        return iter([{"id": "a"}, {"id": "b"}]), {}
+
+    monkeypatch.setattr(connector, "read_table", fake_read_table)
+    rows = _dispatch(
+        "read_table",
+        connector,
+        tableName="labels",
+        after_date="2024/01/15",  # ignored — labels isn't a filterable table
+    )
+    assert len(rows) == 2
+    assert captured["q"] is None
+
+
+def test_read_table_returns_all_rows_no_framework_cap(connector, monkeypatch):
+    # The Scala-aligned ReadTableOp dropped framework-side row capping —
+    # callers chain ``.limit(N)`` on the resulting DataFrame instead. The
+    # override must surface every row the source produces.
+    monkeypatch.setattr(
+        connector,
+        "read_table",
+        lambda t, s, o: (iter([{"id": str(i)} for i in range(20)]), {}),
+    )
+    rows = _dispatch("read_table", connector, tableName="messages")
+    assert len(rows) == 20
+
+
+# ---------------------------------------------------------------------------
+# search_messages: list + metadata-format batch fetch → typed rows
+# ---------------------------------------------------------------------------
+
+def _make_message_payload(
+    *,
+    msg_id: str,
+    thread_id: str,
+    subject: str,
+    sender: str,
+    attachments: int = 0,
+):
+    parts = []
+    for i in range(attachments):
+        parts.append(
+            {
+                "partId": f"a{i}",
+                "mimeType": "application/pdf",
+                "filename": f"file{i}.pdf",
+                "body": {"attachmentId": f"att{i}", "size": 1024},
+            }
+        )
+    return {
+        "id": msg_id,
+        "threadId": thread_id,
+        "labelIds": ["INBOX"],
+        "snippet": f"snippet for {msg_id}",
+        "sizeEstimate": 4096,
+        "payload": {
+            "mimeType": "multipart/mixed",
+            "headers": [
+                {"name": "From", "value": sender},
+                {"name": "To", "value": "me@example.com"},
+                {"name": "Subject", "value": subject},
+                {"name": "Date", "value": "Wed, 1 Jan 2024 00:00:00 +0000"},
+            ],
+            "parts": parts,
+        },
+    }
+
+
+def test_search_messages_typed_filters_drive_listing_q(connector, monkeypatch):
+    requests_log: list = []
+
+    def fake_make_request(self, method, path, params=None, **_):
+        requests_log.append((method, path, dict(params or {})))
+        if path.endswith("/messages"):
+            return {"messages": [{"id": "m1"}, {"id": "m2"}]}
+        return None
+
+    def fake_batch(self, endpoints, params_list=None):
+        return [
+            _make_message_payload(
+                msg_id="m1",
+                thread_id="t1",
+                subject="hi",
+                sender="alice@example.com",
+                attachments=1,
+            ),
+            _make_message_payload(
+                msg_id="m2",
+                thread_id="t2",
+                subject="hello",
+                sender="bob@example.com",
+            ),
+        ]
+
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        fake_make_request,
+    )
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_batch_request",
+        fake_batch,
+    )
+
+    rows = _dispatch(
+        "search_messages",
+        connector,
+        from_address="alice@example.com",
+        newer_than="7d",
+        limit=10,
+    )
+    # 2 rows, header fields decoded, has_attachment toggled per payload.
+    assert len(rows) == 2
+    by_id = {r["id"]: r for r in rows}
+    assert by_id["m1"]["from_address"] == "alice@example.com"
+    assert by_id["m1"]["subject"] == "hi"
+    assert by_id["m1"]["has_attachment"] == "true"
+    assert by_id["m2"]["has_attachment"] == "false"
+    assert by_id["m1"]["size_estimate"] == 4096
+
+    # The list call must have received a composed q.
+    listing = next(call for call in requests_log if call[1].endswith("/messages"))
+    q = listing[2].get("q")
+    assert "from:alice@example.com" in q
+    assert "newer_than:7d" in q
+
+
+def test_search_messages_returns_empty_when_no_matches(connector, monkeypatch):
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        lambda self, *a, **kw: {"resultSizeEstimate": 0},
+    )
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_batch_request",
+        lambda self, *a, **kw: [],
+    )
+    rows = _dispatch("search_messages", connector, query="from:nobody")
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# get_message: decodes plain + html and surfaces drive IDs
+# ---------------------------------------------------------------------------
+
+def test_get_message_decodes_bodies_and_extracts_drive_links(connector, monkeypatch):
+    html = (
+        '<a href="https://drive.google.com/file/d/'
+        '1AbCdEf_GhIjKlMnOpQrStUvWxYz12345/view">file</a>'
+    )
+    text = "plain text fallback"
+
+    payload = {
+        "id": "m1",
+        "threadId": "t1",
+        "labelIds": ["INBOX"],
+        "snippet": "preview",
+        "sizeEstimate": 2048,
+        "payload": {
+            "mimeType": "multipart/alternative",
+            "headers": [
+                {"name": "From", "value": "alice@example.com"},
+                {"name": "To", "value": "bob@example.com"},
+                {"name": "Subject", "value": "subj"},
+                {"name": "Date", "value": "now"},
+            ],
+            "parts": [
+                {
+                    "mimeType": "text/plain",
+                    "body": {"data": _b64u(text)},
+                },
+                {
+                    "mimeType": "text/html",
+                    "body": {"data": _b64u(html)},
+                },
+                {
+                    "mimeType": "application/pdf",
+                    "filename": "doc.pdf",
+                    "body": {"attachmentId": "att1", "size": 1234},
+                },
+            ],
+        },
+    }
+
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        lambda self, method, path, params=None, **_: payload
+        if path.endswith("/messages/m1")
+        else {"historyId": "1"},
+    )
+
+    rows = _dispatch("get_message", connector, message_id="m1")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["body_text"] == text
+    assert "drive.google.com" in row["body_html"]
+    assert row["drive_file_ids"] == ["1AbCdEf_GhIjKlMnOpQrStUvWxYz12345"]
+    assert len(row["attachments"]) == 1
+    assert row["attachments"][0]["filename"] == "doc.pdf"
+
+
+def test_get_message_missing_id_raises_bad_request(connector):
+    with pytest.raises(AgentError) as info:
+        _dispatch("get_message", connector)  # no message_id
+    assert info.value.code == ErrorCode.BAD_REQUEST
+    assert "message_id" in str(info.value)
+
+
+def test_get_message_not_found_yields_not_found_error(connector, monkeypatch):
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        lambda self, method, path, params=None, **_: None,
+    )
+    with pytest.raises(AgentError) as info:
+        _dispatch("get_message", connector, message_id="ghost")
+    assert info.value.code == ErrorCode.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# list_attachments: gmail-native + Drive metadata enrichment
+# ---------------------------------------------------------------------------
+
+def test_list_attachments_mixes_gmail_and_drive_rows(connector, monkeypatch):
+    payload = {
+        "id": "m1",
+        "payload": {
+            "mimeType": "multipart/mixed",
+            "headers": [],
+            "parts": [
+                {
+                    "mimeType": "text/html",
+                    "body": {
+                        "data": _b64u(
+                            'see <a href="https://drive.google.com/file/d/'
+                            "1AbCdEf_GhIjKlMnOpQrStUvWxYz12345/view"
+                            '">doc</a>'
+                        )
+                    },
+                },
+                {
+                    "mimeType": "application/pdf",
+                    "filename": "report.pdf",
+                    "body": {"attachmentId": "gmail_att_1", "size": 2048},
+                },
+            ],
+        },
+    }
+
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        lambda self, method, path, params=None, **_: payload,
+    )
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.get_drive_file_metadata",
+        lambda self, file_id: {
+            "id": file_id,
+            "name": "shared.pdf",
+            "mimeType": "application/pdf",
+            "size": "5120",
+        },
+    )
+
+    rows = _dispatch("list_attachments", connector, message_id="m1")
+    by_kind = {r["kind"]: r for r in rows}
+    assert by_kind["gmail"]["filename"] == "report.pdf"
+    assert by_kind["gmail"]["attachment_id"] == "gmail_att_1"
+    assert by_kind["drive"]["drive_file_id"] == "1AbCdEf_GhIjKlMnOpQrStUvWxYz12345"
+    assert by_kind["drive"]["filename"] == "shared.pdf"
+    assert by_kind["drive"]["size_bytes"] == 5120
+
+
+def test_list_attachments_drive_403_surfaces_error_marker(connector, monkeypatch):
+    payload = {
+        "id": "m1",
+        "payload": {
+            "headers": [],
+            "parts": [
+                {
+                    "mimeType": "text/html",
+                    "body": {
+                        "data": _b64u(
+                            "https://drive.google.com/file/d/"
+                            "1AbCdEf_GhIjKlMnOpQrStUvWxYz12345/view"
+                        )
+                    },
+                }
+            ],
+        },
+    }
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        lambda self, method, path, params=None, **_: payload,
+    )
+
+    def _raise_403(self, file_id):
+        raise GmailApiError(403, "not shared with user")
+
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.get_drive_file_metadata",
+        _raise_403,
+    )
+    rows = _dispatch("list_attachments", connector, message_id="m1")
+    drive_rows = [r for r in rows if r["kind"] == "drive"]
+    assert len(drive_rows) == 1
+    assert drive_rows[0]["mime_type"] == "error:http_403"
+    assert drive_rows[0]["filename"] is None
+
+
+# ---------------------------------------------------------------------------
+# download_attachment: validates inputs, writes to volume path
+# ---------------------------------------------------------------------------
+
+def test_download_attachment_rejects_non_volume_path(connector):
+    rows = _dispatch(
+        "download_attachment",
+        connector,
+        volume_path="/tmp/x",
+        attachment_id="a",
+        message_id="m1",
+    )
+    assert len(rows) == 1
+    assert rows[0]["_meta"]["status"] == "error"
+    assert rows[0]["_meta"]["code"] == ErrorCode.BAD_REQUEST
+    assert "Volumes" in rows[0]["_meta"]["message"]
+
+
+def test_download_attachment_requires_one_id(connector, tmp_path, monkeypatch):
+    # Both supplied → bad_request.
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_agent_ops."
+        "DownloadAttachmentOp._VOLUME_PREFIX",
+        str(tmp_path) + "/",
+    )
+    target = tmp_path / "f.bin"
+    rows = _dispatch(
+        "download_attachment",
+        connector,
+        volume_path=str(target),
+        attachment_id="a",
+        drive_file_id="d",
+        message_id="m1",
+    )
+    assert rows[0]["_meta"]["code"] == ErrorCode.BAD_REQUEST
+
+
+def test_download_attachment_gmail_writes_bytes(connector, tmp_path, monkeypatch):
+    payload = {
+        "payload": {
+            "headers": [],
+            "parts": [
+                {
+                    "mimeType": "application/pdf",
+                    "filename": "x.pdf",
+                    "body": {"attachmentId": "att1", "size": 11},
+                }
+            ],
+        }
+    }
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        lambda self, method, path, params=None, **_: payload,
+    )
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.get_attachment",
+        lambda self, mid, aid: b"hello world",
+    )
+    # Allow the test to use a tmp path instead of /Volumes/.
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_agent_ops."
+        "DownloadAttachmentOp._VOLUME_PREFIX",
+        str(tmp_path) + "/",
+    )
+    target = tmp_path / "subdir" / "x.pdf"
+    rows = _dispatch(
+        "download_attachment",
+        connector,
+        volume_path=str(target),
+        attachment_id="att1",
+        message_id="m1",
+    )
+    assert len(rows) == 1
+    assert rows[0]["_meta"]["status"] == "ok"
+    assert rows[0]["size_bytes"] == 11
+    assert rows[0]["filename"] == "x.pdf"
+    assert rows[0]["mime_type"] == "application/pdf"
+    assert rows[0]["source"] == "gmail"
+    assert os.path.exists(target)
+    assert target.read_bytes() == b"hello world"
+
+
+def test_download_attachment_drive_streams_and_returns_metadata(
+    connector, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.download_drive_file",
+        lambda self, fid, dest, export_mime_type=None, chunk_size=None: (
+            42,
+            "shared.pdf",
+            "application/pdf",
+        ),
+    )
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_agent_ops."
+        "DownloadAttachmentOp._VOLUME_PREFIX",
+        str(tmp_path) + "/",
+    )
+    target = tmp_path / "shared.pdf"
+    rows = _dispatch(
+        "download_attachment",
+        connector,
+        volume_path=str(target),
+        drive_file_id="1AbCdEf_GhIjKlMnOpQrStUvWxYz12345",
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["source"] == "drive"
+    assert row["size_bytes"] == 42
+    assert row["filename"] == "shared.pdf"
+    assert row["mime_type"] == "application/pdf"
+
+
+def test_download_attachment_drive_403_yields_permission_denied(
+    connector, tmp_path, monkeypatch
+):
+    def _raise_403(self, fid, dest, export_mime_type=None, chunk_size=None):
+        raise GmailApiError(403, "not shared")
+
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.download_drive_file",
+        _raise_403,
+    )
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_agent_ops."
+        "DownloadAttachmentOp._VOLUME_PREFIX",
+        str(tmp_path) + "/",
+    )
+    target = tmp_path / "shared.pdf"
+    rows = _dispatch(
+        "download_attachment",
+        connector,
+        volume_path=str(target),
+        drive_file_id="1AbCdEf_GhIjKlMnOpQrStUvWxYz12345",
+    )
+    assert rows[0]["_meta"]["code"] == ErrorCode.PERMISSION_DENIED
+
+
+# ---------------------------------------------------------------------------
+# read_table default row cap
+# ---------------------------------------------------------------------------
+
+def _install_paginated_messages_api(monkeypatch, total_available: int):
+    """Stub the Gmail API to act like a mailbox with ``total_available`` messages
+    served via pagination. Tracks how many list+detail calls were issued."""
+    counters = {"list_calls": 0, "detail_calls": 0}
+
+    def fake_make_request(self, method, path, params=None, **kwargs):
+        if path.endswith("/profile"):
+            return {"historyId": "1"}
+        if path.endswith("/messages") and (params or {}).get("pageToken") is None:
+            counters["list_calls"] += 1
+            page_size = int((params or {}).get("maxResults", 100))
+            start = 0
+            end = min(page_size, total_available)
+            msgs = [{"id": f"m{i}"} for i in range(start, end)]
+            next_token = "T1" if end < total_available else None
+            return {"messages": msgs, "nextPageToken": next_token} if next_token else {"messages": msgs}
+        if path.endswith("/messages") and (params or {}).get("pageToken"):
+            counters["list_calls"] += 1
+            token = params["pageToken"]
+            prev_end = int(token[1:]) * int((params or {}).get("maxResults", 100))
+            page_size = int((params or {}).get("maxResults", 100))
+            start = prev_end
+            end = min(prev_end + page_size, total_available)
+            msgs = [{"id": f"m{i}"} for i in range(start, end)]
+            next_idx = int(token[1:]) + 1
+            next_token = f"T{next_idx}" if end < total_available else None
+            return {"messages": msgs, "nextPageToken": next_token} if next_token else {"messages": msgs}
+        if "/messages/" in path:
+            counters["detail_calls"] += 1
+            mid = path.rsplit("/", 1)[-1]
+            return {"id": mid, "historyId": "1"}
+        return {}
+
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        fake_make_request,
+    )
+    return counters
+
+
+def test_read_table_default_cap_is_50(monkeypatch):
+    """No maxResults → agent read_table returns 50 messages by default."""
+    counters = _install_paginated_messages_api(monkeypatch, total_available=200)
+    connector = GmailLakeflowConnect(
+        {"client_id": "x", "client_secret": "x", "refresh_token": "x"}
+    )
+    rows = _dispatch("read_table", connector, tableName="messages")
+    assert len(rows) == 50, f"expected 50, got {len(rows)}"
+    # Pagination must stop early; never fetch all 200 details.
+    assert counters["detail_calls"] == 50
+
+
+def test_read_table_max_results_minus_one_returns_all(monkeypatch):
+    counters = _install_paginated_messages_api(monkeypatch, total_available=120)
+    connector = GmailLakeflowConnect(
+        {"client_id": "x", "client_secret": "x", "refresh_token": "x"}
+    )
+    rows = _dispatch("read_table", connector, tableName="messages", maxResults="-1")
+    assert len(rows) == 120
+    assert counters["detail_calls"] == 120
+
+
+def test_read_table_respects_explicit_max_results(monkeypatch):
+    counters = _install_paginated_messages_api(monkeypatch, total_available=500)
+    connector = GmailLakeflowConnect(
+        {"client_id": "x", "client_secret": "x", "refresh_token": "x"}
+    )
+    rows = _dispatch("read_table", connector, tableName="messages", maxResults="10")
+    assert len(rows) == 10
+    assert counters["detail_calls"] == 10

--- a/tests/unit/sources/gmail/test_gmail_agent_ops.py
+++ b/tests/unit/sources/gmail/test_gmail_agent_ops.py
@@ -1,13 +1,16 @@
 """Unit tests for the Gmail ingestion-agent operations.
 
-Covers the five Gmail-specific operations dispatched through
+Covers the Gmail-specific operations dispatched through
 ``IngestionAgentDispatcher``:
 
   - read_table (override): typed filters compose into Gmail q syntax
   - search_messages: triage view, metadata-format messages
+  - search_threads: thread-level triage, one row per conversation
   - get_message: single-message fetch with decoded bodies + drive IDs
+  - get_thread: full conversation with decoded message bodies
   - list_attachments: gmail-native + Drive-hosted enumeration
   - download_attachment: Volume-path writes for both kinds
+  - mailbox_overview: per-label message/thread counts
 
 Mocks ``GmailApiClient`` so tests stay offline.
 """
@@ -718,3 +721,191 @@ def test_read_table_respects_explicit_max_results(monkeypatch):
     rows = _dispatch("read_table", connector, tableName="messages", maxResults="10")
     assert len(rows) == 10
     assert counters["detail_calls"] == 10
+
+
+# ---------------------------------------------------------------------------
+# get_thread: full conversation with decoded message bodies
+# ---------------------------------------------------------------------------
+
+def _thread_msg(msg_id, sender, subject, body_text, date, to="me@example.com", labels=None):
+    return {
+        "id": msg_id,
+        "threadId": "t1",
+        "labelIds": labels if labels is not None else ["INBOX"],
+        "snippet": f"snip {msg_id}",
+        "sizeEstimate": 100,
+        "payload": {
+            "mimeType": "multipart/alternative",
+            "headers": [
+                {"name": "From", "value": sender},
+                {"name": "To", "value": to},
+                {"name": "Subject", "value": subject},
+                {"name": "Date", "value": date},
+            ],
+            "parts": [{"mimeType": "text/plain", "body": {"data": _b64u(body_text)}}],
+        },
+    }
+
+
+def test_get_thread_returns_one_row_with_decoded_messages(connector, monkeypatch):
+    thread = {
+        "id": "t1",
+        "historyId": "555",
+        "messages": [
+            _thread_msg("m1", "alice@example.com", "Kickoff", "first body",
+                        "Wed, 1 Jan 2024 00:00:00 +0000"),
+            _thread_msg("m2", "bob@example.com", "Re: Kickoff", "second body",
+                        "Thu, 2 Jan 2024 00:00:00 +0000", labels=["INBOX", "IMPORTANT"]),
+        ],
+    }
+
+    def fake_make_request(self, method, path, params=None, **_):
+        assert path.endswith("/threads/t1")
+        assert (params or {}).get("format") == "full"
+        return thread
+
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        fake_make_request,
+    )
+
+    rows = _dispatch("get_thread", connector, thread_id="t1")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["thread_id"] == "t1"
+    assert row["history_id"] == "555"
+    assert row["subject"] == "Kickoff"          # first message's subject
+    assert row["message_count"] == 2
+    assert set(row["participants"]) == {
+        "alice@example.com", "bob@example.com", "me@example.com",
+    }
+    assert set(row["labelIds"]) == {"INBOX", "IMPORTANT"}
+    assert [m["id"] for m in row["messages"]] == ["m1", "m2"]
+    assert row["messages"][0]["body_text"] == "first body"
+    assert row["messages"][1]["from_address"] == "bob@example.com"
+
+
+def test_get_thread_not_found_raises(connector, monkeypatch):
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        lambda self, *a, **kw: None,
+    )
+    with pytest.raises(AgentError) as info:
+        _dispatch("get_thread", connector, thread_id="missing")
+    assert info.value.code == ErrorCode.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# search_threads: one row per conversation, typed filters compose into q
+# ---------------------------------------------------------------------------
+
+def test_search_threads_returns_one_row_per_thread(connector, monkeypatch):
+    requests_log: list = []
+
+    def fake_make_request(self, method, path, params=None, **_):
+        requests_log.append((method, path, dict(params or {})))
+        if path.endswith("/threads"):
+            return {"threads": [
+                {"id": "t1", "snippet": "snippet one"},
+                {"id": "t2", "snippet": "snippet two"},
+            ]}
+        return None
+
+    def fake_batch(self, endpoints, params_list=None):
+        return [
+            {"id": "t1", "historyId": "10", "messages": [
+                _thread_msg("m1", "alice@example.com", "Kickoff", "b1",
+                            "Wed, 1 Jan 2024 00:00:00 +0000"),
+                _thread_msg("m2", "bob@example.com", "Re: Kickoff", "b2",
+                            "Thu, 2 Jan 2024 00:00:00 +0000"),
+            ]},
+            {"id": "t2", "historyId": "11", "messages": [
+                _thread_msg("m3", "carol@example.com", "Lunch?", "b3",
+                            "Fri, 3 Jan 2024 00:00:00 +0000"),
+            ]},
+        ]
+
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        fake_make_request,
+    )
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_batch_request",
+        fake_batch,
+    )
+
+    rows = _dispatch("search_threads", connector, from_address="alice@example.com",
+                     newer_than="30d", limit=10)
+    assert len(rows) == 2
+    by_id = {r["id"]: r for r in rows}
+    assert by_id["t1"]["subject"] == "Kickoff"
+    assert by_id["t1"]["snippet"] == "snippet one"
+    assert by_id["t1"]["message_count"] == 2
+    assert by_id["t1"]["last_date"] == "Thu, 2 Jan 2024 00:00:00 +0000"
+    assert "alice@example.com" in by_id["t1"]["participants"]
+    assert by_id["t2"]["message_count"] == 1
+
+    listing = next(c for c in requests_log if c[1].endswith("/threads"))
+    q = listing[2].get("q")
+    assert "from:alice@example.com" in q
+    assert "newer_than:30d" in q
+
+
+def test_search_threads_empty_when_no_matches(connector, monkeypatch):
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        lambda self, *a, **kw: {"resultSizeEstimate": 0},
+    )
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_batch_request",
+        lambda self, *a, **kw: [],
+    )
+    rows = _dispatch("search_threads", connector, query="from:nobody")
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# mailbox_overview: per-label counts
+# ---------------------------------------------------------------------------
+
+def test_mailbox_overview_returns_per_label_counts(connector, monkeypatch):
+    def fake_make_request(self, method, path, params=None, **_):
+        if path.endswith("/labels"):
+            return {"labels": [{"id": "INBOX"}, {"id": "Label_1"}]}
+        return None
+
+    def fake_batch(self, endpoints, params_list=None):
+        return [
+            {"id": "INBOX", "name": "INBOX", "type": "system",
+             "messagesTotal": 120, "messagesUnread": 4,
+             "threadsTotal": 100, "threadsUnread": 3},
+            {"id": "Label_1", "name": "Work", "type": "user",
+             "messagesTotal": 30, "messagesUnread": 0,
+             "threadsTotal": 25, "threadsUnread": 0},
+        ]
+
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_request",
+        fake_make_request,
+    )
+    monkeypatch.setattr(
+        "databricks.labs.community_connector.sources.gmail.gmail_utils."
+        "GmailApiClient.make_batch_request",
+        fake_batch,
+    )
+
+    rows = _dispatch("mailbox_overview", connector)
+    assert len(rows) == 2
+    by_id = {r["label_id"]: r for r in rows}
+    assert by_id["INBOX"]["messages_total"] == 120
+    assert by_id["INBOX"]["messages_unread"] == 4
+    assert by_id["Label_1"]["name"] == "Work"
+    assert by_id["Label_1"]["type"] == "user"
+    assert by_id["Label_1"]["threads_total"] == 25

--- a/tests/unit/sources/gmail/test_gmail_unit.py
+++ b/tests/unit/sources/gmail/test_gmail_unit.py
@@ -92,3 +92,49 @@ class TestGmailConnectorUnit:
         field_names = [f.name for f in schema.fields]
 
         assert "emailAddress" in field_names
+
+
+class TestBatchRequestFallback:
+    """make_batch_request must fall back to sequential when a 200 response
+    parses to zero rows (Gmail's batch endpoint can answer 200 with a body
+    the multipart parser can't read)."""
+
+    class _FakeResp:
+        def __init__(self, status_code, text):
+            self.status_code = status_code
+            self.text = text
+
+    def _client(self):
+        from databricks.labs.community_connector.sources.gmail.gmail_utils import (
+            GmailApiClient,
+        )
+        return GmailApiClient(access_token="tok")
+
+    def test_empty_parse_falls_back_to_sequential(self, monkeypatch):
+        client = self._client()
+        # Batch returns 200 but an unparseable body -> _parse_batch_response == [].
+        monkeypatch.setattr(
+            client._session, "post",
+            lambda *a, **kw: self._FakeResp(200, "HTTP/1.1 200 OK\r\n\r\n<not multipart>"),
+        )
+        seen = []
+        def fake_get(method, endpoint, params=None, retry_count=3):
+            seen.append(endpoint)
+            return {"id": endpoint.rsplit("/", 1)[-1]}
+        monkeypatch.setattr(client, "make_request", fake_get)
+
+        out = client.make_batch_request(["/users/me/messages/m1", "/users/me/messages/m2"])
+        assert [r["id"] for r in out] == ["m1", "m2"]   # came from the sequential fallback
+        assert len(seen) == 2
+
+    def test_non_200_falls_back_to_sequential(self, monkeypatch):
+        client = self._client()
+        monkeypatch.setattr(
+            client._session, "post", lambda *a, **kw: self._FakeResp(503, "unavailable")
+        )
+        monkeypatch.setattr(
+            client, "make_request",
+            lambda method, endpoint, params=None, retry_count=3: {"id": "x"},
+        )
+        out = client.make_batch_request(["/users/me/messages/m1"])
+        assert out == [{"id": "x"}]

--- a/tests/unit/sparkpds_ingestion_agent_test.py
+++ b/tests/unit/sparkpds_ingestion_agent_test.py
@@ -214,8 +214,9 @@ def test_list_operations_returns_builtin_catalog():
         OP_READ_TABLE,
         OP_GET_OBJECT_METADATA,
         OP_VALIDATE_CONNECTION,
-        OP_LIST_OPERATIONS,
     }.issubset(names)
+    # list_operations does not advertise itself — you already called it.
+    assert OP_LIST_OPERATIONS not in names
 
 
 def test_list_operations_works_when_connector_failed_to_build():
@@ -227,9 +228,9 @@ def test_list_operations_works_when_connector_failed_to_build():
     )
     rows = _collect(dispatcher)
     names = {r["name"] for r in rows}
-    # Built-ins are still listed.
+    # Built-ins are still listed (but not list_operations itself).
     assert OP_LIST_OBJECTS in names
-    assert OP_LIST_OPERATIONS in names
+    assert OP_LIST_OPERATIONS not in names
 
 
 def test_list_operations_rows_carry_planning_metadata():
@@ -508,8 +509,8 @@ def test_list_operations_includes_source_plug_ins():
         "read_table",
         "get_object_metadata",
         "validate_connection",
-        "list_operations",
     }.issubset(names)
+    assert "list_operations" not in names  # not self-listed
     assert _DescribeTableOp.name in names
     assert _RowCountOp.name in names
     descriptions = {r["name"]: r["description"] for r in rows}

--- a/tools/scripts/merge_exclude_config.json
+++ b/tools/scripts/merge_exclude_config.json
@@ -17,12 +17,16 @@
     ],
     "google_analytics_aggregated": [
       "pipeline_spec.example.py"
+    ],
+    "gmail": [
+      "gmail_agent_ops.py"
     ]
   },
   "_comments": {
     "zoho_crm_oauth_setup.py": "Databricks notebook to help users set up OAuth credentials for Zoho CRM. Not part of the connector runtime.",
     "osipi/ingest.py": "Databricks notebook example for ingestion. Not part of the connector runtime.",
     "microsoft_teams/sample-ingest.py": "Databricks notebook sample for fully automated ingestion. Not part of the connector runtime.",
-    "google_analytics_aggregated/pipeline_spec.example.py": "Example pipeline spec notebook. Not part of the connector runtime."
+    "google_analytics_aggregated/pipeline_spec.example.py": "Example pipeline spec notebook. Not part of the connector runtime.",
+    "gmail/gmail_agent_ops.py": "Ingestion-agent operation implementations (search_messages, get_message, list_attachments, download_attachment, filtered read_table). Served from the installed wheel via the lakeflow_connect agent format, not the SDP pipeline path; excluded so the merged single-file stays free of the agent-dispatch framework imports."
   }
 }

--- a/tools/scripts/merge_python_source.py
+++ b/tools/scripts/merge_python_source.py
@@ -438,6 +438,7 @@ def deduplicate_imports(
     skip_patterns = [
         "from databricks.labs.community_connector.libs.utils import",
         "from databricks.labs.community_connector.sparkpds.lakeflow_datasource import",
+        "from databricks.labs.community_connector.sparkpds.ingestion_agent_datasource import",
         "from databricks.labs.community_connector.sources.",
         "from databricks.labs.community_connector.interface",
     ]
@@ -622,6 +623,8 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
     partition_path = src_base / "interface" / "supports_partition.py"
     namespaces_path = src_base / "interface" / "supports_namespaces.py"
     ingestion_agent_path = src_base / "interface" / "supports_ingestion_agent.py"
+    agent_protocol_path = src_base / "interface" / "agent_protocol.py"
+    dispatcher_path = src_base / "sparkpds" / "ingestion_agent_datasource.py"
     source_path = src_base / "sources" / source_name / f"{source_name}.py"
     lakeflow_source_path = src_base / "sparkpds" / "lakeflow_datasource.py"
 
@@ -641,6 +644,8 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
         partition_content = read_file_content(partition_path)
         namespaces_content = read_file_content(namespaces_path)
         ingestion_agent_content = read_file_content(ingestion_agent_path)
+        agent_protocol_content = read_file_content(agent_protocol_path)
+        dispatcher_content = read_file_content(dispatcher_path)
         source_content = read_file_content(source_path)
         lakeflow_source_content = read_file_content(lakeflow_source_path)
 
@@ -659,6 +664,8 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
     print(f"- supports_partition.py: {partition_path}", file=sys.stderr)
     print(f"- supports_namespaces.py: {namespaces_path}", file=sys.stderr)
     print(f"- supports_ingestion_agent.py: {ingestion_agent_path}", file=sys.stderr)
+    print(f"- agent_protocol.py: {agent_protocol_path}", file=sys.stderr)
+    print(f"- ingestion_agent_datasource.py: {dispatcher_path}", file=sys.stderr)
     if lib_files:
         for lib_file in lib_files:
             print(f"- {lib_file.name}: {lib_file}", file=sys.stderr)
@@ -677,6 +684,10 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
     ingestion_agent_imports, ingestion_agent_code = extract_imports_and_code(
         ingestion_agent_content
     )
+    agent_protocol_imports, agent_protocol_code = extract_imports_and_code(
+        agent_protocol_content
+    )
+    dispatcher_imports, dispatcher_code = extract_imports_and_code(dispatcher_content)
     source_imports, source_code = extract_imports_and_code(source_content)
     lakeflow_imports, lakeflow_code = extract_imports_and_code(lakeflow_source_content)
 
@@ -730,7 +741,9 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
         interface_imports,
         partition_imports,
         namespaces_imports,
+        agent_protocol_imports,
         ingestion_agent_imports,
+        dispatcher_imports,
     ]
     for _, lib_imports, _ in lib_imports_and_code:
         all_import_lists.append(lib_imports)
@@ -824,6 +837,23 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
     merged_lines.append("")
     merged_lines.append("")
 
+    # Section 2c2: src/databricks/labs/community_connector/interface/agent_protocol.py
+    # Inlined before supports_ingestion_agent / ingestion_agent_datasource —
+    # it defines ErrorCode, AgentError, and Parameter, which those use.
+    merged_lines.append("    " + "#" * 56)
+    merged_lines.append(
+        "    # src/databricks/labs/community_connector/interface/agent_protocol.py"
+    )
+    merged_lines.append("    " + "#" * 56)
+    merged_lines.append("")
+    for line in agent_protocol_code.strip().split("\n"):
+        if line.strip():
+            merged_lines.append("    " + line)
+        else:
+            merged_lines.append("")
+    merged_lines.append("")
+    merged_lines.append("")
+
     # Section 2d: src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
     merged_lines.append("    " + "#" * 56)
     merged_lines.append(
@@ -832,6 +862,24 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
     merged_lines.append("    " + "#" * 56)
     merged_lines.append("")
     for line in ingestion_agent_code.strip().split("\n"):
+        if line.strip():
+            merged_lines.append("    " + line)
+        else:
+            merged_lines.append("")
+    merged_lines.append("")
+    merged_lines.append("")
+
+    # Section 2e: src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py
+    # The ingestion-agent dispatcher + built-in operations. Inlined before
+    # lakeflow_datasource (which delegates to IngestionAgentDispatcher when the
+    # `operation` option is present).
+    merged_lines.append("    " + "#" * 56)
+    merged_lines.append(
+        "    # src/databricks/labs/community_connector/sparkpds/ingestion_agent_datasource.py"
+    )
+    merged_lines.append("    " + "#" * 56)
+    merged_lines.append("")
+    for line in dispatcher_code.strip().split("\n"):
         if line.strip():
             merged_lines.append("    " + line)
         else:

--- a/tools/scripts/merge_python_source.py
+++ b/tools/scripts/merge_python_source.py
@@ -621,6 +621,7 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
     interface_path = src_base / "interface" / "lakeflow_connect.py"
     partition_path = src_base / "interface" / "supports_partition.py"
     namespaces_path = src_base / "interface" / "supports_namespaces.py"
+    ingestion_agent_path = src_base / "interface" / "supports_ingestion_agent.py"
     source_path = src_base / "sources" / source_name / f"{source_name}.py"
     lakeflow_source_path = src_base / "sparkpds" / "lakeflow_datasource.py"
 
@@ -639,6 +640,7 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
         interface_content = read_file_content(interface_path)
         partition_content = read_file_content(partition_path)
         namespaces_content = read_file_content(namespaces_path)
+        ingestion_agent_content = read_file_content(ingestion_agent_path)
         source_content = read_file_content(source_path)
         lakeflow_source_content = read_file_content(lakeflow_source_path)
 
@@ -656,6 +658,7 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
     print(f"- lakeflow_connect.py: {interface_path}", file=sys.stderr)
     print(f"- supports_partition.py: {partition_path}", file=sys.stderr)
     print(f"- supports_namespaces.py: {namespaces_path}", file=sys.stderr)
+    print(f"- supports_ingestion_agent.py: {ingestion_agent_path}", file=sys.stderr)
     if lib_files:
         for lib_file in lib_files:
             print(f"- {lib_file.name}: {lib_file}", file=sys.stderr)
@@ -671,6 +674,9 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
     interface_imports, interface_code = extract_imports_and_code(interface_content)
     partition_imports, partition_code = extract_imports_and_code(partition_content)
     namespaces_imports, namespaces_code = extract_imports_and_code(namespaces_content)
+    ingestion_agent_imports, ingestion_agent_code = extract_imports_and_code(
+        ingestion_agent_content
+    )
     source_imports, source_code = extract_imports_and_code(source_content)
     lakeflow_imports, lakeflow_code = extract_imports_and_code(lakeflow_source_content)
 
@@ -719,7 +725,13 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
     lakeflow_code = "\n".join(filtered_lines)
 
     # Deduplicate and organize all imports
-    all_import_lists = [utils_imports, interface_imports, partition_imports, namespaces_imports]
+    all_import_lists = [
+        utils_imports,
+        interface_imports,
+        partition_imports,
+        namespaces_imports,
+        ingestion_agent_imports,
+    ]
     for _, lib_imports, _ in lib_imports_and_code:
         all_import_lists.append(lib_imports)
     all_import_lists.extend([source_imports, lakeflow_imports])
@@ -805,6 +817,21 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
     merged_lines.append("    " + "#" * 56)
     merged_lines.append("")
     for line in namespaces_code.strip().split("\n"):
+        if line.strip():
+            merged_lines.append("    " + line)
+        else:
+            merged_lines.append("")
+    merged_lines.append("")
+    merged_lines.append("")
+
+    # Section 2d: src/databricks/labs/community_connector/interface/supports_ingestion_agent.py
+    merged_lines.append("    " + "#" * 56)
+    merged_lines.append(
+        "    # src/databricks/labs/community_connector/interface/supports_ingestion_agent.py"
+    )
+    merged_lines.append("    " + "#" * 56)
+    merged_lines.append("")
+    for line in ingestion_agent_code.strip().split("\n"):
         if line.strip():
             merged_lines.append("    " + line)
         else:


### PR DESCRIPTION
## Summary

Full Gmail connector work (agent operations, case-insensitive option handling, default read_table cap, optional Trigger.AvailableNow import, sequential batch fallback) on the connector's **original in-code OAuth refresh** auth model.

This is an alternative to the COMMUNITY-u2m variant: the connector requires `client_id` + `client_secret` + `refresh_token` and exchanges them at Google's token endpoint for short-lived access tokens at query time (cached, refreshed on expiry) — rather than receiving a pre-issued `access_token` from a COMMUNITY connection.

## What's included

- **Ingestion-agent operations** on the `lakeflow_connect` format (`operation=<name>`):
  - `read_table` override — typed filters compose into Gmail `q` syntax (after_date, before_date, newer_than, subject, from_address, to_address, label, has_attachment, is_unread, query); default cap 50 rows, `maxResults=-1` for unlimited.
  - `search_messages`, `get_message`, `list_attachments`, `download_attachment`.
- **Per-source `GmailDataSource`** subclass of `LakeflowSource` (format stays `lakeflow_connect` for UC injection); `find_data_source()` lookup + conformance test.
- **Case-insensitive Spark options** (`CaseInsensitiveDict`) so camelCase lookups survive lowercased UC delivery; cloudpickle-safe.
- **Optional `pyspark.sql.streaming.datasource` import** so the package loads on runtimes without the Trigger.AvailableNow API (agent + batch paths don't need it).
- **Sequential batch fallback** when Gmail's global batch endpoint answers 200 with an unparseable body.

## Auth model

`connector_spec.yaml` declares three secret params (`client_id`, `client_secret`, `refresh_token`) plus optional `user_id`; no `oauth:` block. The simulator registers the `/token` endpoint + `oauth_token.json` corpus. Required scopes: `gmail.readonly` + `drive.readonly` (Drive scope needed for `download_attachment` of Drive-hosted attachments).

## Tests

Unit suites pass (gmail, agent dispatcher, registry, virtual tables, libs). Test fixtures added during the COMMUNITY-auth era were updated back to the credential triple.

This pull request and its description were written by Isaac.