### PR TITLE
Fix example connector pickle failure on SDP deploy

### DIFF
--- a/src/databricks/labs/community_connector/sources/example/_generated_example_python_source.py
+++ b/src/databricks/labs/community_connector/sources/example/_generated_example_python_source.py
@@ -670,13 +670,19 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options: dict[str, str]) -> None:
             super().__init__(options)
-            username = options.get("username", "default_user")
-            password = options.get("password", "default_pass")
-            self._api = get_api(username, password)
+            self._username = options.get("username", "default_user")
+            self._password = options.get("password", "default_pass")
 
             # Cap cursors at init time so a trigger never chases new data.
             # The next trigger creates a fresh instance and picks up from here.
             self._init_ts = datetime.now(timezone.utc).isoformat()
+
+        @property
+        def _api(self):
+            # Resolved lazily so the connector instance carries no non-picklable
+            # state — the underlying simulator holds a threading.Lock that Spark
+            # cannot serialize when shipping the reader to executors.
+            return get_api(self._username, self._password)
 
         def _request_with_retry(self, method: str, path: str, **kwargs):
             """Issue an API request, retrying on 429/500/503 with exponential backoff."""

--- a/src/databricks/labs/community_connector/sources/example/example.py
+++ b/src/databricks/labs/community_connector/sources/example/example.py
@@ -24,13 +24,19 @@ class ExampleLakeflowConnect(LakeflowConnect):
 
     def __init__(self, options: dict[str, str]) -> None:
         super().__init__(options)
-        username = options.get("username", "default_user")
-        password = options.get("password", "default_pass")
-        self._api = get_api(username, password)
+        self._username = options.get("username", "default_user")
+        self._password = options.get("password", "default_pass")
 
         # Cap cursors at init time so a trigger never chases new data.
         # The next trigger creates a fresh instance and picks up from here.
         self._init_ts = datetime.now(timezone.utc).isoformat()
+
+    @property
+    def _api(self):
+        # Resolved lazily so the connector instance carries no non-picklable
+        # state — the underlying simulator holds a threading.Lock that Spark
+        # cannot serialize when shipping the reader to executors.
+        return get_api(self._username, self._password)
 
     def _request_with_retry(self, method: str, path: str, **kwargs):
         """Issue an API request, retrying on 429/500/503 with exponential backoff."""


### PR DESCRIPTION
## Summary

Deploying the `example` connector to a real SDP cluster fails with:

```
Could not serialize object: TypeError: cannot pickle '_thread.lock' object SQLSTATE: 38000
```

`ExampleLakeflowConnect.__init__` stored `self._api = get_api(...)`. The returned `SimulatedSourceAPI` holds a `Store` whose `threading.Lock` is not picklable, so when Spark ships the `LakeflowBatchReader` (which references the connector) to executors, pickle blows up.

Fix: store credentials only; resolve `_api` lazily via a `@property` that calls `get_api(...)` on access. `get_api` is a module-level singleton lookup, so per-access cost is negligible, and the instance now carries only picklable state.

I also surveyed the other 17 connectors — pickled each with its stand-in `replay_config` (auth-validating connectors were stubbed). All pickled cleanly. `requests.Session` and `google.oauth2.service_account.Credentials` both implement pickle-safe state. The example connector was the only one storing a custom object holding a raw `threading.Lock`.

## Test plan
- [x] `tests/unit/sources/example/` — 12 passed, 2 skipped.
- [x] Manual pickle round-trip: `pickle.dumps(ExampleLakeflowConnect({...}))` succeeds (227 bytes); `_init_ts` preserved across the round trip; `_api` resolves to `SimulatedSourceAPI` on both sides; `list_tables()` still works after unpickle.

This pull request and its description were written by Isaac.