### PR TITLE
CLI: let update_connection refresh the U2M OAuth grant

### DIFF
--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -1952,6 +1952,29 @@ def create_connection(
     help='Connection options as JSON string (e.g., \'{"key": "value"}\')',
 )
 @click.option(
+    "--auth-type",
+    "auth_type",
+    type=click.Choice(list(AUTH_TYPE_CHOICES), case_sensitive=False),
+    default=AUTH_TYPE_STATIC,
+    show_default=True,
+    help=(
+        "Authentication mode for the COMMUNITY connection. Must match the "
+        "mode the connection was created with — the auth mode itself can't "
+        "be switched on update. Pass '--auth-type=u2m' to re-run the "
+        "browser authorization-code flow and refresh the stored OAuth grant."
+    ),
+)
+@click.option(
+    "--redirect-port",
+    "redirect_port",
+    type=int,
+    default=None,
+    help=(
+        "Loopback port for the OAuth U2M redirect (only used with "
+        "--auth-type=u2m). Defaults to an OS-assigned free port."
+    ),
+)
+@click.option(
     "--spec",
     "-s",
     "spec_path",
@@ -1966,6 +1989,8 @@ def update_connection(
     source_name: str,
     connection_name: str,
     options: str,
+    auth_type: str,
+    redirect_port: Optional[int],
     spec_path: Optional[str],
 ):
     """
@@ -1977,7 +2002,12 @@ def update_connection(
 
     The connection's auth mode (community_oauth_flow) is fixed at creation
     time and cannot be changed here — recreate the connection to switch
-    between static, m2m, u2m, and u2m_per_user modes.
+    between static, m2m, u2m, and u2m_per_user modes. Pass the SAME
+    --auth-type the connection was created with so the update preserves it.
+    For --auth-type=u2m this re-runs the browser authorization-code + PKCE
+    flow and writes a fresh authorization_code / pkce_verifier /
+    oauth_redirect_uri, which is how you refresh an expired or revoked OAuth
+    grant without recreating the connection.
 
     Connection options are validated against the connector spec (connector_spec.yaml).
     The externalOptionsAllowList is automatically added from the spec.
@@ -1986,6 +2016,14 @@ def update_connection(
     Example:
         community-connector update_connection github my_github_conn \\
             -o '{"token": "ghp_xxxx"}'
+
+        # Refresh an expired U2M OAuth grant (re-runs the browser flow):
+        community-connector update_connection github my_github_conn \\
+            --auth-type u2m \\
+            -o '{"client_id":"...","client_secret":"...",
+                 "authorization_endpoint":"https://idp/authorize",
+                 "token_endpoint":"https://idp/token",
+                 "oauth_scope":"repo"}'
 
         # With custom spec file:
         community-connector update_connection github my_github_conn \\
@@ -1996,11 +2034,15 @@ def update_connection(
             -o '{"token": "ghp_xxxx"}' --spec https://github.com/myorg/myrepo
     """
     debug = ctx.obj.get("debug", False)
+    auth_type = auth_type.lower()
 
     click.echo(f"Updating connection for source: {source_name}")
     click.echo(f"Connection name: {connection_name}")
+    click.echo(f"Auth type: {auth_type}")
 
-    options_dict = _prepare_connection_options(source_name, options, spec_path, debug)
+    options_dict = _prepare_connection_options(
+        source_name, options, spec_path, debug, auth_type, redirect_port
+    )
 
     workspace_client = _make_workspace_client()
     body = {"name": connection_name, "options": options_dict}

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -1050,6 +1050,95 @@ class TestCreateConnectionConnectionType:
         assert opts["oauth_redirect_uri"] == "http://localhost:54321/callback"
 
 
+class TestUpdateConnectionCommand:
+    """update_connection must support the same auth modes as create_connection
+    so a U2M OAuth grant can be refreshed without recreating the connection."""
+
+    @patch(
+        "databricks.labs.community_connector_cli.cli.run_u2m_authorization_code_flow"
+    )
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_update_connection_u2m_refreshes_oauth_grant(
+        self, mock_workspace_client, mock_load_spec, mock_oauth
+    ):
+        """--auth-type=u2m re-runs the loopback flow and PATCHes a fresh
+        authorization code / verifier / redirect into the connection."""
+        runner = CliRunner()
+
+        mock_load_spec.return_value = None
+        mock_ws = MagicMock()
+        mock_workspace_client.return_value = mock_ws
+        mock_ws.api_client.do.return_value = {"name": "my_conn", "connection_id": "123"}
+        mock_oauth.return_value = (
+            "NEWCODE",
+            "NEWVERIFIER",
+            "http://localhost:54321/callback",
+        )
+
+        result = runner.invoke(
+            main,
+            [
+                "update_connection",
+                "github",
+                "my_conn",
+                "--auth-type",
+                "u2m",
+                "-o",
+                json.dumps(
+                    {
+                        "client_id": "cid",
+                        "client_secret": "csecret",
+                        "authorization_endpoint": "https://example.com/authorize",
+                        "token_endpoint": "https://example.com/token",
+                        "oauth_scope": "repo",
+                    }
+                ),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_oauth.assert_called_once()
+
+        method, path = mock_ws.api_client.do.call_args.args[:2]
+        assert method == "PATCH"
+        assert path.endswith("/connections/my_conn")
+
+        opts = mock_ws.api_client.do.call_args.kwargs["body"]["options"]
+        assert opts["community_oauth_flow"] == "u2m"
+        assert opts["authorization_code"] == "NEWCODE"
+        assert opts["pkce_verifier"] == "NEWVERIFIER"
+        assert opts["oauth_redirect_uri"] == "http://localhost:54321/callback"
+
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_update_connection_defaults_to_static_no_oauth_flow(
+        self, mock_workspace_client, mock_load_spec
+    ):
+        """Without --auth-type the update stays static and runs no OAuth flow."""
+        runner = CliRunner()
+
+        mock_load_spec.return_value = None
+        mock_ws = MagicMock()
+        mock_workspace_client.return_value = mock_ws
+        mock_ws.api_client.do.return_value = {"name": "my_conn", "connection_id": "123"}
+
+        result = runner.invoke(
+            main,
+            [
+                "update_connection",
+                "github",
+                "my_conn",
+                "-o",
+                '{"token": "ghp_xxxx"}',
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        opts = mock_ws.api_client.do.call_args.kwargs["body"]["options"]
+        assert "community_oauth_flow" not in opts
+
+
 class TestOAuthDefaultsAutoFill:
     """Tests for auto-populating OAuth options from connector_spec.yaml."""
 


### PR DESCRIPTION
## Summary

`community-connector update_connection` could not refresh a U2M OAuth grant. The command had **no `--auth-type` option** and always called `_prepare_connection_options(...)` with the default `static` auth type, so it never re-ran the U2M authorization-code flow. The only way to recover an expired or revoked OAuth grant was to recreate the connection.

This was found while testing #220 (Gmail U2M OAuth).

## Fix

Add `--auth-type` and `--redirect-port` to `update_connection`, mirroring `create_connection`, and thread them into `_prepare_connection_options`. With `--auth-type=u2m` the command re-runs the loopback authorization-code + PKCE flow and PATCHes a fresh `authorization_code` / `pkce_verifier` / `oauth_redirect_uri` into the connection options.

The auth **mode** itself still can't be switched on update (that remains a recreate) — you pass the same mode the connection was created with. The default stays `static`, so existing `update_connection` usage is unchanged.

```bash
# Refresh an expired U2M OAuth grant without recreating the connection:
community-connector update_connection gmail my_gmail_conn \
  --auth-type u2m \
  -o '{"client_id":"...","client_secret":"..."}'
```

## Test plan

- [x] New `TestUpdateConnectionCommand`:
  - `--auth-type=u2m` re-runs the loopback flow and PATCHes the refreshed code / verifier / redirect (and `community_oauth_flow=u2m`)
  - a default update (no `--auth-type`) stays static and runs no OAuth flow
- [x] Full `tools/community_connector/tests/test_cli.py` — 131 passed

This pull request and its description were written by Isaac.