### PR TITLE
Register sources via per-source DataSource subclasses + find_data_source()

### DIFF
--- a/.claude/skills/implement-connector/SKILL.md
+++ b/.claude/skills/implement-connector/SKILL.md
@@ -114,5 +114,16 @@ or any of the built-in op classes (`ListObjectsOp`, `ReadTableOp`,
 customisation API is still being finalised. Just implement
 `LakeflowConnect` — the agent surface comes along for free.
 
+## Expose the DataSource class
+
+In the source package's `__init__.py`, expose a `<Source>DataSource`
+subclass of `LakeflowSource` that binds your connector via
+`_lakeflow_connect_cls` (name = connector class with `LakeflowConnect`
+replaced by `DataSource`, e.g. `GmailLakeflowConnect` → `GmailDataSource`).
+This is required — it's what lets the source register through
+`spark.dataSource.register(...)` / `find_data_source("{source_name}")`.
+Set only `_lakeflow_connect_cls`; leave `_format_name` at its default and
+add the class to `__all__`. Copy the shape from `sources/example/__init__.py`.
+
 ## Merge files
 After completion, run `python tools/scripts/merge_python_source.py {source_name}` to generate the merged connector file `_generated_{source_name}_python_source.py`. 

--- a/.claude/skills/self-review-connector/SKILL.md
+++ b/.claude/skills/self-review-connector/SKILL.md
@@ -78,7 +78,7 @@ report actionable.
 
 ---
 
-### Section A — Connector implementation (12 checks)
+### Section A — Connector implementation (13 checks)
 
 Source under audit:
 `src/databricks/labs/community_connector/sources/{{source_name}}/{{source_name}}.py`
@@ -97,6 +97,7 @@ Source under audit:
 | A10 | MAJOR | Imports clean — no imports outside `sources/{{source_name}}/`, `interface/`, `libs/`, `requests`, `pyspark`, std-lib | `grep -nE "^(from\\|import) " ...` |
 | A11 | MAJOR | Pylint clean on connector source — same gate as `.github/workflows/pylint.yml` and the `tools/scripts/precommit_pylint.sh` PreToolUse hook | see "Running pylint" below |
 | A12 | MAJOR | Connector does **not** implement the experimental ingestion-agent surface (still in design). | `grep -nE "SupportsIngestionAgent\|AgentOperation\|agent_operations\(\)" src/.../sources/{{source_name}}/` — must be empty |
+| A13 | BLOCKER | Source package exposes a `<Source>DataSource(LakeflowSource)` subclass binding the connector via `_lakeflow_connect_cls`, so it can register via `spark.dataSource.register` / `find_data_source`. Leaves `_format_name` at its default. | `grep -nE "class \\w+DataSource\\(LakeflowSource\\)" src/.../sources/{{source_name}}/__init__.py` and verify `_lakeflow_connect_cls\\s*=` is set |
 
 #### Running pylint (A11)
 
@@ -286,6 +287,7 @@ Run at: 2026-05-06T15:32:00Z
 - ❌ A11. Pylint: 1 finding — `source.py:142: R0912 too-many-branches
        (21/20)`. Same gate as CI; fix before merge.
 - ✅ A12. No ingestion-agent surface implemented (experimental)
+- ✅ A13. `GithubDataSource(LakeflowSource)` exposed — `__init__.py:5`
 
 ## B. Testing & simulator validation — 22 / 26
 - ✅ B1–B7

--- a/src/databricks/labs/community_connector/sources/actitime/__init__.py
+++ b/src/databricks/labs/community_connector/sources/actitime/__init__.py
@@ -4,4 +4,18 @@ from databricks.labs.community_connector.sources.actitime.actitime import (
     ActitimeLakeflowConnect,
 )
 
-__all__ = ["ActitimeLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class ActitimeDataSource(LakeflowSource):
+    _lakeflow_connect_cls = ActitimeLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "actitime"
+
+
+__all__ = ["ActitimeLakeflowConnect",
+    "ActitimeDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/actitime/_generated_actitime_python_source.py
+++ b/src/databricks/labs/community_connector/sources/actitime/_generated_actitime_python_source.py
@@ -1965,8 +1965,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -1981,13 +2006,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/adme/__init__.py
+++ b/src/databricks/labs/community_connector/sources/adme/__init__.py
@@ -4,4 +4,18 @@ from databricks.labs.community_connector.sources.adme.adme import (
     ADMELakeflowConnect,
 )
 
-__all__ = ["ADMELakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class ADMEDataSource(LakeflowSource):
+    _lakeflow_connect_cls = ADMELakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "adme"
+
+
+__all__ = ["ADMELakeflowConnect",
+    "ADMEDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/adme/_generated_adme_python_source.py
+++ b/src/databricks/labs/community_connector/sources/adme/_generated_adme_python_source.py
@@ -1863,8 +1863,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -1879,13 +1904,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/appsflyer/__init__.py
+++ b/src/databricks/labs/community_connector/sources/appsflyer/__init__.py
@@ -2,4 +2,18 @@
 
 from databricks.labs.community_connector.sources.appsflyer.appsflyer import AppsflyerLakeflowConnect
 
-__all__ = ["AppsflyerLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class AppsflyerDataSource(LakeflowSource):
+    _lakeflow_connect_cls = AppsflyerLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "appsflyer"
+
+
+__all__ = ["AppsflyerLakeflowConnect",
+    "AppsflyerDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/appsflyer/_generated_appsflyer_python_source.py
+++ b/src/databricks/labs/community_connector/sources/appsflyer/_generated_appsflyer_python_source.py
@@ -1511,8 +1511,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -1527,13 +1552,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/azure_devops/__init__.py
+++ b/src/databricks/labs/community_connector/sources/azure_devops/__init__.py
@@ -4,4 +4,18 @@ from databricks.labs.community_connector.sources.azure_devops.azure_devops impor
     AzureDevopsLakeflowConnect,
 )
 
-__all__ = ["AzureDevopsLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class AzureDevopsDataSource(LakeflowSource):
+    _lakeflow_connect_cls = AzureDevopsLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "azure_devops"
+
+
+__all__ = ["AzureDevopsLakeflowConnect",
+    "AzureDevopsDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/azure_devops/_generated_azure_devops_python_source.py
+++ b/src/databricks/labs/community_connector/sources/azure_devops/_generated_azure_devops_python_source.py
@@ -2588,8 +2588,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -2604,13 +2629,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/dicomweb/__init__.py
+++ b/src/databricks/labs/community_connector/sources/dicomweb/__init__.py
@@ -1,3 +1,17 @@
 from databricks.labs.community_connector.sources.dicomweb.dicomweb import DICOMwebLakeflowConnect
 
-__all__ = ["DICOMwebLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class DICOMwebDataSource(LakeflowSource):
+    _lakeflow_connect_cls = DICOMwebLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "dicomweb"
+
+
+__all__ = ["DICOMwebLakeflowConnect",
+    "DICOMwebDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/dicomweb/_generated_dicomweb_python_source.py
+++ b/src/databricks/labs/community_connector/sources/dicomweb/_generated_dicomweb_python_source.py
@@ -2427,8 +2427,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -2443,13 +2468,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/example/__init__.py
+++ b/src/databricks/labs/community_connector/sources/example/__init__.py
@@ -2,4 +2,18 @@
 
 from databricks.labs.community_connector.sources.example.example import ExampleLakeflowConnect
 
-__all__ = ["ExampleLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class ExampleDataSource(LakeflowSource):
+    _lakeflow_connect_cls = ExampleLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "example"
+
+
+__all__ = ["ExampleLakeflowConnect",
+    "ExampleDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/example/_generated_example_python_source.py
+++ b/src/databricks/labs/community_connector/sources/example/_generated_example_python_source.py
@@ -1344,8 +1344,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -1360,13 +1385,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/fhir/__init__.py
+++ b/src/databricks/labs/community_connector/sources/fhir/__init__.py
@@ -1,0 +1,15 @@
+from databricks.labs.community_connector.sources.fhir.fhir import (
+    FhirLakeflowConnect,
+)
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class FhirDataSource(LakeflowSource):
+    _lakeflow_connect_cls = FhirLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "fhir"
+
+
+__all__ = ["FhirLakeflowConnect", "FhirDataSource"]

--- a/src/databricks/labs/community_connector/sources/fhir/_generated_fhir_python_source.py
+++ b/src/databricks/labs/community_connector/sources/fhir/_generated_fhir_python_source.py
@@ -2869,8 +2869,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -2885,13 +2910,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/github/__init__.py
+++ b/src/databricks/labs/community_connector/sources/github/__init__.py
@@ -2,4 +2,18 @@
 
 from databricks.labs.community_connector.sources.github.github import GithubLakeflowConnect
 
-__all__ = ["GithubLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class GithubDataSource(LakeflowSource):
+    _lakeflow_connect_cls = GithubLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "github"
+
+
+__all__ = ["GithubLakeflowConnect",
+    "GithubDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/github/_generated_github_python_source.py
+++ b/src/databricks/labs/community_connector/sources/github/_generated_github_python_source.py
@@ -2361,8 +2361,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -2377,13 +2402,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/gmail/__init__.py
+++ b/src/databricks/labs/community_connector/sources/gmail/__init__.py
@@ -2,4 +2,18 @@
 
 from databricks.labs.community_connector.sources.gmail.gmail import GmailLakeflowConnect
 
-__all__ = ["GmailLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class GmailDataSource(LakeflowSource):
+    _lakeflow_connect_cls = GmailLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "gmail"
+
+
+__all__ = ["GmailLakeflowConnect",
+    "GmailDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
+++ b/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
@@ -2054,8 +2054,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -2070,13 +2095,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/google_analytics_aggregated/__init__.py
+++ b/src/databricks/labs/community_connector/sources/google_analytics_aggregated/__init__.py
@@ -5,4 +5,18 @@ from databricks.labs.community_connector.sources.\
         GoogleAnalyticsAggregatedLakeflowConnect,
     )
 
-__all__ = ["GoogleAnalyticsAggregatedLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class GoogleAnalyticsAggregatedDataSource(LakeflowSource):
+    _lakeflow_connect_cls = GoogleAnalyticsAggregatedLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "google_analytics_aggregated"
+
+
+__all__ = ["GoogleAnalyticsAggregatedLakeflowConnect",
+    "GoogleAnalyticsAggregatedDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/google_analytics_aggregated/_generated_google_analytics_aggregated_python_source.py
+++ b/src/databricks/labs/community_connector/sources/google_analytics_aggregated/_generated_google_analytics_aggregated_python_source.py
@@ -1779,8 +1779,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -1795,13 +1820,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/google_sheets_docs/__init__.py
+++ b/src/databricks/labs/community_connector/sources/google_sheets_docs/__init__.py
@@ -10,4 +10,18 @@ from databricks.labs.community_connector.sources.google_sheets_docs.google_sheet
     GoogleSheetsDocsLakeflowConnect,
 )
 
-__all__ = ["GoogleSheetsDocsLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class GoogleSheetsDocsDataSource(LakeflowSource):
+    _lakeflow_connect_cls = GoogleSheetsDocsLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "google_sheets_docs"
+
+
+__all__ = ["GoogleSheetsDocsLakeflowConnect",
+    "GoogleSheetsDocsDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/google_sheets_docs/_generated_google_sheets_docs_python_source.py
+++ b/src/databricks/labs/community_connector/sources/google_sheets_docs/_generated_google_sheets_docs_python_source.py
@@ -1495,8 +1495,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -1511,13 +1536,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/hubspot/__init__.py
+++ b/src/databricks/labs/community_connector/sources/hubspot/__init__.py
@@ -2,4 +2,18 @@
 
 from databricks.labs.community_connector.sources.hubspot.hubspot import HubspotLakeflowConnect
 
-__all__ = ["HubspotLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class HubspotDataSource(LakeflowSource):
+    _lakeflow_connect_cls = HubspotLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "hubspot"
+
+
+__all__ = ["HubspotLakeflowConnect",
+    "HubspotDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
+++ b/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
@@ -1584,8 +1584,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -1600,13 +1625,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/microsoft_teams/__init__.py
+++ b/src/databricks/labs/community_connector/sources/microsoft_teams/__init__.py
@@ -4,4 +4,18 @@ from databricks.labs.community_connector.sources.microsoft_teams.microsoft_teams
     MicrosoftTeamsLakeflowConnect,
 )
 
-__all__ = ["MicrosoftTeamsLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class MicrosoftTeamsDataSource(LakeflowSource):
+    _lakeflow_connect_cls = MicrosoftTeamsLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "microsoft_teams"
+
+
+__all__ = ["MicrosoftTeamsLakeflowConnect",
+    "MicrosoftTeamsDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/microsoft_teams/_generated_microsoft_teams_python_source.py
+++ b/src/databricks/labs/community_connector/sources/microsoft_teams/_generated_microsoft_teams_python_source.py
@@ -2279,8 +2279,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -2295,13 +2320,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/mixpanel/__init__.py
+++ b/src/databricks/labs/community_connector/sources/mixpanel/__init__.py
@@ -2,4 +2,18 @@
 
 from databricks.labs.community_connector.sources.mixpanel.mixpanel import MixpanelLakeflowConnect
 
-__all__ = ["MixpanelLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class MixpanelDataSource(LakeflowSource):
+    _lakeflow_connect_cls = MixpanelLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "mixpanel"
+
+
+__all__ = ["MixpanelLakeflowConnect",
+    "MixpanelDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/mixpanel/_generated_mixpanel_python_source.py
+++ b/src/databricks/labs/community_connector/sources/mixpanel/_generated_mixpanel_python_source.py
@@ -1551,8 +1551,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -1567,13 +1592,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/osipi/__init__.py
+++ b/src/databricks/labs/community_connector/sources/osipi/__init__.py
@@ -17,6 +17,18 @@ from databricks.labs.community_connector.sources.osipi.osipi_schemas import (
     TABLE_SCHEMAS,
 )
 
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class OsipiDataSource(LakeflowSource):
+    _lakeflow_connect_cls = OsipiLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "osipi"
+
+
 __all__ = [
     "OsipiLakeflowConnect",
     "SUPPORTED_TABLES",
@@ -27,4 +39,5 @@ __all__ = [
     "TABLES_GOVERNANCE_DIAGNOSTICS",
     "TABLE_SCHEMAS",
     "TABLE_METADATA",
+    "OsipiDataSource",
 ]

--- a/src/databricks/labs/community_connector/sources/osipi/_generated_osipi_python_source.py
+++ b/src/databricks/labs/community_connector/sources/osipi/_generated_osipi_python_source.py
@@ -4402,8 +4402,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -4418,13 +4443,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/palantir/__init__.py
+++ b/src/databricks/labs/community_connector/sources/palantir/__init__.py
@@ -1,5 +1,15 @@
 """Palantir Foundry connector for Lakeflow Community Connectors."""
 
 from databricks.labs.community_connector.sources.palantir.palantir import PalantirLakeflowConnect
+from databricks.labs.community_connector.sparkpds import LakeflowSource
 
-__all__ = ["PalantirLakeflowConnect"]
+
+class PalantirDataSource(LakeflowSource):
+    _lakeflow_connect_cls = PalantirLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "palantir"
+
+
+__all__ = ["PalantirLakeflowConnect", "PalantirDataSource"]

--- a/src/databricks/labs/community_connector/sources/palantir/_generated_palantir_python_source.py
+++ b/src/databricks/labs/community_connector/sources/palantir/_generated_palantir_python_source.py
@@ -1936,8 +1936,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -1952,13 +1977,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/qualtrics/__init__.py
+++ b/src/databricks/labs/community_connector/sources/qualtrics/__init__.py
@@ -1,0 +1,15 @@
+from databricks.labs.community_connector.sources.qualtrics.qualtrics import (
+    QualtricsLakeflowConnect,
+)
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class QualtricsDataSource(LakeflowSource):
+    _lakeflow_connect_cls = QualtricsLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "qualtrics"
+
+
+__all__ = ["QualtricsLakeflowConnect", "QualtricsDataSource"]

--- a/src/databricks/labs/community_connector/sources/qualtrics/_generated_qualtrics_python_source.py
+++ b/src/databricks/labs/community_connector/sources/qualtrics/_generated_qualtrics_python_source.py
@@ -2599,8 +2599,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -2615,13 +2640,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/sap_successfactors/__init__.py
+++ b/src/databricks/labs/community_connector/sources/sap_successfactors/__init__.py
@@ -4,4 +4,18 @@ from databricks.labs.community_connector.sources.sap_successfactors.sap_successf
     SapSuccessFactorsLakeflowConnect,
 )
 
-__all__ = ["SapSuccessFactorsLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class SapSuccessFactorsDataSource(LakeflowSource):
+    _lakeflow_connect_cls = SapSuccessFactorsLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "sap_successfactors"
+
+
+__all__ = ["SapSuccessFactorsLakeflowConnect",
+    "SapSuccessFactorsDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/sap_successfactors/_generated_sap_successfactors_python_source.py
+++ b/src/databricks/labs/community_connector/sources/sap_successfactors/_generated_sap_successfactors_python_source.py
@@ -8142,8 +8142,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -8158,13 +8183,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/shopify/__init__.py
+++ b/src/databricks/labs/community_connector/sources/shopify/__init__.py
@@ -4,4 +4,18 @@ from databricks.labs.community_connector.sources.shopify.shopify import (
     ShopifyLakeflowConnect,
 )
 
-__all__ = ["ShopifyLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class ShopifyDataSource(LakeflowSource):
+    _lakeflow_connect_cls = ShopifyLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "shopify"
+
+
+__all__ = ["ShopifyLakeflowConnect",
+    "ShopifyDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/shopify/_generated_shopify_python_source.py
+++ b/src/databricks/labs/community_connector/sources/shopify/_generated_shopify_python_source.py
@@ -1856,8 +1856,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -1872,13 +1897,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/surveymonkey/__init__.py
+++ b/src/databricks/labs/community_connector/sources/surveymonkey/__init__.py
@@ -4,4 +4,18 @@ from databricks.labs.community_connector.sources.surveymonkey.surveymonkey impor
     SurveymonkeyLakeflowConnect,
 )
 
-__all__ = ["SurveymonkeyLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class SurveymonkeyDataSource(LakeflowSource):
+    _lakeflow_connect_cls = SurveymonkeyLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "surveymonkey"
+
+
+__all__ = ["SurveymonkeyLakeflowConnect",
+    "SurveymonkeyDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/surveymonkey/_generated_surveymonkey_python_source.py
+++ b/src/databricks/labs/community_connector/sources/surveymonkey/_generated_surveymonkey_python_source.py
@@ -2321,8 +2321,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -2337,13 +2362,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/zendesk/__init__.py
+++ b/src/databricks/labs/community_connector/sources/zendesk/__init__.py
@@ -2,4 +2,18 @@
 
 from databricks.labs.community_connector.sources.zendesk.zendesk import ZendeskLakeflowConnect
 
-__all__ = ["ZendeskLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class ZendeskDataSource(LakeflowSource):
+    _lakeflow_connect_cls = ZendeskLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "zendesk"
+
+
+__all__ = ["ZendeskLakeflowConnect",
+    "ZendeskDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/zendesk/_generated_zendesk_python_source.py
+++ b/src/databricks/labs/community_connector/sources/zendesk/_generated_zendesk_python_source.py
@@ -1381,8 +1381,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -1397,13 +1422,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sources/zoho_crm/__init__.py
+++ b/src/databricks/labs/community_connector/sources/zoho_crm/__init__.py
@@ -2,4 +2,18 @@
 
 from databricks.labs.community_connector.sources.zoho_crm.zoho_crm import ZohoCRMLakeflowConnect
 
-__all__ = ["ZohoCRMLakeflowConnect"]
+
+from databricks.labs.community_connector.sparkpds import LakeflowSource
+
+
+class ZohoCRMDataSource(LakeflowSource):
+    _lakeflow_connect_cls = ZohoCRMLakeflowConnect
+    # Override the Spark format name with the source name once this no
+    # longer relies on UC connection-option injection. Kept as the default
+    # "lakeflow_connect" for now so existing pipelines keep working.
+    # _format_name = "zoho_crm"
+
+
+__all__ = ["ZohoCRMLakeflowConnect",
+    "ZohoCRMDataSource",
+]

--- a/src/databricks/labs/community_connector/sources/zoho_crm/_generated_zoho_crm_python_source.py
+++ b/src/databricks/labs/community_connector/sources/zoho_crm/_generated_zoho_crm_python_source.py
@@ -2417,8 +2417,33 @@ def register_lakeflow_source(spark):
 
     class LakeflowSource(DataSource):
         """
-        PySpark DataSource implementation for Lakeflow Connect.
+        PySpark DataSource base for Lakeflow Connect.
+
+        Two ways the connector implementation is bound:
+
+        - Per-source subclass (wheel / multi-file deployment): subclass and set
+          ``_lakeflow_connect_cls``::
+
+              class GmailDataSource(LakeflowSource):
+                  _lakeflow_connect_cls = GmailLakeflowConnect
+
+              spark.dataSource.register(GmailDataSource)
+
+        - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+          ``None`` and the connector is taken from the module-level
+          ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+          with the actual implementation class.
         """
+
+        # Per-source subclasses set this. Left ``None`` on the base so the merged
+        # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+        _lakeflow_connect_cls = None
+
+        # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+        # connection-option injection looks for that exact string. A per-source
+        # subclass may override this with its source name once it no longer relies
+        # on UC injection (see the commented override in each source's __init__.py).
+        _format_name = "lakeflow_connect"
 
         def __init__(self, options):
             self.options = options
@@ -2433,13 +2458,15 @@ def register_lakeflow_source(spark):
                     f"For a regular source table, use a name that does not start "
                     f"with '_community_'."
                 )
-            # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-            # class during merge. See the placeholder comment at the top of this file.
-            self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+            # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+            # The merged single-file path leaves it None and relies on the
+            # LakeflowConnectImpl placeholder (substituted by the merge script).
+            connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+            self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
         @classmethod
         def name(cls):
-            return "lakeflow_connect"
+            return cls._format_name
 
         def schema(self):
             table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sparkpds/__init__.py
+++ b/src/databricks/labs/community_connector/sparkpds/__init__.py
@@ -10,6 +10,7 @@ read path.
 
 from databricks.labs.community_connector.sparkpds.registry import (
     register,
+    find_data_source,
 )
 from databricks.labs.community_connector.sparkpds.lakeflow_datasource import (
     LakeflowSource,
@@ -29,6 +30,7 @@ from databricks.labs.community_connector.sparkpds.ingestion_agent_datasource imp
 __all__ = [
     # Registry
     "register",
+    "find_data_source",
     # Core classes
     "LakeflowSource",
     "LakeflowStreamReader",

--- a/src/databricks/labs/community_connector/sparkpds/lakeflow_datasource.py
+++ b/src/databricks/labs/community_connector/sparkpds/lakeflow_datasource.py
@@ -314,8 +314,33 @@ class LakeflowBatchReader(DataSourceReader):
 
 class LakeflowSource(DataSource):
     """
-    PySpark DataSource implementation for Lakeflow Connect.
+    PySpark DataSource base for Lakeflow Connect.
+
+    Two ways the connector implementation is bound:
+
+    - Per-source subclass (wheel / multi-file deployment): subclass and set
+      ``_lakeflow_connect_cls``::
+
+          class GmailDataSource(LakeflowSource):
+              _lakeflow_connect_cls = GmailLakeflowConnect
+
+          spark.dataSource.register(GmailDataSource)
+
+    - Merged single-file deployment (SDP): ``_lakeflow_connect_cls`` is left
+      ``None`` and the connector is taken from the module-level
+      ``LakeflowConnectImpl`` placeholder, which the merge script substitutes
+      with the actual implementation class.
     """
+
+    # Per-source subclasses set this. Left ``None`` on the base so the merged
+    # single-file path falls back to the ``LakeflowConnectImpl`` placeholder.
+    _lakeflow_connect_cls = None
+
+    # Spark format name. Defaults to "lakeflow_connect" because Unity Catalog
+    # connection-option injection looks for that exact string. A per-source
+    # subclass may override this with its source name once it no longer relies
+    # on UC injection (see the commented override in each source's __init__.py).
+    _format_name = "lakeflow_connect"
 
     def __init__(self, options):
         self.options = options
@@ -330,13 +355,15 @@ class LakeflowSource(DataSource):
                 f"For a regular source table, use a name that does not start "
                 f"with '_community_'."
             )
-        # TEMPORARY: LakeflowConnectImpl is replaced with the actual implementation
-        # class during merge. See the placeholder comment at the top of this file.
-        self.lakeflow_connect = LakeflowConnectImpl(options)  # pylint: disable=abstract-class-instantiated
+        # Per-source subclasses bind the implementation via _lakeflow_connect_cls.
+        # The merged single-file path leaves it None and relies on the
+        # LakeflowConnectImpl placeholder (substituted by the merge script).
+        connect_cls = type(self)._lakeflow_connect_cls or LakeflowConnectImpl
+        self.lakeflow_connect = connect_cls(options)  # pylint: disable=abstract-class-instantiated
 
     @classmethod
     def name(cls):
-        return "lakeflow_connect"
+        return cls._format_name
 
     def schema(self):
         table = self.options[TABLE_NAME]

--- a/src/databricks/labs/community_connector/sparkpds/registry.py
+++ b/src/databricks/labs/community_connector/sparkpds/registry.py
@@ -1,171 +1,144 @@
 """
-Registry module for registering LakeflowSource with Spark's DataSource API.
+Registry helpers for Lakeflow source DataSources.
 
-This module provides functions to register a LakeflowConnect implementation
-or a custom DataSource with Spark, making it available as a Python Data Source.
+Three ways to register a source with Spark, all valid:
+
+1. Direct import (preferred for wheel-installed connectors)::
+
+       from databricks.labs.community_connector.sources.gmail import GmailDataSource
+       spark.dataSource.register(GmailDataSource)
+       df = spark.read.format("lakeflow_connect").option(...).load()
+
+2. Lookup by source name (handy when the source is selected at runtime)::
+
+       from databricks.labs.community_connector.sparkpds import find_data_source
+       spark.dataSource.register(find_data_source("gmail"))
+
+3. Legacy ``register()`` (used by pipeline templates)::
+
+       from databricks.labs.community_connector import register
+       register(spark, "gmail")
+
+   This resolves the pre-merged single-file deployment
+   (``_generated_<source>_python_source.py``) and registers the
+   ``lakeflow_connect`` format. It is intentionally limited to that path and
+   will be deprecated — new code should call ``spark.dataSource.register``
+   with the source's ``DataSource`` class (path 1) or :func:`find_data_source`
+   (path 2) instead.
 """
 
 import importlib
 import inspect
 from types import ModuleType
-from typing import Type, Union
-from pyspark.sql import SparkSession
-from pyspark.sql.datasource import DataSource
+from typing import Type
 
-from databricks.labs.community_connector.interface import LakeflowConnect
+from pyspark.sql import SparkSession
+
 from databricks.labs.community_connector.sparkpds.lakeflow_datasource import LakeflowSource
 
 
 _BASE_PKG = "databricks.labs.community_connector.sources"
 
-def _get_class_fqn(cls: Type) -> str:
-    """Get the fully qualified name of a class (module.ClassName)."""
-    return f"{cls.__module__}.{cls.__name__}"
 
+def find_data_source(source_name: str) -> Type[LakeflowSource]:
+    """Return the ``<Source>DataSource`` class exposed by a source package.
 
-def _import_class(fqn: str) -> Type:
-    """Import a class from its fully qualified name (e.g., 'module.ClassName')."""
-    module_name, class_name = fqn.rsplit(".", 1)
-    module = importlib.import_module(module_name)
-    return getattr(module, class_name)
+    Looks in ``databricks.labs.community_connector.sources.<source_name>`` for
+    a :class:`LakeflowSource` subclass and returns it. The match restricts to
+    classes defined inside the source package so unrelated re-exports (e.g.
+    the base ``LakeflowSource`` itself) don't satisfy the search.
+
+    Raises:
+        ValueError: when the source package is missing or doesn't expose a
+            :class:`LakeflowSource` subclass.
+    """
+    package_fqn = f"{_BASE_PKG}.{source_name}"
+    try:
+        package = importlib.import_module(package_fqn)
+    except ModuleNotFoundError as exc:
+        raise ValueError(
+            f"Source '{source_name}' not found. "
+            f"Make sure the package '{package_fqn}' is installed."
+        ) from exc
+
+    for _, obj in inspect.getmembers(package, inspect.isclass):
+        if (
+            issubclass(obj, LakeflowSource)
+            and obj is not LakeflowSource
+            and getattr(obj, "__module__", "").startswith(package_fqn)
+        ):
+            return obj
+
+    raise ValueError(
+        f"Could not find a LakeflowSource subclass for source '{source_name}'. "
+        f"Expose a ``<Source>DataSource`` class from '{package_fqn}.__init__' "
+        f"that sets '_lakeflow_connect_cls'."
+    )
 
 
 def _get_source_module(source_name: str, module_name: str) -> ModuleType:
     """Import a module from a source package."""
     try:
         importlib.import_module(f"{_BASE_PKG}.{source_name}")
-    except ModuleNotFoundError:
+    except ModuleNotFoundError as exc:
         raise ValueError(
             f"Source '{source_name}' not found. "
             f"Make sure the directory 'src/databricks/labs/community_connector/sources/{source_name}/' exists."
-        )
+        ) from exc
 
     module_path = f"{_BASE_PKG}.{source_name}.{module_name}"
-    try:
-        return importlib.import_module(module_path)
-    except ModuleNotFoundError:
-        raise ImportError(
-            f"Could not import '{module_name}.py' from source '{source_name}'. "
-            f"Please ensure 'src/databricks/labs/community_connector/sources/{source_name}/{module_name}.py' exists."
-        )
+    return importlib.import_module(module_path)  # raises ModuleNotFoundError if absent
 
 
 def _get_register_function(source_name: str):
-    """Get the register_lakeflow_source function from a generated source module."""
+    """Return ``register_lakeflow_source`` from the pre-merged source module.
+
+    Raises ``ModuleNotFoundError`` when the source has no merged file, or
+    ``AttributeError`` when the module lacks the function, so the caller can
+    fall back to the per-source DataSource class lookup.
+    """
     module_name = f"_generated_{source_name}_python_source"
     module = _get_source_module(source_name, module_name)
 
     if not hasattr(module, "register_lakeflow_source"):
-        raise ImportError(
-            f"Module '{module_name}' does not have a 'register_lakeflow_source' function. "
-            f"Please ensure the module defines this function."
+        raise AttributeError(
+            f"Module '{module_name}' does not have a 'register_lakeflow_source' function."
         )
 
     return module.register_lakeflow_source
 
 
-def _find_lakeflow_connect_class(source_name: str) -> Type[LakeflowConnect]:
-    """
-    Find a LakeflowConnect subclass from the source package.
+def register(spark: SparkSession, source: str) -> None:
+    """Register a source by name via its merged ``_generated`` module.
 
-    Looks in databricks.labs.community_connector.sources.{source_name} for a class
-    that inherits from LakeflowConnect. All source packages are expected to expose
-    their implementation at the package level via __init__.py. This handles the case
-    where the source is provided via a wheel package (uploaded or installed from PyPI)
-    rather than via the generated source module.
-    """
-    package_fqn = f"{_BASE_PKG}.{source_name}"
-    try:
-        package = importlib.import_module(package_fqn)
-    except ModuleNotFoundError:
-        raise ValueError(
-            f"Source '{source_name}' not found. "
-            f"Make sure the package '{package_fqn}' is installed."
-        )
+    This is a legacy shim that exists only so existing code (pipeline
+    templates, SDP deployments) can register a source by name. It resolves
+    the pre-merged single-file module and registers the ``lakeflow_connect``
+    format.
 
-    for _, obj in inspect.getmembers(package, inspect.isclass):
-        if issubclass(obj, LakeflowConnect) and obj is not LakeflowConnect:
-            return obj
-
-    raise ValueError(
-        f"Could not find a LakeflowConnect implementation for source '{source_name}'. "
-        f"Expected a class inheriting from LakeflowConnect exposed in {package_fqn}.__init__."
-    )
-
-
-def _register_lakeflow_connect(spark: SparkSession, cls: Type[LakeflowConnect]) -> None:
-    """Wrap a LakeflowConnect class in a LakeflowSource and register it with Spark."""
-    class_fqn = _get_class_fqn(cls)
-
-    class RegisterableLakeflowSource(LakeflowSource):
-        """Wrapper that dynamically imports the LakeflowConnect class by FQN."""
-
-        def __init__(self, options):
-            self.options = options
-            lakeflow_connect_cls = _import_class(class_fqn)
-            self.lakeflow_connect = lakeflow_connect_cls(options)
-
-    RegisterableLakeflowSource.__name__ = f"RegisterableLakeflowSource_{cls.__name__}"
-
-    spark.dataSource.register(RegisterableLakeflowSource)
-
-
-def register(
-    spark: SparkSession,
-    source: Union[str, Type[DataSource], Type[LakeflowConnect]],
-) -> None:
-    """
-    Register a source with Spark's DataSource API.
-
-    This unified registration function handles:
-    - String source names: Dynamically loads and registers the generated source module.
-      Falls back to discovering a LakeflowConnect subclass from the source package
-      when the generated module is not available (e.g. package-based deployment).
-    - DataSource subclasses: Registered directly with Spark.
-    - LakeflowConnect subclasses: Wrapped in a LakeflowSource and registered.
+    Deprecated — to register a source directly, call
+    ``spark.dataSource.register(<Source>DataSource)`` (or
+    ``spark.dataSource.register(find_data_source("<source>"))``). There is
+    intentionally no class-based or :func:`find_data_source` path here.
 
     Args:
-        spark: The SparkSession instance.
-        source: A source name string (e.g., "zendesk", "github"), a DataSource subclass,
-                or a LakeflowConnect subclass.
+        spark: The active SparkSession.
+        source: A source name, e.g. ``"gmail"``.
 
     Raises:
-        TypeError: If source is not a string, DataSource subclass, or LakeflowConnect subclass.
-        ValueError: If a string source name is provided but the source module doesn't exist.
+        TypeError: If source is not a string.
+        ValueError: If the source name has no source package.
+        ModuleNotFoundError: If the source package has no merged module.
+        AttributeError: If the merged module lacks ``register_lakeflow_source``.
 
     Examples:
-        >>> # Register a source by name:
-        >>> register(spark, "zendesk")
-        >>> df = spark.read.format("lakeflow_connect").options(...).load()
-
-        >>> # Register a LakeflowConnect implementation:
-        >>> from my_connector import MyLakeflowConnect
-        >>> register(spark, MyLakeflowConnect)
-        >>> df = spark.read.format("lakeflow_connect").options(...).load()
-
-        >>> # Register a custom DataSource directly:
-        >>> from my_pds import MyCustomPDS
-        >>> register(spark, MyCustomPDS)
-        >>> df = spark.read.format(MyCustomPDS.name()).options(...).load()
+        >>> register(spark, "gmail")
     """
-    if isinstance(source, str):
-        try:
-            register_fn = _get_register_function(source)
-            register_fn(spark)
-            return
-        except ImportError:
-            lakeflow_cls = _find_lakeflow_connect_class(source)
-            _register_lakeflow_connect(spark, lakeflow_cls)
-            return
-
-    if isinstance(source, type) and issubclass(source, DataSource):
-        spark.dataSource.register(source)
-        return
-
-    if isinstance(source, type) and issubclass(source, LakeflowConnect):
-        _register_lakeflow_connect(spark, source)
-        return
-
-    raise TypeError(
-        f"source must be a string, DataSource subclass, or LakeflowConnect subclass, got {type(source)}"
-    )
+    if not isinstance(source, str):
+        raise TypeError(
+            f"register() takes a source name string, got {type(source)}. "
+            f"To register a DataSource class, call spark.dataSource.register(...) "
+            f"directly (e.g. spark.dataSource.register(GmailDataSource))."
+        )
+    register_fn = _get_register_function(source)
+    register_fn(spark)

--- a/src/databricks/labs/community_connector/sparkpds/registry.py
+++ b/src/databricks/labs/community_connector/sparkpds/registry.py
@@ -62,11 +62,12 @@ def find_data_source(source_name: str) -> Type[LakeflowSource]:
         ) from exc
 
     for _, obj in inspect.getmembers(package, inspect.isclass):
-        if (
-            issubclass(obj, LakeflowSource)
-            and obj is not LakeflowSource
-            and getattr(obj, "__module__", "").startswith(package_fqn)
-        ):
+        module = getattr(obj, "__module__", "")
+        # Match on the package boundary, not a bare prefix, so a source whose
+        # name is a prefix of another (e.g. "github" vs "github_enterprise")
+        # can't resolve to the wrong package's class.
+        in_package = module == package_fqn or module.startswith(package_fqn + ".")
+        if issubclass(obj, LakeflowSource) and obj is not LakeflowSource and in_package:
             return obj
 
     raise ValueError(

--- a/tests/unit/sparkpds_registry_test.py
+++ b/tests/unit/sparkpds_registry_test.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock
 
 import databricks.labs.community_connector.sparkpds.registry as registry
 from databricks.labs.community_connector.interface import LakeflowConnect
+from databricks.labs.community_connector.sparkpds.lakeflow_datasource import LakeflowSource
 from pyspark.sql.datasource import DataSource
 
 
@@ -14,59 +15,71 @@ class DummyDataSource(DataSource):
     pass
 
 
-def test_datasource_subclass_register():
+def test_datasource_class_is_not_accepted_by_register():
+    # register() is a name-only legacy shim. A DataSource class must be
+    # registered via spark.dataSource.register(...) directly, not through here.
     mock_spark = MagicMock()
-    registry.register(mock_spark, DummyDataSource)
-    mock_spark.dataSource.register.assert_called_once_with(DummyDataSource)
+    with pytest.raises(TypeError, match="register\\(\\) takes a source name string"):
+        registry.register(mock_spark, DummyDataSource)
+    mock_spark.dataSource.register.assert_not_called()
 
 
-def test_lakeflow_connect_subclass_register():
-    mock_spark = MagicMock()
-    with patch.object(registry, "_import_class", return_value=DummyLakeflowConnect):
-        registry.register(mock_spark, DummyLakeflowConnect)
-
-    mock_spark.dataSource.register.assert_called_once()
-    registered_cls = mock_spark.dataSource.register.call_args[0][0]
-    assert registered_cls.__name__ == "RegisterableLakeflowSource_DummyLakeflowConnect"
-
-
-@patch.object(registry, "_get_register_function", side_effect=ImportError("no generated module"))
-@patch.object(registry, "_find_lakeflow_connect_class", return_value=DummyLakeflowConnect)
-@patch.object(registry, "_import_class", return_value=DummyLakeflowConnect)
-def test_string_source_fallback_to_lakeflow_connect(mock_import_cls, mock_find_cls, mock_get_reg):
-    mock_spark = MagicMock()
-
-    registry.register(mock_spark, "dummy_source")
-
-    mock_get_reg.assert_called_once_with("dummy_source")
-    mock_find_cls.assert_called_once_with("dummy_source")
-
-    mock_spark.dataSource.register.assert_called_once()
-    registered_cls = mock_spark.dataSource.register.call_args[0][0]
-    assert registered_cls.__name__ == "RegisterableLakeflowSource_DummyLakeflowConnect"
-
-
-@patch.object(registry, "_get_register_function")
-def test_string_source_uses_generated_module(mock_get_reg):
+def test_string_source_uses_generated_module():
     mock_spark = MagicMock()
     mock_register_fn = MagicMock()
-    mock_get_reg.return_value = mock_register_fn
-
-    registry.register(mock_spark, "zendesk")
+    with patch.object(registry, "_get_register_function", return_value=mock_register_fn) as mock_get_reg:
+        registry.register(mock_spark, "zendesk")
 
     mock_get_reg.assert_called_once_with("zendesk")
     mock_register_fn.assert_called_once_with(mock_spark)
 
 
-def test_invalid_source_raises_type_error():
+@patch.object(registry, "find_data_source")
+@patch.object(registry, "_get_register_function", side_effect=ModuleNotFoundError("no generated module"))
+def test_string_source_does_not_fall_back_to_find_data_source(mock_get_reg, mock_find):
+    # The string path is the legacy merged-module path only; it must NOT fall
+    # back to find_data_source. The lookup error propagates unchanged.
     mock_spark = MagicMock()
-    with pytest.raises(TypeError, match="source must be a string"):
+    with pytest.raises(ModuleNotFoundError, match="no generated module"):
+        registry.register(mock_spark, "dummy_source")
+
+    mock_find.assert_not_called()
+    mock_spark.dataSource.register.assert_not_called()
+
+
+@patch.object(registry, "find_data_source")
+@patch.object(registry, "_get_register_function", side_effect=AttributeError("no register fn"))
+def test_string_source_propagates_missing_register_fn(mock_get_reg, mock_find):
+    mock_spark = MagicMock()
+    with pytest.raises(AttributeError, match="no register fn"):
+        registry.register(mock_spark, "dummy_source")
+
+    mock_find.assert_not_called()
+    mock_spark.dataSource.register.assert_not_called()
+
+
+def test_lakeflow_connect_class_is_not_accepted_by_register():
+    # register() takes a name string only; classes (of any kind) are rejected.
+    mock_spark = MagicMock()
+    with pytest.raises(TypeError, match="register\\(\\) takes a source name string"):
+        registry.register(mock_spark, DummyLakeflowConnect)
+
+
+def test_non_string_source_raises_type_error():
+    mock_spark = MagicMock()
+    with pytest.raises(TypeError, match="register\\(\\) takes a source name string"):
         registry.register(mock_spark, 42)
 
 
-@patch.object(registry, "_get_register_function", side_effect=ImportError("no generated module"))
-@patch.object(registry, "_find_lakeflow_connect_class", side_effect=ValueError("not found"))
-def test_string_source_fallback_raises_when_no_class_found(mock_find_cls, mock_get_reg):
-    mock_spark = MagicMock()
+def test_find_data_source_returns_source_subclass():
+    ds = registry.find_data_source("example")
+    assert issubclass(ds, LakeflowSource)
+    assert ds is not LakeflowSource
+    assert ds._lakeflow_connect_cls is not None
+    # Format name stays "lakeflow_connect" until a source opts out of UC injection.
+    assert ds.name() == "lakeflow_connect"
+
+
+def test_find_data_source_missing_source_raises():
     with pytest.raises(ValueError, match="not found"):
-        registry.register(mock_spark, "nonexistent")
+        registry.find_data_source("nonexistent_source_xyz")

--- a/tests/unit/sparkpds_registry_test.py
+++ b/tests/unit/sparkpds_registry_test.py
@@ -83,3 +83,25 @@ def test_find_data_source_returns_source_subclass():
 def test_find_data_source_missing_source_raises():
     with pytest.raises(ValueError, match="not found"):
         registry.find_data_source("nonexistent_source_xyz")
+
+
+def test_find_data_source_respects_package_boundary():
+    # A class from a sibling package whose name is a prefix-superset
+    # ("github_enterprise" vs "github") must not satisfy the lookup for the
+    # shorter name, even when it sorts first in getmembers() iteration.
+    import types
+
+    class AaaEnterpriseDataSource(LakeflowSource):  # sorts first
+        _lakeflow_connect_cls = object
+    AaaEnterpriseDataSource.__module__ = f"{registry._BASE_PKG}.github_enterprise.x"
+
+    class ZzzGithubDataSource(LakeflowSource):
+        _lakeflow_connect_cls = object
+    ZzzGithubDataSource.__module__ = f"{registry._BASE_PKG}.github"
+
+    fake_pkg = types.ModuleType("fake_github_pkg")
+    fake_pkg.AaaEnterpriseDataSource = AaaEnterpriseDataSource
+    fake_pkg.ZzzGithubDataSource = ZzzGithubDataSource
+
+    with patch.object(registry.importlib, "import_module", return_value=fake_pkg):
+        assert registry.find_data_source("github") is ZzzGithubDataSource


### PR DESCRIPTION
## Summary

Reworks source registration to use PySpark's native `spark.dataSource.register`, replacing the confusing `register(spark, Union[str, DataSource, LakeflowConnect])` overload (which re-imported the connector by FQN inside a dynamically-built wrapper).

Three registration paths:

1. **Direct** (wheel-installed connectors):
   ```python
   from databricks.labs.community_connector.sources.gmail import GmailDataSource
   spark.dataSource.register(GmailDataSource)
   ```
2. **Lookup by name** — new `find_data_source("gmail")` returns the `<Source>DataSource` class.
3. **Legacy** `register(spark, "gmail")` — resolves the merged `_generated_<source>_python_source.py` register function and registers the `lakeflow_connect` format. **No fallback**: it does *not* fall back to `find_data_source`. The intent is to deprecate this path and have users explicitly call `spark.dataSource.register` (path 1/2).

## Changes

- **`LakeflowSource`** gains two class attributes:
  - `_lakeflow_connect_cls` — bound by each per-source subclass. Left `None` on the base so the merged single-file (SDP) path falls back to the `LakeflowConnectImpl` merge placeholder, exactly as today.
  - `_format_name` — overridable, defaults to `"lakeflow_connect"`. `name()` now returns it.
- **`registry.py`** — adds `find_data_source()`; `register()` takes `str | DataSource` only. The string path is the legacy merged-module path **with no `find_data_source` fallback**. The `LakeflowConnect`/FQN-wrapper overload is removed (no callers passed a class — all use the string form).
- **Every source `__init__.py`** (including the new **palantir** connector) exposes a `<Source>DataSource(LakeflowSource)` subclass setting `_lakeflow_connect_cls`. The source-name format override (`# _format_name = "<source>"`) is **included but commented out**, so all sources keep registering as `"lakeflow_connect"`.
- Regenerated all `_generated_*.py` files for the `LakeflowSource` change (CI enforces freshness).
- **Skills**: `implement-connector` now requires exposing the `<Source>DataSource` class (concise instruction pointing at `sources/example`); `self-review-connector` adds **BLOCKER check A13** enforcing that every connector exposes it.

## Format-name decision

- Merged `_generated` path stays `lakeflow_connect` (UC connection-option injection keys off that exact string).
- New subclasses default to `lakeflow_connect` too; the source-name override is left commented for a future change once a source no longer relies on UC injection.

## Notes

- PR #189 (`gmail-improvements`) contains an overlapping version of this refactor bundled with the agent-ops feature; this PR is the standalone foundation off `master` and that PR can rebase on top.

## Test plan

- [x] `tests/unit/sparkpds_registry_test.py` rewritten for the new API (incl. no-fallback assertions) — 8 passed
- [x] `find_data_source` resolves all 22 sources (incl. palantir) to a `LakeflowSource` subclass with `name() == "lakeflow_connect"`
- [x] All source unit suites pass (palantir: 68 passed); `sparkpds_ingestion_agent_test.py` and `test_sparkpds_virtual_tables.py` pass
- [x] `merge_python_source.py all` regenerates deterministically; generated `example`/`palantir` fall back to the substituted `LakeflowConnectImpl` and report `lakeflow_connect`
- [x] pylint 10.00/10 on changed non-generated files

This pull request and its description were written by Isaac.