### PR TITLE
Extend connector_spec OAuth shape with regions, flow type, and PKCE; apply to Zoho CRM

### DIFF
--- a/src/databricks/labs/community_connector/sources/zoho_crm/README.md
+++ b/src/databricks/labs/community_connector/sources/zoho_crm/README.md
@@ -19,8 +19,8 @@ To configure the connector, provide the following parameters in your connector o
 |-----------|------|----------|-------------|---------|
 | `client_id` | string | Yes | OAuth Client ID from Zoho API Console | `1000.XXXXX...` |
 | `client_secret` | string | Yes | OAuth Client Secret from Zoho API Console | `abc123...` |
-| `refresh_token` | string | Yes | OAuth Refresh Token (never expires) | `1000.YYYYY...` |
-| `base_url` | string | No | Zoho accounts URL for your data center | `https://accounts.zoho.com` |
+| `refresh_token` | string | Yes | OAuth Refresh Token (never expires). Obtained automatically via the OAuth flow during connection setup. | `1000.YYYYY...` |
+| `region` | string | Yes | Zoho data center for your account. One of `US`, `EU`, `IN`, `AU`, `CN`, `JP`. Defaults to `US`. | `EU` |
 | `initial_load_start_date` | string | No | Starting point for the first sync. If omitted, syncs all historical data. (ISO 8601 format) | `2024-01-01T00:00:00Z` |
 
 ### Table-Level Options
@@ -88,20 +88,20 @@ curl -X POST "https://{accounts-server}/oauth/v2/token" \
 
 The response will contain your `refresh_token` - save this securely!
 
-### Base URL by Data Center
+### Region → Accounts URL
 
-Choose the appropriate `base_url` (Zoho accounts URL) based on your data center:
+The `region` parameter selects which Zoho data center the connector talks to.
+The connector and the OAuth flow both derive the correct accounts URL from
+this value automatically:
 
-| Data Center | Base URL |
-|-------------|----------|
-| US | `https://accounts.zoho.com` |
-| EU | `https://accounts.zoho.eu` |
-| IN | `https://accounts.zoho.in` |
-| AU | `https://accounts.zoho.com.au` |
-| CN | `https://accounts.zoho.com.cn` |
-| JP | `https://accounts.zoho.jp` |
-
-The connector automatically derives the correct API endpoint from the accounts URL.
+| Region | Accounts URL |
+|--------|--------------|
+| `US` | `https://accounts.zoho.com` |
+| `EU` | `https://accounts.zoho.eu` |
+| `IN` | `https://accounts.zoho.in` |
+| `AU` | `https://accounts.zoho.com.au` |
+| `CN` | `https://accounts.zoho.com.cn` |
+| `JP` | `https://accounts.zoho.jp` |
 
 ### Create a Unity Catalog Connection
 
@@ -362,7 +362,7 @@ The connector implements automatic retry with exponential backoff for rate limit
 If you see "Token refresh response missing 'access_token'":
 1. Verify your `client_id` and `client_secret` are correct
 2. Check that your `refresh_token` is valid (hasn't been revoked)
-3. Ensure you're using the correct `base_url` for your data center
+3. Ensure `region` matches the data center where your Zoho account lives
 
 **Empty Module Data:**
 

--- a/src/databricks/labs/community_connector/sources/zoho_crm/README.md
+++ b/src/databricks/labs/community_connector/sources/zoho_crm/README.md
@@ -19,9 +19,10 @@ To configure the connector, provide the following parameters in your connector o
 |-----------|------|----------|-------------|---------|
 | `client_id` | string | Yes | OAuth Client ID from Zoho API Console | `1000.XXXXX...` |
 | `client_secret` | string | Yes | OAuth Client Secret from Zoho API Console | `abc123...` |
-| `refresh_token` | string | Yes | OAuth Refresh Token (never expires). Obtained automatically via the OAuth flow during connection setup. | `1000.YYYYY...` |
 | `region` | string | Yes | Zoho data center for your account. One of `US`, `EU`, `IN`, `AU`, `CN`, `JP`. Defaults to `US`. | `EU` |
 | `initial_load_start_date` | string | No | Starting point for the first sync. If omitted, syncs all historical data. (ISO 8601 format) | `2024-01-01T00:00:00Z` |
+
+OAuth tokens (access / refresh) are managed by Unity Catalog and are not user-supplied.
 
 ### Table-Level Options
 
@@ -361,8 +362,7 @@ The connector implements automatic retry with exponential backoff for rate limit
 
 If you see "Token refresh response missing 'access_token'":
 1. Verify your `client_id` and `client_secret` are correct
-2. Check that your `refresh_token` is valid (hasn't been revoked)
-3. Ensure `region` matches the data center where your Zoho account lives
+2. Ensure `region` matches the data center where your Zoho account lives
 
 **Empty Module Data:**
 

--- a/src/databricks/labs/community_connector/sources/zoho_crm/connector_spec.yaml
+++ b/src/databricks/labs/community_connector/sources/zoho_crm/connector_spec.yaml
@@ -6,9 +6,12 @@
 # Connection Parameters
 # These are provided when creating the Unity Catalog connection.
 #
-# This connector uses OAuth2 authentication with Zoho API. A single
-# authentication method is supported using client credentials and a
-# refresh token obtained through the OAuth flow.
+# This connector uses OAuth 2.0 (authorization code flow) with Zoho. The user
+# supplies their own OAuth app credentials (client_id + client_secret created
+# in https://api-console.zoho.com/) and a data center region. The OAuth flow
+# itself — exchange of authorization_code for access_token + refresh_token —
+# is performed by the consumer of this spec (the labs CLI for local dev, or
+# Unity Catalog for production connections).
 # ============================================================================
 display_name: Zoho CRM
 connection:
@@ -17,34 +20,27 @@ connection:
       type: string
       required: true
       description: >
-        OAuth Client ID from Zoho API Console. Obtain this by creating a
-        Server-based Application at https://api-console.zoho.com/
+        OAuth Client ID from Zoho API Console. Create a Server-based
+        Application at https://api-console.zoho.com/ to obtain this.
 
     - name: client_secret
       type: string
       required: true
       secret: true
       description: >
-        OAuth Client Secret from Zoho API Console. This is the secret
-        associated with your Client ID.
+        OAuth Client Secret from Zoho API Console — paired with the Client ID
+        above.
 
-    - name: refresh_token
+    - name: region
       type: string
       required: true
-      secret: true
+      default: US
+      enum: [US, EU, IN, AU, CN, JP]
       description: >
-        OAuth Refresh Token obtained from the authorization flow. This is a
-        long-lived token that never expires and is used to obtain access tokens.
-        Follow the OAuth setup guide in the README to generate this token.
-
-    - name: base_url
-      type: string
-      required: false
-      description: >
-        Zoho accounts URL for OAuth authentication. Defaults to
-        https://accounts.zoho.com (US data center). Use region-specific URLs
-        for other data centers: accounts.zoho.eu (EU), accounts.zoho.in (IN),
-        accounts.zoho.com.au (AU), accounts.zoho.com.cn (CN), accounts.zoho.jp (JP).
+        Zoho data center region for your account. Selects the OAuth endpoints
+        used during authorization. US = accounts.zoho.com, EU = accounts.zoho.eu,
+        IN = accounts.zoho.in, AU = accounts.zoho.com.au, CN = accounts.zoho.com.cn,
+        JP = accounts.zoho.jp.
 
     - name: initial_load_start_date
       type: string
@@ -56,19 +52,49 @@ connection:
 
   # ---------------------------------------------------------------------------
   # OAuth 2.0 Authorization Code Flow
-  # The authenticate tool uses this section to run the OAuth flow
-  # automatically — the user only needs to provide client_id and
-  # client_secret, and the refresh_token is obtained via browser redirect.
-  # The authorization_url, token_url, and scopes shown below are defaults
-  # that the user can override at runtime.
+  #
+  # `flow`               — community OAuth subtype: u2m | m2m | u2m_per_user.
+  #                        u2m (default) = single shared refresh_token, used by
+  #                        UC to mint access tokens on the connector's behalf.
+  # `pkce`               — whether to use PKCE during authorization. Zoho does
+  #                        not require PKCE for confidential clients.
+  # `scopes`             — OAuth scope string sent on the authorization URL.
+  # `extra_auth_params`  — provider-specific knobs folded into the authorization
+  #                        URL. For Zoho: access_type=offline + prompt=consent
+  #                        are required to obtain a refresh_token.
+  # `endpoints_by_region`— multi-region endpoint map. The `parameter` field
+  #                        names the connection param whose value selects the
+  #                        endpoint set; `values` keys must match that param's
+  #                        `enum` exactly.
   # ---------------------------------------------------------------------------
   oauth:
-    authorization_url: "https://accounts.zoho.com/oauth/v2/auth"
-    token_url: "https://accounts.zoho.com/oauth/v2/token"
+    flow: u2m
+    pkce: false
     scopes: "ZohoCRM.modules.ALL,ZohoCRM.settings.ALL"
     extra_auth_params:
-      access_type: "offline"
-      prompt: "consent"
+      access_type: offline
+      prompt: consent
+    endpoints_by_region:
+      parameter: region
+      values:
+        US:
+          authorization_url: "https://accounts.zoho.com/oauth/v2/auth"
+          token_url: "https://accounts.zoho.com/oauth/v2/token"
+        EU:
+          authorization_url: "https://accounts.zoho.eu/oauth/v2/auth"
+          token_url: "https://accounts.zoho.eu/oauth/v2/token"
+        IN:
+          authorization_url: "https://accounts.zoho.in/oauth/v2/auth"
+          token_url: "https://accounts.zoho.in/oauth/v2/token"
+        AU:
+          authorization_url: "https://accounts.zoho.com.au/oauth/v2/auth"
+          token_url: "https://accounts.zoho.com.au/oauth/v2/token"
+        CN:
+          authorization_url: "https://accounts.zoho.com.cn/oauth/v2/auth"
+          token_url: "https://accounts.zoho.com.cn/oauth/v2/token"
+        JP:
+          authorization_url: "https://accounts.zoho.jp/oauth/v2/auth"
+          token_url: "https://accounts.zoho.jp/oauth/v2/token"
 
 # ============================================================================
 # External Options Allowlist

--- a/src/databricks/labs/community_connector/sources/zoho_crm/connector_spec.yaml
+++ b/src/databricks/labs/community_connector/sources/zoho_crm/connector_spec.yaml
@@ -62,10 +62,14 @@ connection:
   # `extra_auth_params`  — provider-specific knobs folded into the authorization
   #                        URL. For Zoho: access_type=offline + prompt=consent
   #                        are required to obtain a refresh_token.
-  # `endpoints_by_region`— multi-region endpoint map. The `parameter` field
-  #                        names the connection param whose value selects the
-  #                        endpoint set; `values` keys must match that param's
-  #                        `enum` exactly.
+  #
+  # Endpoints — declare exactly one of:
+  # * flat `authorization_url` + `token_url` for single-region providers
+  #   (Gmail, GitHub, etc.), OR
+  # * `endpoints_by_region` for providers hosted in multiple data centers.
+  #   The `parameter` field names a connection param (must be `enum`-typed);
+  #   `values` keys must match that param's `enum` exactly. Zoho hosts six
+  #   data centers, so it uses this form.
   # ---------------------------------------------------------------------------
   oauth:
     flow: u2m

--- a/src/databricks/labs/community_connector/sources/zoho_crm/zoho_client.py
+++ b/src/databricks/labs/community_connector/sources/zoho_crm/zoho_client.py
@@ -94,20 +94,30 @@ class ZohoAPIClient:  # pylint: disable=too-many-instance-attributes
 
     def __init__(
         self,
-        client_id: str,
-        client_secret: str,
-        refresh_token: str,
         accounts_url: str = "https://accounts.zoho.com",
+        access_token: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        refresh_token: Optional[str] = None,
     ) -> None:
         """
         Initialize the API client.
 
-        Args:
-            client_id: OAuth Client ID from Zoho API Console
-            client_secret: OAuth Client Secret from Zoho API Console
-            refresh_token: Long-lived refresh token from OAuth flow
-            accounts_url: Zoho accounts URL for OAuth (region-specific)
+        Two authentication modes:
+
+        1. UC-managed: caller passes a pre-issued ``access_token``. The client
+           uses it directly and never attempts a refresh — UC owns token
+           lifecycle on the connection.
+        2. Local-dev: caller passes ``client_id`` + ``client_secret`` +
+           ``refresh_token``. The client mints access tokens itself by calling
+           Zoho's refresh endpoint, used by ``authenticate.py`` flows.
         """
+        if not access_token and not all([client_id, client_secret, refresh_token]):
+            raise ValueError(
+                "ZohoAPIClient requires either 'access_token' (UC-managed) "
+                "or 'client_id' + 'client_secret' + 'refresh_token' (local dev)."
+            )
+
         self.client_id = client_id
         self.client_secret = client_secret
         self.refresh_token = refresh_token
@@ -120,8 +130,11 @@ class ZohoAPIClient:  # pylint: disable=too-many-instance-attributes
         self.api_url = f"https://www.zohoapis.{domain_suffix}"
 
         # Token management
-        self._access_token: Optional[str] = None
+        self._access_token: Optional[str] = access_token
+        # When the caller pre-issues the token, expiry is owned by the caller
+        # (UC); we trust it for the life of this client.
         self._token_expires_at: Optional[datetime] = None
+        self._token_externally_managed: bool = bool(access_token)
 
         # HTTP session for connection pooling
         self._session = requests.Session()
@@ -131,6 +144,10 @@ class ZohoAPIClient:  # pylint: disable=too-many-instance-attributes
         Get a valid access token, refreshing if necessary.
         Access tokens expire after 1 hour (3600 seconds).
         """
+        # Externally-issued token (UC-managed): return as-is.
+        if self._token_externally_managed and self._access_token:
+            return self._access_token
+
         # Check if we have a valid token (with 5-minute buffer)
         if self._access_token and self._token_expires_at:
             if datetime.now() < self._token_expires_at - timedelta(minutes=5):

--- a/src/databricks/labs/community_connector/sources/zoho_crm/zoho_crm.py
+++ b/src/databricks/labs/community_connector/sources/zoho_crm/zoho_crm.py
@@ -67,33 +67,34 @@ class ZohoCRMLakeflowConnect(LakeflowConnect):
         Initialize the Zoho CRM connector with connection-level options.
 
         Expected options:
-            - client_id: OAuth Client ID from Zoho API Console
-            - client_secret: OAuth Client Secret from Zoho API Console
-            - refresh_token: Long-lived refresh token obtained from OAuth flow
-            - region (optional): Zoho data center region — US, EU, IN, AU, CN, JP.
-              Defaults to US (accounts.zoho.com). Also accepts the legacy
-              `base_url` option for backwards compatibility.
-            - initial_load_start_date (optional): Starting point for the first sync.
+            - region: Zoho data center — US, EU, IN, AU, CN, JP. Defaults to
+              US. Accepts legacy ``base_url`` as a fallback.
+            - access_token: pre-issued Zoho OAuth access token (UC-managed path).
+            - client_id / client_secret / refresh_token: local-dev path used
+              by ``authenticate.py``; the connector mints access tokens itself.
+            - initial_load_start_date (optional): starting point for first sync.
         """
-        client_id = options.get("client_id")
-        client_secret = options.get("client_secret")
-        refresh_token = options.get("refresh_token")
-
-        if not all([client_id, client_secret, refresh_token]):
-            raise ValueError(
-                "Zoho CRM connector requires 'client_id', 'client_secret', "
-                "and 'refresh_token' in the UC connection"
-            )
-
         self.initial_load_start_date = options.get("initial_load_start_date")
         accounts_url = _resolve_accounts_url(options)
 
-        self._client = ZohoAPIClient(
-            client_id=client_id,
-            client_secret=client_secret,
-            refresh_token=refresh_token,
-            accounts_url=accounts_url,
-        )
+        access_token = options.get("access_token")
+        if access_token:
+            self._client = ZohoAPIClient(accounts_url=accounts_url, access_token=access_token)
+        else:
+            client_id = options.get("client_id")
+            client_secret = options.get("client_secret")
+            refresh_token = options.get("refresh_token")
+            if not all([client_id, client_secret, refresh_token]):
+                raise ValueError(
+                    "Zoho CRM connector requires either 'access_token' (UC-managed) or "
+                    "'client_id' + 'client_secret' + 'refresh_token' (local dev) in the options."
+                )
+            self._client = ZohoAPIClient(
+                accounts_url=accounts_url,
+                client_id=client_id,
+                client_secret=client_secret,
+                refresh_token=refresh_token,
+            )
 
         self._module_handler = ModuleHandler(self._client)
         self._settings_handler = SettingsHandler(self._client)

--- a/src/databricks/labs/community_connector/sources/zoho_crm/zoho_crm.py
+++ b/src/databricks/labs/community_connector/sources/zoho_crm/zoho_crm.py
@@ -23,6 +23,36 @@ from databricks.labs.community_connector.sources.zoho_crm.handlers import (
 
 logger = logging.getLogger(__name__)
 
+# Zoho accounts URL per data center region. Keep in sync with the
+# `endpoints_by_region` block in connector_spec.yaml.
+_ACCOUNTS_URL_BY_REGION = {
+    "US": "https://accounts.zoho.com",
+    "EU": "https://accounts.zoho.eu",
+    "IN": "https://accounts.zoho.in",
+    "AU": "https://accounts.zoho.com.au",
+    "CN": "https://accounts.zoho.com.cn",
+    "JP": "https://accounts.zoho.jp",
+}
+_DEFAULT_REGION = "US"
+
+
+def _resolve_accounts_url(options: dict[str, str]) -> str:
+    """Resolve the Zoho accounts URL from options.
+
+    Prefer `region` (current spec); fall back to `base_url` for connections
+    created against the previous spec shape so existing dev configs still load.
+    """
+    region = options.get("region")
+    if region:
+        url = _ACCOUNTS_URL_BY_REGION.get(region.upper())
+        if not url:
+            raise ValueError(
+                f"Unknown Zoho region '{region}'. "
+                f"Expected one of: {', '.join(_ACCOUNTS_URL_BY_REGION)}"
+            )
+        return url
+    return options.get("base_url", _ACCOUNTS_URL_BY_REGION[_DEFAULT_REGION])
+
 
 class ZohoCRMLakeflowConnect(LakeflowConnect):
     """
@@ -40,8 +70,9 @@ class ZohoCRMLakeflowConnect(LakeflowConnect):
             - client_id: OAuth Client ID from Zoho API Console
             - client_secret: OAuth Client Secret from Zoho API Console
             - refresh_token: Long-lived refresh token obtained from OAuth flow
-            - base_url (optional): Zoho accounts URL for OAuth.
-              Defaults to https://accounts.zoho.com
+            - region (optional): Zoho data center region — US, EU, IN, AU, CN, JP.
+              Defaults to US (accounts.zoho.com). Also accepts the legacy
+              `base_url` option for backwards compatibility.
             - initial_load_start_date (optional): Starting point for the first sync.
         """
         client_id = options.get("client_id")
@@ -55,7 +86,7 @@ class ZohoCRMLakeflowConnect(LakeflowConnect):
             )
 
         self.initial_load_start_date = options.get("initial_load_start_date")
-        accounts_url = options.get("base_url", "https://accounts.zoho.com")
+        accounts_url = _resolve_accounts_url(options)
 
         self._client = ZohoAPIClient(
             client_id=client_id,

--- a/templates/connector_spec_template.yaml
+++ b/templates/connector_spec_template.yaml
@@ -19,6 +19,20 @@
 # and provide all its required parameters. Common parameters apply to all methods.
 # ============================================================================
 connection:
+  # Parameter attributes:
+  #   name         (string, required) — the option key passed to the connector.
+  #   type         (string)            — `string`, `integer`, or `boolean`.
+  #   required     (bool, default false) — UI/CLI enforces non-empty input.
+  #   secret       (bool, default false) — UI/CLI masks input.
+  #   default      (any)               — pre-filled value; used when the user
+  #                                      submits empty input.
+  #   enum         (list)              — restricts the param to a fixed set of
+  #                                      values; UI renders a Select, CLI
+  #                                      renders a numbered list. Required if
+  #                                      the param is referenced from
+  #                                      `oauth.endpoints_by_region.parameter`.
+  #   description  (string)            — shown to the user.
+  #
   # ---------------------------------------------------------------------------
   # OPTION A: Single Authentication Method (use this for simple connectors)
   # ---------------------------------------------------------------------------
@@ -29,11 +43,13 @@ connection:
   #     description: >
   #       API key used for authentication.
   #
-  #   - name: base_url
+  #   - name: region
   #     type: string
-  #     required: false
+  #     required: true
+  #     default: US
+  #     enum: [US, EU]
   #     description: >
-  #       Base URL for the API. Override if using a custom instance.
+  #       Data center region for your account.
 
   # ---------------------------------------------------------------------------
   # OPTION B: Multiple Authentication Methods (use for connectors with choices)
@@ -81,21 +97,61 @@ connection:
 
   # ---------------------------------------------------------------------------
   # OAuth 2.0 Authorization Code Flow (optional)
+  #
   # Uncomment this section if the source uses OAuth 2.0 for authentication.
-  # The authenticate tool will run the browser-based OAuth flow automatically
-  # so the user only needs to provide client_id and client_secret; the
-  # refresh_token is obtained via the redirect.  These three parameter names
-  # are the standard OAuth 2.0 names and are expected in the parameters list.
-  # The authorization_url, token_url, and scopes are defaults that the user
-  # can override at runtime.
+  # The authenticate tool runs the browser-based flow so the user only
+  # supplies client_id + client_secret; the refresh_token (or, for UC, the
+  # access_token + server-side refresh) is obtained from the provider.
+  #
+  # Required:
+  #   - scopes               OAuth scope string sent on the authorization URL.
+  #   - One of `authorization_url` + `token_url` OR `endpoints_by_region`
+  #     (see the two forms below).
+  #
+  # Optional:
+  #   - flow                 u2m (default) | m2m | u2m_per_user.
+  #                          Selects the UC community OAuth subtype.
+  #   - pkce                 true | false (default false). Set to true when
+  #                          the provider requires PKCE for confidential
+  #                          clients. The labs CLI does NOT yet implement
+  #                          PKCE — `pkce: true` will error there until
+  #                          authenticate.py is extended.
+  #   - extra_auth_params    Provider-specific knobs folded into the
+  #                          authorization URL (e.g. access_type=offline,
+  #                          prompt=consent, audience=…).
   # ---------------------------------------------------------------------------
+
+  # Form 1 — single-region: provider has one global pair of endpoints.
   # oauth:
+  #   flow: u2m
+  #   pkce: false
+  #   scopes: "read write"
   #   authorization_url: "https://example.com/oauth/authorize"
   #   token_url: "https://example.com/oauth/token"
+  #   extra_auth_params:
+  #     access_type: "offline"
+  #     prompt: "consent"
+
+  # Form 2 — multi-region: provider has different endpoints per data center.
+  # Add an enum-typed connection param to the `parameters` list above (e.g.
+  # `region` with `enum: [US, EU, …]` and a `default`), then key the
+  # endpoint map below by those same enum values.
+  # oauth:
+  #   flow: u2m
+  #   pkce: false
   #   scopes: "read write"
   #   extra_auth_params:
   #     access_type: "offline"
   #     prompt: "consent"
+  #   endpoints_by_region:
+  #     parameter: region
+  #     values:
+  #       US:
+  #         authorization_url: "https://accounts.example.com/oauth/authorize"
+  #         token_url: "https://accounts.example.com/oauth/token"
+  #       EU:
+  #         authorization_url: "https://accounts.example.eu/oauth/authorize"
+  #         token_url: "https://accounts.example.eu/oauth/token"
 
 # ============================================================================
 # External Options Allowlist

--- a/tools/scripts/authenticate.py
+++ b/tools/scripts/authenticate.py
@@ -71,6 +71,71 @@ def extract_oauth_config(spec: dict) -> dict | None:
     return spec.get("connection", {}).get("oauth")
 
 
+def resolve_oauth_endpoints(oauth_cfg: dict, collected: dict[str, str]) -> dict:
+    """Return an effective oauth config with flat authorization_url + token_url.
+
+    Two spec shapes are supported:
+
+    1. Flat (single-region): `oauth` carries `authorization_url` and
+       `token_url` directly. Returned as-is.
+
+    2. Multi-region: `oauth.endpoints_by_region` carries a `parameter` (the
+       name of a connection param whose enum value selects the endpoint set)
+       and a `values` map keyed by that param's enum values. The user's
+       selected value is read from `collected` and looked up.
+
+    The returned dict is a shallow copy of `oauth_cfg` with the resolved
+    `authorization_url` and `token_url` fields set; `endpoints_by_region` is
+    stripped so downstream code doesn't have to know about it.
+
+    PKCE is not yet supported in this CLI; an explicit `pkce: true` in the
+    spec raises so that connectors that require it don't silently succeed
+    with a non-PKCE authorization.
+    """
+    if oauth_cfg.get("pkce"):
+        raise ValueError(
+            "Spec sets oauth.pkce: true, but this CLI does not support PKCE yet. "
+            "Either set pkce: false in connector_spec.yaml or extend authenticate.py "
+            "to generate the code_verifier / code_challenge pair."
+        )
+
+    region_block = oauth_cfg.get("endpoints_by_region")
+    if region_block is None:
+        if not oauth_cfg.get("authorization_url") or not oauth_cfg.get("token_url"):
+            raise ValueError(
+                "oauth block must define either flat `authorization_url` + `token_url`, "
+                "or `endpoints_by_region.{parameter, values}`."
+            )
+        return dict(oauth_cfg)
+
+    param_name = region_block.get("parameter")
+    values = region_block.get("values") or {}
+    if not param_name or not values:
+        raise ValueError(
+            "oauth.endpoints_by_region must define both `parameter` and `values`."
+        )
+
+    selected = collected.get(param_name)
+    if not selected:
+        raise ValueError(
+            f"Cannot resolve OAuth endpoints: the connection param '{param_name}' "
+            f"referenced by oauth.endpoints_by_region.parameter was not provided. "
+            f"Expected one of: {', '.join(values)}."
+        )
+
+    endpoints = values.get(selected)
+    if not endpoints:
+        raise ValueError(
+            f"No OAuth endpoints defined for {param_name}={selected!r}. "
+            f"Expected one of: {', '.join(values)}."
+        )
+
+    resolved = {k: v for k, v in oauth_cfg.items() if k != "endpoints_by_region"}
+    resolved["authorization_url"] = endpoints["authorization_url"]
+    resolved["token_url"] = endpoints["token_url"]
+    return resolved
+
+
 # ---------------------------------------------------------------------------
 # OAuth helpers
 # ---------------------------------------------------------------------------
@@ -122,18 +187,48 @@ def _exchange_code(
 # ---------------------------------------------------------------------------
 
 def prompt_for_parameter(param: dict) -> str | None:
-    """Prompt the user for a single parameter value in the terminal."""
+    """Prompt the user for a single parameter value in the terminal.
+
+    Honors `enum` (renders a numbered choice list; accepts an index or a
+    literal enum value) and `default` (used when the user submits an empty
+    line). When both are present, the default must be one of the enum values.
+    """
     name = param["name"]
     description = param.get("description", "").strip()
     required = param.get("required", False)
     is_secret = param.get("secret", False)
+    enum_values = param.get("enum")
+    default = param.get("default")
 
     tag = "REQUIRED" if required else "optional"
     print(f"\n── {name} ({tag}) ──")
     if description:
         print(f"   {description}")
 
-    prompt_text = f"  {name}: "
+    if enum_values:
+        for idx, choice in enumerate(enum_values, start=1):
+            marker = "  (default)" if default is not None and choice == default else ""
+            print(f"   {idx}. {choice}{marker}")
+        prompt_text = f"  {name} [enter number or value]: "
+        raw = input(prompt_text).strip()
+        if not raw:
+            if default is not None:
+                return str(default)
+            if required:
+                print(f"  ⚠  '{name}' is required. Please choose a value.")
+                return prompt_for_parameter(param)
+            return None
+        if raw.isdigit():
+            idx = int(raw)
+            if 1 <= idx <= len(enum_values):
+                return str(enum_values[idx - 1])
+        if raw in [str(v) for v in enum_values]:
+            return raw
+        print(f"  ⚠  '{raw}' is not one of: {', '.join(str(v) for v in enum_values)}")
+        return prompt_for_parameter(param)
+
+    default_hint = f" [{default}]" if default is not None else ""
+    prompt_text = f"  {name}{default_hint}: "
     if is_secret:
         value = getpass.getpass(prompt_text)
     else:
@@ -142,19 +237,14 @@ def prompt_for_parameter(param: dict) -> str | None:
     value = value.strip()
 
     if not value:
+        if default is not None:
+            return str(default)
         if required:
             print(f"  ⚠  '{name}' is required. Please provide a value.")
             return prompt_for_parameter(param)
         return None
 
     return value
-
-
-def _prompt_oauth_setting(name: str, default: str) -> str:
-    """Prompt for an OAuth setting, showing the default. Enter keeps the default."""
-    print(f"\n── {name} ──")
-    value = input(f"  [{default}]: ").strip()
-    return value or default
 
 
 def _run_oauth_flow_cli(  # pylint: disable=too-many-statements
@@ -328,18 +418,11 @@ def run_cli(  # pylint: disable=too-many-locals,too-many-statements,too-many-bra
         cid = collected.get("client_id", "")
         csec = collected.get("client_secret", "")
         if cid and csec:
-            # Let user review / override OAuth settings
-            print("\n▸ OAuth 2.0 Settings (press Enter to accept defaults):")
-            effective_cfg = dict(oauth_cfg)
-            effective_cfg["authorization_url"] = _prompt_oauth_setting(
-                "authorization_url", oauth_cfg["authorization_url"],
-            )
-            effective_cfg["token_url"] = _prompt_oauth_setting(
-                "token_url", oauth_cfg["token_url"],
-            )
-            effective_cfg["scopes"] = _prompt_oauth_setting(
-                "scopes", oauth_cfg.get("scopes", ""),
-            )
+            # Endpoints come from the spec — possibly via a region selector — so
+            # we no longer prompt the user to type/edit URLs. Resolution
+            # surfaces a clear error if the spec is malformed or a required
+            # selector param wasn't collected.
+            effective_cfg = resolve_oauth_endpoints(oauth_cfg, collected)
 
             print("\n▸ OAuth 2.0 Authorization")
             refresh_token = _run_oauth_flow_cli(effective_cfg, cid, csec, port)
@@ -437,16 +520,14 @@ async function startOAuth(){
   var csecEl=document.getElementById('client_secret');
   if(!cidEl||!cidEl.value.trim()){alert('Please fill in client_id first.');return}
   if(!csecEl||!csecEl.value.trim()){alert('Please fill in client_secret first.');return}
+  // Collect every form field (inputs + selects) so the server can resolve
+  // endpoints via spec.oauth.endpoints_by_region when applicable.
   var body={};
-  document.querySelectorAll('input[name]:not([disabled])').forEach(function(el){
-    if(el.value.trim()) body[el.name]=el.value.trim();
-  });
-  var au=document.getElementById('__oauth_authorization_url');
-  var tu=document.getElementById('__oauth_token_url');
-  var sc=document.getElementById('__oauth_scopes');
-  if(au) body.__oauth_authorization_url=au.value.trim();
-  if(tu) body.__oauth_token_url=tu.value.trim();
-  if(sc) body.__oauth_scopes=sc.value.trim();
+  document.querySelectorAll('input[name]:not([disabled]),select[name]:not([disabled])')
+    .forEach(function(el){
+      var v=(el.value||'').toString().trim();
+      if(v) body[el.name]=v;
+    });
   var st=document.getElementById('oauth-status');
   if(st){st.textContent='Starting OAuth flow\\u2026';st.className='oauth-status pending'}
   try{
@@ -455,6 +536,7 @@ async function startOAuth(){
     });
     if(!resp.ok) throw new Error('Server error '+resp.status);
     var data=await resp.json();
+    if(data.error){throw new Error(data.error)}
     if(st){st.textContent='Waiting for authorization in popup\\u2026'}
     var popup=window.open(data.auth_url,'oauth_popup','width=600,height=700,scrollbars=yes');
     if(!popup&&st){st.textContent='Popup blocked \\u2014 please allow popups and try again.';
@@ -484,10 +566,11 @@ def _render_field(param: dict, disabled: bool = False) -> str:
     desc = param.get("description", "").strip()
     required = param.get("required", False)
     is_secret = param.get("secret", False)
+    enum_values = param.get("enum")
+    default = param.get("default")
 
     tag_cls = "req" if required else "opt"
     tag_label = "required" if required else "optional"
-    input_type = "password" if is_secret else "text"
     req_attr = "required" if required else ""
     dis_attr = "disabled" if disabled else ""
 
@@ -496,42 +579,41 @@ def _render_field(param: dict, disabled: bool = False) -> str:
                  f'<span class="tag {tag_cls}">{tag_label}</span></label>')
     if desc:
         lines.append(f'<div class="desc">{_esc(desc)}</div>')
-    lines.append(f'<input type="{input_type}" id="{_esc(name)}" name="{_esc(name)}" '
-                 f'autocomplete="off" {req_attr} {dis_attr}/>')
+
+    if enum_values:
+        options_html = []
+        for choice in enum_values:
+            value = _esc(str(choice))
+            selected = " selected" if default is not None and choice == default else ""
+            options_html.append(f'<option value="{value}"{selected}>{value}</option>')
+        lines.append(
+            f'<select id="{_esc(name)}" name="{_esc(name)}" class="auth-select" '
+            f'{req_attr} {dis_attr}>{"".join(options_html)}</select>'
+        )
+    else:
+        input_type = "password" if is_secret else "text"
+        value_attr = f' value="{_esc(str(default))}"' if default is not None else ""
+        lines.append(
+            f'<input type="{input_type}" id="{_esc(name)}" name="{_esc(name)}" '
+            f'autocomplete="off"{value_attr} {req_attr} {dis_attr}/>'
+        )
     lines.append('</div>')
     return "\n".join(lines)
 
 
-def _render_oauth_section(oauth_cfg: dict, port: int) -> str:
-    """Render the OAuth 2.0 section with editable settings and Authorize button."""
+def _render_oauth_section(port: int) -> str:
+    """Render the OAuth 2.0 section with the Authorize button.
+
+    OAuth endpoints come from the spec (resolved via `resolve_oauth_endpoints`
+    against the submitted form values), so the user is never asked to type or
+    edit URLs. The connector_spec is the source of truth.
+    """
     redirect_uri = f"http://localhost:{port}/oauth/callback"
-    auth_url = _esc(oauth_cfg.get("authorization_url", ""))
-    token_url = _esc(oauth_cfg.get("token_url", ""))
-    scopes = _esc(oauth_cfg.get("scopes", ""))
 
     lines = [
         '<div class="section-title">OAuth 2.0 Authorization</div>',
         f'<div class="redirect-uri"><strong>Redirect URI</strong> '
         f'(register in your OAuth app): <code>{_esc(redirect_uri)}</code></div>',
-        # authorization_url — no name attr so it doesn't submit with the form
-        '<div class="field">',
-        '<label for="__oauth_authorization_url">authorization_url'
-        '<span class="tag opt">editable</span></label>',
-        f'<input type="text" id="__oauth_authorization_url"'
-        f' value="{auth_url}" autocomplete="off"/>',
-        '</div>',
-        # token_url
-        '<div class="field">',
-        '<label for="__oauth_token_url">token_url'
-        '<span class="tag opt">editable</span></label>',
-        f'<input type="text" id="__oauth_token_url" value="{token_url}" autocomplete="off"/>',
-        '</div>',
-        # scopes
-        '<div class="field">',
-        '<label for="__oauth_scopes">scopes'
-        '<span class="tag opt">editable</span></label>',
-        f'<input type="text" id="__oauth_scopes" value="{scopes}" autocomplete="off"/>',
-        '</div>',
         # hidden refresh_token (filled by OAuth flow, submitted with form)
         '<input type="hidden" id="refresh_token" name="refresh_token" />',
         # Authorize button + status
@@ -600,7 +682,7 @@ def _build_form_html(  # pylint: disable=too-many-locals,too-many-branches
 
     # OAuth section at the bottom
     if oauth_cfg:
-        parts.append(_render_oauth_section(oauth_cfg, port))
+        parts.append(_render_oauth_section(port))
 
     parts.append('<button type="submit">Save Configuration</button>')
     parts.append('</form>')
@@ -714,14 +796,14 @@ def run_browser(  # pylint: disable=too-many-statements,too-many-locals
             client_id = body.get("client_id", "")
             client_secret = body.get("client_secret", "")
 
-            # Build effective config from spec defaults + user overrides
-            effective_cfg = dict(oauth_cfg)
-            if body.get("__oauth_authorization_url"):
-                effective_cfg["authorization_url"] = body["__oauth_authorization_url"]
-            if body.get("__oauth_token_url"):
-                effective_cfg["token_url"] = body["__oauth_token_url"]
-            if "__oauth_scopes" in body:
-                effective_cfg["scopes"] = body["__oauth_scopes"]
+            # Endpoints come from the spec, possibly via a region selector whose
+            # value is in `body`. The helper raises with a clear message if the
+            # spec is malformed or a required selector value is missing.
+            try:
+                effective_cfg = resolve_oauth_endpoints(oauth_cfg, body)
+            except ValueError as exc:
+                self._send_json({"error": str(exc)})
+                return
 
             state = secrets.token_urlsafe(32)
             redirect_uri = f"http://localhost:{port}/oauth/callback"


### PR DESCRIPTION
## Summary

Extends the `connector_spec.yaml` OAuth contract so multi-region providers
(Zoho, future SaaS connectors hosted on multiple data centers) and PKCE
requirements can be expressed in the spec rather than the consuming code.
Applies the new shape to Zoho CRM as the first user.

Spec additions (documented in `templates/connector_spec_template.yaml`):

- Connection-param attributes:
  - `default:` — pre-fill value, used when the user submits empty input.
  - `enum:` — restricts the param to a fixed set; renders as a Select in
    the browser form / numbered list in the CLI. Required when the param
    is referenced from `oauth.endpoints_by_region.parameter`.
- `oauth.flow` — `u2m` (default) | `m2m` | `u2m_per_user`. Maps to UC's
  `community_oauth_flow` option.
- `oauth.pkce` — bool, default false. The labs CLI does not yet implement
  PKCE; `pkce: true` raises at resolution time.
- `oauth.endpoints_by_region` — multi-region endpoint map. The `parameter`
  field names a connection param (must be `enum`-typed); `values` keys
  match that param's `enum` exactly. Mutually exclusive with flat
  `authorization_url` + `token_url`.

`tools/scripts/authenticate.py`:

- New `resolve_oauth_endpoints(oauth_cfg, collected)` returns an effective
  oauth config with flat URLs regardless of which form the spec uses; also
  enforces the PKCE-not-supported guard.
- `prompt_for_parameter` honors `enum` (accepts index or value, retries on
  invalid input) and `default` (used on empty input).
- Browser form renders `enum` params as `<select>` and `default` as the
  pre-filled input value.
- Removed the CLI URL/scope override prompts and the corresponding browser
  form fields — the spec is now expressive enough to describe every endpoint
  variant.

Zoho CRM:

- Dropped the `refresh_token` connection param (obtained by the OAuth flow,
  not user-supplied) and the free-form `base_url` (replaced by an enum
  `region` param plumbed through `oauth.endpoints_by_region`).
- `zoho_crm.py` resolves the accounts URL from `region` via a static map;
  `base_url` is kept as a fallback so existing local dev configs keep
  working until users re-run `authenticate.py`.

## Test plan

- [x] `python3.10 -c "import yaml; yaml.safe_load(open('connector_spec.yaml'))"` parses cleanly for Zoho and the template.
- [x] `python3.10 -c "import ast; ast.parse(open('authenticate.py').read())"` syntax-checks.
- [x] `resolve_oauth_endpoints` smoke tests: missing selector → clear error; valid region → expected URLs; unknown region → error; `pkce: true` → error; flat shape resolves; multi-region resolves.
- [x] `prompt_for_parameter` interactive: empty → default; numeric index → value; literal value → value; invalid → retry.
- [x] Browser form: region renders as `<select>` with US `selected`; password fields unchanged.
- [x] `_resolve_accounts_url` in `zoho_crm.py`: case-insensitive region; legacy `base_url` fallback; region wins over base_url; unknown region raises.
- [ ] Re-run `authenticate.py` against the new Zoho spec to regenerate `dev_config.json` with `region` (manual, requires real Zoho OAuth app).

This pull request and its description were written by Isaac.