### PR TITLE
CLI: derive auth type from spec oauth.flow (work with the new Gmail spec)

### DIFF
--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -203,10 +203,20 @@ def _get_constant_external_options_allowlist() -> str:
 
 
 def _validate_connection_options_with_spec(
-    source_name: str, options_dict: dict, parsed_spec: ParsedConnectorSpec
+    source_name: str,
+    options_dict: dict,
+    parsed_spec: ParsedConnectorSpec,
+    additional_known_keys: Optional[Set[str]] = None,
+    skip_required: Optional[Set[str]] = None,
 ) -> List[str]:
     """Validate connection options against spec. Returns list of error messages."""
-    result = validate_connection_options(source_name, options_dict, parsed_spec)
+    result = validate_connection_options(
+        source_name,
+        options_dict,
+        parsed_spec,
+        additional_known_keys=additional_known_keys,
+        skip_required=skip_required,
+    )
 
     # Print detected auth method
     if result.detected_auth_method:
@@ -239,21 +249,24 @@ def _prepare_connection_options(  # pylint: disable=too-many-arguments,too-many-
     options: str,
     spec_path: Optional[str],
     debug: bool,
-    auth_type: str = AUTH_TYPE_STATIC,
+    auth_type: Optional[str] = None,
     redirect_port: Optional[int] = None,
 ) -> dict:
     """Parse, validate, and enrich connection options. Raises ClickException on failure.
 
-    For ``auth_type != static``:
-      - Validates that the user-supplied ``--options`` JSON contains the fixed
-        set of OAuth fields required by the chosen flow.
-      - Sets ``community_oauth_flow`` on the options dict so the connection
-        resolves to the correct CONNECTION_COMMUNITY_OAUTH_* securable kind.
+    ``auth_type`` may be ``None``; when omitted it is taken from the spec's
+    ``oauth.flow`` (or ``static`` if the spec has no oauth block), so the user
+    no longer has to pass ``--auth-type`` for connectors that declare their
+    flow in the spec.
+
+    For OAuth auth types:
+      - Validates that ``--options`` plus the spec's oauth defaults provide the
+        fixed set of OAuth fields required by the flow.
+      - Sets ``community_oauth_flow`` so the connection resolves to the correct
+        CONNECTION_COMMUNITY_OAUTH_* securable kind.
       - For ``u2m``, runs an in-process authorization-code + PKCE flow against
         a loopback redirect and injects ``authorization_code``,
         ``pkce_verifier``, and ``oauth_redirect_uri``.
-      - OAuth keys are exempted from connector-spec parameter validation
-        (connector specs only describe runtime/source-side options).
     """
     # Parse options JSON
     try:
@@ -269,32 +282,46 @@ def _prepare_connection_options(  # pylint: disable=too-many-arguments,too-many-
     connector_spec = _load_connector_spec(source_name, spec_path)
     parsed_spec = _parse_connector_spec(connector_spec) if connector_spec else None
 
+    # Resolve the auth type: an explicit --auth-type wins; otherwise take the
+    # spec's oauth.flow; otherwise static.
+    auth_type = _resolve_auth_type(auth_type, parsed_spec)
+    click.echo(f"Auth type: {auth_type}")
+
     # Merge OAuth defaults from the spec BEFORE auth-type validation, so the
     # required-field check sees the auto-populated values. User-supplied
     # values in --options win over spec defaults.
+    flow_controls: dict = {}
     if parsed_spec and auth_type != AUTH_TYPE_STATIC and parsed_spec.oauth_defaults:
-        _apply_oauth_defaults(options_dict, parsed_spec.oauth_defaults)
+        conn_oauth, flow_controls = _resolve_oauth_block(parsed_spec.oauth_defaults)
+        _apply_oauth_defaults(options_dict, conn_oauth)
 
-    _apply_auth_type(options_dict, auth_type, redirect_port)
-
+    # Validate the connector-spec connection parameters BEFORE running any
+    # browser flow, for every auth type. OAuth modes still enforce the
+    # connector-specific required params (just like static mode); they only
+    # exempt the keys the OAuth layer / UC supply — the OAuth fields
+    # (client_id, endpoints, …) and the UC-injected runtime tokens — from the
+    # required and unknown-parameter checks.
     if parsed_spec:
         _debug_print_spec(parsed_spec, constant_allowlist, debug)
 
         if auth_type == AUTH_TYPE_STATIC:
-            # Static credentials: the user supplies all connector-runtime
-            # parameters listed in the spec; validate them.
             errors = _validate_connection_options_with_spec(
                 source_name, options_dict, parsed_spec
             )
-            if errors:
-                raise click.ClickException("\n".join(errors))
-        # For non-static auth modes the connector spec's parameters describe
-        # what the connector reads at *runtime* (typically OAuth-issued tokens
-        # like access_token / refresh_token that UC injects after the OAuth
-        # dance). Those are not user-supplied at create-connection time, so
-        # we skip parameter validation. The OAuth field set is already
-        # validated by _apply_auth_type.
+        else:
+            errors = _validate_connection_options_with_spec(
+                source_name,
+                options_dict,
+                parsed_spec,
+                additional_known_keys=OAUTH_OPTION_KEYS,
+                skip_required=OAUTH_OPTION_KEYS | _RUNTIME_INJECTED_KEYS,
+            )
+        if errors:
+            raise click.ClickException("\n".join(errors))
 
+    _apply_auth_type(options_dict, auth_type, redirect_port, flow_controls)
+
+    if parsed_spec:
         # Auto-add externalOptionsAllowList
         _add_external_options_allowlist(
             options_dict, parsed_spec.external_options_allowlist, constant_allowlist
@@ -317,6 +344,71 @@ def _prepare_connection_options(  # pylint: disable=too-many-arguments,too-many-
     return options_dict
 
 
+# The connector-spec oauth block (PR #218 shape) uses human-friendly key
+# names; the connection layer and run_u2m_authorization_code_flow expect the
+# RFC 6749 names. Translate on the way in. Specs that already use the RFC
+# names pass through unchanged (the aliased name wins only if present).
+_OAUTH_SPEC_KEY_ALIASES = {
+    "authorization_url": "authorization_endpoint",
+    "token_url": "token_endpoint",
+    "scopes": "oauth_scope",
+}
+
+# oauth-block keys that steer the local OAuth flow but are NOT stored as
+# connection options (they describe how to obtain the grant, not the grant).
+_OAUTH_FLOW_CONTROL_KEYS = frozenset({"flow", "pkce", "extra_auth_params"})
+
+# Tokens UC mints/injects into the connector at query time — never supplied by
+# the user at connection-creation time, so they are not required by the CLI
+# even if a connector spec happens to list them as parameters.
+_RUNTIME_INJECTED_KEYS = frozenset({"access_token", "refresh_token"})
+
+
+def _resolve_oauth_block(oauth_defaults: dict) -> Tuple[dict, dict]:
+    """Split the connector-spec oauth block into connection options and flow controls.
+
+    Returns ``(connection_oauth_options, flow_controls)``:
+
+    - ``connection_oauth_options`` uses RFC 6749 names (``authorization_endpoint``,
+      ``token_endpoint``, ``oauth_scope``, …), ready to merge into the connection
+      options the user submits.
+    - ``flow_controls`` carries ``flow`` / ``pkce`` / ``extra_auth_params``, which
+      steer the loopback U2M flow but are never stored on the connection.
+    """
+    conn_options: dict = {}
+    flow_controls: dict = {}
+    for key, value in oauth_defaults.items():
+        if key in _OAUTH_FLOW_CONTROL_KEYS:
+            flow_controls[key] = value
+            continue
+        conn_options[_OAUTH_SPEC_KEY_ALIASES.get(key, key)] = value
+    return conn_options, flow_controls
+
+
+def _resolve_auth_type(explicit: Optional[str], parsed_spec) -> str:
+    """Resolve the connection auth type.
+
+    An explicit ``--auth-type`` wins. Otherwise fall back to the connector
+    spec's ``oauth.flow`` (so specs that declare their flow don't need
+    ``--auth-type`` on the command line), and finally to ``static`` for specs
+    with no oauth block.
+    """
+    if explicit:
+        resolved = explicit.lower()
+    else:
+        spec_flow = None
+        if parsed_spec and parsed_spec.oauth_defaults:
+            spec_flow = parsed_spec.oauth_defaults.get("flow")
+        resolved = str(spec_flow).lower() if spec_flow else AUTH_TYPE_STATIC
+
+    if resolved not in AUTH_TYPE_CHOICES:
+        raise click.ClickException(
+            f"Unknown auth type '{resolved}'. Expected one of: "
+            f"{', '.join(AUTH_TYPE_CHOICES)}."
+        )
+    return resolved
+
+
 def _apply_oauth_defaults(options_dict: dict, oauth_defaults: dict) -> None:
     """Fill in standard OAuth options from the connector spec, only when
     the user did not already supply a value for that key."""
@@ -333,12 +425,18 @@ def _apply_oauth_defaults(options_dict: dict, oauth_defaults: dict) -> None:
 
 
 def _apply_auth_type(
-    options_dict: dict, auth_type: str, redirect_port: Optional[int]
+    options_dict: dict,
+    auth_type: str,
+    redirect_port: Optional[int],
+    flow_controls: Optional[dict] = None,
 ) -> None:
     """Validate auth-type-specific required options and stamp the flow value.
 
     For ``u2m`` this also runs the loopback authorization-code flow and writes
     the resulting code / verifier / redirect URI back into ``options_dict``.
+    ``flow_controls`` carries spec-supplied ``extra_auth_params`` folded into
+    the authorization request (e.g. ``access_type=offline`` so the provider
+    returns a refreshable grant).
     """
     if auth_type == AUTH_TYPE_STATIC:
         # Static credentials: user-supplied option set is arbitrary; the
@@ -365,12 +463,14 @@ def _apply_auth_type(
     options_dict["community_oauth_flow"] = AUTH_TYPE_OAUTH_FLOW_VALUE[auth_type]
 
     if auth_type == AUTH_TYPE_U2M:
+        extra_auth_params = (flow_controls or {}).get("extra_auth_params")
         click.echo("Running OAuth 2.0 authorization-code flow (PKCE) ...")
         code, verifier, redirect_uri = run_u2m_authorization_code_flow(
             client_id=options_dict["client_id"],
             authorization_endpoint=options_dict["authorization_endpoint"],
             scope=options_dict.get("oauth_scope"),
             redirect_port=redirect_port,
+            extra_auth_params=extra_auth_params,
             echo=lambda msg: click.echo(msg),
         )
         options_dict["authorization_code"] = code
@@ -1815,13 +1915,13 @@ def show_pipeline(ctx: click.Context, pipeline_name: str):
     "--auth-type",
     "auth_type",
     type=click.Choice(list(AUTH_TYPE_CHOICES), case_sensitive=False),
-    default=AUTH_TYPE_STATIC,
-    show_default=True,
+    default=None,
     help=(
-        "Authentication mode for the COMMUNITY connection. "
-        "'static' (default) accepts arbitrary key/value options; other modes "
-        "require a fixed set of OAuth options and set 'community_oauth_flow' "
-        "automatically."
+        "Authentication mode for the COMMUNITY connection. If omitted, it is "
+        "taken from the connector spec's oauth.flow, or 'static' when the spec "
+        "has no oauth block. 'static' accepts arbitrary key/value options; "
+        "OAuth modes require a fixed set of OAuth options and set "
+        "'community_oauth_flow' automatically."
     ),
 )
 @click.option(
@@ -1830,8 +1930,8 @@ def show_pipeline(ctx: click.Context, pipeline_name: str):
     type=int,
     default=None,
     help=(
-        "Loopback port for the OAuth U2M redirect (only used with "
-        "--auth-type=u2m). Defaults to an OS-assigned free port."
+        "Loopback port for the OAuth U2M redirect (only used with the u2m "
+        "flow). Defaults to an OS-assigned free port."
     ),
 )
 @click.option(
@@ -1849,7 +1949,7 @@ def create_connection(
     source_name: str,
     connection_name: str,
     options: str,
-    auth_type: str,
+    auth_type: Optional[str],
     redirect_port: Optional[int],
     spec_path: Optional[str],
 ):
@@ -1860,11 +1960,12 @@ def create_connection(
 
     CONNECTION_NAME is the name for the new connection.
 
-    The connection type is set to COMMUNITY. The --auth-type flag selects the
-    auth mode:
+    The connection type is set to COMMUNITY. The auth mode is taken from the
+    connector spec's oauth.flow when --auth-type is omitted (or 'static' if the
+    spec has no oauth block); pass --auth-type only to override:
 
     \b
-      - static       (default) arbitrary key/value options; no OAuth flow.
+      - static       arbitrary key/value options; no OAuth flow.
       - m2m          requires client_id, client_secret, token_endpoint.
       - u2m          requires client_id, client_secret, authorization_endpoint,
                      token_endpoint. The CLI opens a browser, runs the OAuth
@@ -1875,6 +1976,9 @@ def create_connection(
                      token_endpoint. The per-user OAuth happens at runtime per
                      end-user; the connection only stores app config.
 
+    For OAuth modes the spec's oauth block supplies the endpoints and scope, so
+    the user typically only passes client_id + client_secret.
+
     Connection options are validated against the connector spec (connector_spec.yaml).
     The externalOptionsAllowList is automatically added from the spec.
 
@@ -1883,19 +1987,15 @@ def create_connection(
         community-connector create_connection github my_github_conn \\
             -o '{"token": "ghp_xxxx"}'
 
-        # OAuth M2M:
+        # OAuth connector whose spec declares oauth.flow (no --auth-type needed):
+        community-connector create_connection gmail my_gmail_conn \\
+            -o '{"client_id":"...","client_secret":"..."}'
+
+        # Override the auth type explicitly:
         community-connector create_connection github my_github_conn \\
             --auth-type m2m \\
             -o '{"client_id":"...","client_secret":"...",
                  "token_endpoint":"https://idp/token"}'
-
-        # OAuth U2M (browser-based authorization-code flow against localhost):
-        community-connector create_connection github my_github_conn \\
-            --auth-type u2m \\
-            -o '{"client_id":"...","client_secret":"...",
-                 "authorization_endpoint":"https://idp/authorize",
-                 "token_endpoint":"https://idp/token",
-                 "oauth_scope":"repo"}'
 
         # With custom spec file:
         community-connector create_connection github my_github_conn \\
@@ -1906,11 +2006,10 @@ def create_connection(
             -o '{"token": "ghp_xxxx"}' --spec https://github.com/myorg/myrepo
     """
     debug = ctx.obj.get("debug", False)
-    auth_type = auth_type.lower()
 
     click.echo(f"Creating connection for source: {source_name}")
     click.echo(f"Connection name: {connection_name}")
-    click.echo(f"Connection type: {CONNECTION_TYPE} (auth_type={auth_type})")
+    click.echo(f"Connection type: {CONNECTION_TYPE}")
 
     options_dict = _prepare_connection_options(
         source_name, options, spec_path, debug, auth_type, redirect_port
@@ -1955,13 +2054,13 @@ def create_connection(
     "--auth-type",
     "auth_type",
     type=click.Choice(list(AUTH_TYPE_CHOICES), case_sensitive=False),
-    default=AUTH_TYPE_STATIC,
-    show_default=True,
+    default=None,
     help=(
-        "Authentication mode for the COMMUNITY connection. Must match the "
-        "mode the connection was created with — the auth mode itself can't "
-        "be switched on update. Pass '--auth-type=u2m' to re-run the "
-        "browser authorization-code flow and refresh the stored OAuth grant."
+        "Authentication mode for the COMMUNITY connection. If omitted, it is "
+        "taken from the connector spec's oauth.flow (or 'static'). Must match "
+        "the mode the connection was created with — the auth mode itself can't "
+        "be switched on update. For the u2m flow this re-runs the browser "
+        "authorization-code flow and refreshes the stored OAuth grant."
     ),
 )
 @click.option(
@@ -1970,8 +2069,8 @@ def create_connection(
     type=int,
     default=None,
     help=(
-        "Loopback port for the OAuth U2M redirect (only used with "
-        "--auth-type=u2m). Defaults to an OS-assigned free port."
+        "Loopback port for the OAuth U2M redirect (only used with the u2m "
+        "flow). Defaults to an OS-assigned free port."
     ),
 )
 @click.option(
@@ -1989,7 +2088,7 @@ def update_connection(
     source_name: str,
     connection_name: str,
     options: str,
-    auth_type: str,
+    auth_type: Optional[str],
     redirect_port: Optional[int],
     spec_path: Optional[str],
 ):
@@ -2000,14 +2099,13 @@ def update_connection(
 
     CONNECTION_NAME is the name of the existing connection to update.
 
-    The connection's auth mode (community_oauth_flow) is fixed at creation
-    time and cannot be changed here — recreate the connection to switch
-    between static, m2m, u2m, and u2m_per_user modes. Pass the SAME
-    --auth-type the connection was created with so the update preserves it.
-    For --auth-type=u2m this re-runs the browser authorization-code + PKCE
-    flow and writes a fresh authorization_code / pkce_verifier /
-    oauth_redirect_uri, which is how you refresh an expired or revoked OAuth
-    grant without recreating the connection.
+    The auth mode is taken from the connector spec's oauth.flow when
+    --auth-type is omitted (or 'static'). The mode is fixed at creation time
+    and cannot be changed here — recreate the connection to switch between
+    static, m2m, u2m, and u2m_per_user modes. For the u2m flow the update
+    re-runs the browser authorization-code + PKCE flow and writes a fresh
+    authorization_code / pkce_verifier / oauth_redirect_uri, which is how you
+    refresh an expired or revoked OAuth grant without recreating the connection.
 
     Connection options are validated against the connector spec (connector_spec.yaml).
     The externalOptionsAllowList is automatically added from the spec.
@@ -2017,13 +2115,9 @@ def update_connection(
         community-connector update_connection github my_github_conn \\
             -o '{"token": "ghp_xxxx"}'
 
-        # Refresh an expired U2M OAuth grant (re-runs the browser flow):
-        community-connector update_connection github my_github_conn \\
-            --auth-type u2m \\
-            -o '{"client_id":"...","client_secret":"...",
-                 "authorization_endpoint":"https://idp/authorize",
-                 "token_endpoint":"https://idp/token",
-                 "oauth_scope":"repo"}'
+        # Refresh a U2M OAuth grant (spec declares oauth.flow; re-runs the flow):
+        community-connector update_connection gmail my_gmail_conn \\
+            -o '{"client_id":"...","client_secret":"..."}'
 
         # With custom spec file:
         community-connector update_connection github my_github_conn \\
@@ -2034,11 +2128,9 @@ def update_connection(
             -o '{"token": "ghp_xxxx"}' --spec https://github.com/myorg/myrepo
     """
     debug = ctx.obj.get("debug", False)
-    auth_type = auth_type.lower()
 
     click.echo(f"Updating connection for source: {source_name}")
     click.echo(f"Connection name: {connection_name}")
-    click.echo(f"Auth type: {auth_type}")
 
     options_dict = _prepare_connection_options(
         source_name, options, spec_path, debug, auth_type, redirect_port

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -364,6 +364,17 @@ _OAUTH_FLOW_CONTROL_KEYS = frozenset({"flow", "pkce", "extra_auth_params"})
 _RUNTIME_INJECTED_KEYS = frozenset({"access_token", "refresh_token"})
 
 
+def _flag_enabled(value, default: bool) -> bool:
+    """Interpret an oauth-block boolean flag that may be a real bool or a string
+    (spec parsing stringifies scalars, so ``pkce: false`` arrives as "False").
+    Returns ``default`` when the value is absent."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() not in ("false", "0", "no", "off", "")
+
+
 def _resolve_oauth_block(oauth_defaults: dict) -> Tuple[dict, dict]:
     """Split the connector-spec oauth block into connection options and flow controls.
 
@@ -463,19 +474,27 @@ def _apply_auth_type(
     options_dict["community_oauth_flow"] = AUTH_TYPE_OAUTH_FLOW_VALUE[auth_type]
 
     if auth_type == AUTH_TYPE_U2M:
-        extra_auth_params = (flow_controls or {}).get("extra_auth_params")
-        click.echo("Running OAuth 2.0 authorization-code flow (PKCE) ...")
+        controls = flow_controls or {}
+        extra_auth_params = controls.get("extra_auth_params")
+        use_pkce = _flag_enabled(controls.get("pkce"), default=True)
+        click.echo(
+            "Running OAuth 2.0 authorization-code flow"
+            f"{' (PKCE)' if use_pkce else ''} ..."
+        )
         code, verifier, redirect_uri = run_u2m_authorization_code_flow(
             client_id=options_dict["client_id"],
             authorization_endpoint=options_dict["authorization_endpoint"],
             scope=options_dict.get("oauth_scope"),
             redirect_port=redirect_port,
             extra_auth_params=extra_auth_params,
+            use_pkce=use_pkce,
             echo=lambda msg: click.echo(msg),
         )
         options_dict["authorization_code"] = code
-        options_dict["pkce_verifier"] = verifier
         options_dict["oauth_redirect_uri"] = redirect_uri
+        # Only store a verifier when PKCE was actually used.
+        if verifier:
+            options_dict["pkce_verifier"] = verifier
         click.echo("  ✓ Captured authorization code from loopback redirect.")
 
 

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/connector_spec.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/connector_spec.py
@@ -307,14 +307,20 @@ def parse_connector_spec(spec: dict) -> ParsedConnectorSpec:
         external_options_allowlist = ""
     parsed.external_options_allowlist = external_options_allowlist
 
-    # Parse OAuth defaults: connection.oauth maps standard RFC 6749 option
-    # names (authorization_endpoint, token_endpoint, oauth_scope, etc.) to
-    # provider-specific values. Used to auto-populate options the user
-    # shouldn't have to retype per connection.
+    # Parse OAuth defaults: connection.oauth maps OAuth-flow attributes
+    # (flow, scopes, authorization_url/token_url or their RFC 6749 aliases,
+    # pkce, extra_auth_params, …) to provider-specific values. Used to
+    # auto-populate options the user shouldn't have to retype per connection.
     oauth_block = connection.get("oauth")
     if isinstance(oauth_block, dict):
+        # Scalars are stringified for the option map; nested values
+        # (e.g. ``extra_auth_params``) are preserved as-is so the caller can
+        # fold them into the authorization request rather than storing a
+        # stringified dict as a connection option.
         parsed.oauth_defaults = {
-            str(k): str(v) for k, v in oauth_block.items() if v is not None
+            str(k): (v if isinstance(v, dict) else str(v))
+            for k, v in oauth_block.items()
+            if v is not None
         }
 
     return parsed
@@ -414,6 +420,8 @@ def validate_connection_options(
     source_name: str,
     options_dict: dict,
     parsed_spec: ParsedConnectorSpec,
+    additional_known_keys: Optional[Set[str]] = None,
+    skip_required: Optional[Set[str]] = None,
 ) -> ValidationResult:
     """
     Validate connection options against the parsed connector spec.
@@ -424,17 +432,28 @@ def validate_connection_options(
         source_name: Name of the connector source.
         options_dict: The connection options dictionary.
         parsed_spec: The parsed connector spec.
+        additional_known_keys: Extra option keys to treat as known (exempt from
+            the unknown-parameter check). Used by OAuth modes where the OAuth
+            layer / UC supply keys (client_id, endpoints, tokens, …) that the
+            connector spec does not list as connection parameters.
+        skip_required: Spec-declared required params to NOT enforce here. Used
+            by OAuth modes for keys the OAuth layer / UC supply rather than the
+            user (e.g. the OAuth fields and UC-injected tokens).
 
     Returns:
         ValidationResult with errors, warnings, and detected auth method.
     """
     result = ValidationResult()
     provided_params = set(options_dict.keys())
+    additional_known_keys = additional_known_keys or set()
+    skip_required = skip_required or set()
 
     if parsed_spec.has_auth_methods():
         # Option B: auth_methods structure
         # First, check common required parameters
-        missing_common = parsed_spec.common_required_params - provided_params
+        missing_common = (
+            parsed_spec.common_required_params - skip_required - provided_params
+        )
         if missing_common:
             result.errors.append(
                 f"Missing required common parameters: {', '.join(sorted(missing_common))}"
@@ -446,7 +465,9 @@ def validate_connection_options(
         if detected_method:
             result.detected_auth_method = detected_method.name
             # Validate all required params for the detected method
-            missing_method_params = detected_method.required_params - provided_params
+            missing_method_params = (
+                detected_method.required_params - skip_required - provided_params
+            )
             if missing_method_params:
                 result.errors.append(
                     f"Missing required parameters for '{detected_method.name}' auth method: "
@@ -469,6 +490,7 @@ def validate_connection_options(
         all_known = parsed_spec.get_all_known_params()
         all_known.add("sourceName")
         all_known.add("externalOptionsAllowList")
+        all_known |= additional_known_keys
         unknown_params = provided_params - all_known
 
         if unknown_params:
@@ -479,7 +501,7 @@ def validate_connection_options(
             )
     else:
         # Option A: flat parameters structure
-        missing_required = parsed_spec.required_params - provided_params
+        missing_required = parsed_spec.required_params - skip_required - provided_params
         if missing_required:
             result.errors.append(
                 f"Missing required connection parameters: {', '.join(sorted(missing_required))}"
@@ -489,6 +511,7 @@ def validate_connection_options(
         all_known = parsed_spec.required_params | parsed_spec.optional_params
         all_known.add("sourceName")
         all_known.add("externalOptionsAllowList")
+        all_known |= additional_known_keys
         unknown_params = provided_params - all_known
 
         if unknown_params:

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/connector_spec.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/connector_spec.py
@@ -494,10 +494,11 @@ def validate_connection_options(
         unknown_params = provided_params - all_known
 
         if unknown_params:
+            known_hint = parsed_spec.get_all_known_params() | additional_known_keys
             result.errors.append(
                 f"Unknown connection parameters for '{source_name}': "
                 f"{', '.join(sorted(unknown_params))}. "
-                f"Known parameters are: {', '.join(sorted(parsed_spec.get_all_known_params()))}"
+                f"Known parameters are: {', '.join(sorted(known_hint))}"
             )
     else:
         # Option A: flat parameters structure
@@ -515,11 +516,15 @@ def validate_connection_options(
         unknown_params = provided_params - all_known
 
         if unknown_params:
+            known_hint = (
+                parsed_spec.required_params
+                | parsed_spec.optional_params
+                | additional_known_keys
+            )
             result.errors.append(
                 f"Unknown connection parameters for '{source_name}': "
                 f"{', '.join(sorted(unknown_params))}. "
-                f"Known parameters are: "
-                f"{', '.join(sorted(parsed_spec.required_params | parsed_spec.optional_params))}"
+                f"Known parameters are: {', '.join(sorted(known_hint))}"
             )
 
     return result

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/oauth_flow.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/oauth_flow.py
@@ -166,6 +166,16 @@ class _CallbackHandler(http.server.BaseHTTPRequestHandler):
         self.wfile.write(body.encode("utf-8"))
 
 
+def _merge_extra_auth_params(auth_params: dict, extra_auth_params: Optional[dict]) -> dict:
+    """Fold provider-specific extras into ``auth_params`` without letting them
+    clobber the flow-critical params already set (response_type, client_id,
+    redirect_uri, state, PKCE, scope). Returns ``auth_params`` for chaining."""
+    if extra_auth_params:
+        for key, value in extra_auth_params.items():
+            auth_params.setdefault(str(key), str(value))
+    return auth_params
+
+
 def run_u2m_authorization_code_flow(
     *,
     client_id: str,
@@ -173,13 +183,20 @@ def run_u2m_authorization_code_flow(
     scope: Optional[str],
     redirect_port: Optional[int] = None,
     extra_auth_params: Optional[dict] = None,
+    use_pkce: bool = True,
     open_browser: bool = True,
     timeout_seconds: int = 300,
     echo=print,
 ) -> Tuple[str, str, str]:
-    """Drive the OAuth 2.0 authorization-code + PKCE flow against a loopback redirect.
+    """Drive the OAuth 2.0 authorization-code flow against a loopback redirect.
 
-    Returns ``(authorization_code, pkce_verifier, redirect_uri)``.
+    Returns ``(authorization_code, pkce_verifier, redirect_uri)``. When
+    ``use_pkce`` is False the flow omits the PKCE challenge and the returned
+    ``pkce_verifier`` is an empty string.
+
+    ``use_pkce`` defaults to True (PKCE is harmless for confidential clients
+    and required for public ones); pass False to honor a connector spec's
+    ``oauth.pkce: false``.
 
     ``extra_auth_params`` are provider-specific knobs (e.g.
     ``access_type=offline``, ``prompt=consent``) folded into the authorization
@@ -198,7 +215,7 @@ def run_u2m_authorization_code_flow(
     # server only listens on 127.0.0.1 → ERR_CONNECTION_REFUSED).
     redirect_uri = f"http://127.0.0.1:{redirect_port}/callback"
 
-    verifier, challenge = _generate_pkce()
+    verifier = ""
     state = secrets.token_urlsafe(24)
 
     auth_params = {
@@ -206,17 +223,15 @@ def run_u2m_authorization_code_flow(
         "client_id": client_id,
         "redirect_uri": redirect_uri,
         "state": state,
-        "code_challenge": challenge,
-        "code_challenge_method": "S256",
     }
+    if use_pkce:
+        verifier, challenge = _generate_pkce()
+        auth_params["code_challenge"] = challenge
+        auth_params["code_challenge_method"] = "S256"
     if scope:
         auth_params["scope"] = scope
 
-    # Fold in provider-specific extras without letting them clobber the
-    # flow-critical params above.
-    if extra_auth_params:
-        for key, value in extra_auth_params.items():
-            auth_params.setdefault(str(key), str(value))
+    _merge_extra_auth_params(auth_params, extra_auth_params)
 
     separator = "&" if "?" in authorization_endpoint else "?"
     auth_url = f"{authorization_endpoint}{separator}{urllib.parse.urlencode(auth_params)}"

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/oauth_flow.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/oauth_flow.py
@@ -172,6 +172,7 @@ def run_u2m_authorization_code_flow(
     authorization_endpoint: str,
     scope: Optional[str],
     redirect_port: Optional[int] = None,
+    extra_auth_params: Optional[dict] = None,
     open_browser: bool = True,
     timeout_seconds: int = 300,
     echo=print,
@@ -179,6 +180,11 @@ def run_u2m_authorization_code_flow(
     """Drive the OAuth 2.0 authorization-code + PKCE flow against a loopback redirect.
 
     Returns ``(authorization_code, pkce_verifier, redirect_uri)``.
+
+    ``extra_auth_params`` are provider-specific knobs (e.g.
+    ``access_type=offline``, ``prompt=consent``) folded into the authorization
+    request. They never override the flow's own parameters (response_type,
+    client_id, redirect_uri, state, PKCE, scope).
 
     Raises ``RuntimeError`` if the user does not complete the flow within
     ``timeout_seconds`` or the IdP returns an error / mismatched state.
@@ -205,6 +211,12 @@ def run_u2m_authorization_code_flow(
     }
     if scope:
         auth_params["scope"] = scope
+
+    # Fold in provider-specific extras without letting them clobber the
+    # flow-critical params above.
+    if extra_auth_params:
+        for key, value in extra_auth_params.items():
+            auth_params.setdefault(str(key), str(value))
 
     separator = "&" if "?" in authorization_endpoint else "?"
     auth_url = f"{authorization_endpoint}{separator}{urllib.parse.urlencode(auth_params)}"

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -1421,6 +1421,183 @@ class TestOAuthSpecBlockShape:
         assert "community_oauth_flow" not in opts
         assert "authorization_endpoint" not in opts
 
+    @patch(
+        "databricks.labs.community_connector_cli.cli.run_u2m_authorization_code_flow"
+    )
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_oauth_mode_still_rejects_truly_unknown_key(
+        self, mock_workspace_client, mock_load_spec, mock_oauth
+    ):
+        """OAuth keys are exempt, but a genuinely unknown key is still rejected
+        (the exemption must not become a blanket pass-through)."""
+        runner = CliRunner()
+        mock_load_spec.return_value = self._SPEC
+        mock_ws = MagicMock()
+        mock_workspace_client.return_value = mock_ws
+
+        result = runner.invoke(
+            main,
+            [
+                "create_connection",
+                "gmail",
+                "my_conn",
+                "-o",
+                '{"client_id":"cid","client_secret":"csecret","bogus_param":"x"}',
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "bogus_param" in result.output
+        mock_oauth.assert_not_called()
+
+    @pytest.mark.parametrize("flow", ["m2m", "u2m_per_user"])
+    @patch(
+        "databricks.labs.community_connector_cli.cli.run_u2m_authorization_code_flow"
+    )
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_non_u2m_flows_derived_from_spec_no_browser(
+        self, mock_workspace_client, mock_load_spec, mock_oauth, flow
+    ):
+        """m2m / u2m_per_user are derived from oauth.flow and stamp
+        community_oauth_flow without opening a browser."""
+        runner = CliRunner()
+        mock_load_spec.return_value = {
+            "connection": {
+                "parameters": [
+                    {"name": "client_id", "type": "string", "required": True},
+                    {"name": "client_secret", "type": "string", "required": True},
+                ],
+                "oauth": {
+                    "flow": flow,
+                    "scopes": "read",
+                    "authorization_url": "https://idp/authorize",
+                    "token_url": "https://idp/token",
+                },
+            },
+            "external_options_allowlist": "",
+        }
+        mock_ws = MagicMock()
+        mock_workspace_client.return_value = mock_ws
+        mock_ws.api_client.do.return_value = {"name": "test", "connection_id": "123"}
+
+        result = runner.invoke(
+            main,
+            [
+                "create_connection",
+                "demo",
+                "my_conn",
+                "-o",
+                '{"client_id":"cid","client_secret":"csecret"}',
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        opts = mock_ws.api_client.do.call_args.kwargs["body"]["options"]
+        assert opts["community_oauth_flow"] == flow
+        mock_oauth.assert_not_called()  # only u2m opens the browser
+
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_invalid_spec_flow_errors(self, mock_workspace_client, mock_load_spec):
+        """An unrecognized oauth.flow value is rejected with a clear error."""
+        runner = CliRunner()
+        mock_load_spec.return_value = {
+            "connection": {"parameters": [], "oauth": {"flow": "bogus"}},
+            "external_options_allowlist": "",
+        }
+        mock_ws = MagicMock()
+        mock_workspace_client.return_value = mock_ws
+
+        result = runner.invoke(
+            main, ["create_connection", "demo", "my_conn", "-o", "{}"]
+        )
+
+        assert result.exit_code != 0
+        assert "Unknown auth type" in result.output
+        assert "bogus" in result.output
+
+    @patch(
+        "databricks.labs.community_connector_cli.cli.run_u2m_authorization_code_flow"
+    )
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_pkce_false_skips_pkce(
+        self, mock_workspace_client, mock_load_spec, mock_oauth
+    ):
+        """oauth.pkce: false runs the flow with use_pkce=False and stores no
+        pkce_verifier."""
+        runner = CliRunner()
+        mock_load_spec.return_value = self._SPEC  # has pkce: False
+        mock_ws = MagicMock()
+        mock_workspace_client.return_value = mock_ws
+        mock_ws.api_client.do.return_value = {"name": "test", "connection_id": "123"}
+        # No-PKCE flow returns an empty verifier.
+        mock_oauth.return_value = ("CODE", "", "http://127.0.0.1:5/callback")
+
+        result = runner.invoke(
+            main,
+            [
+                "create_connection",
+                "gmail",
+                "my_conn",
+                "-o",
+                '{"client_id":"cid","client_secret":"csecret"}',
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert mock_oauth.call_args.kwargs["use_pkce"] is False
+        opts = mock_ws.api_client.do.call_args.kwargs["body"]["options"]
+        assert "pkce_verifier" not in opts
+
+    @patch(
+        "databricks.labs.community_connector_cli.cli.run_u2m_authorization_code_flow"
+    )
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_pkce_defaults_on_when_absent(
+        self, mock_workspace_client, mock_load_spec, mock_oauth
+    ):
+        """No pkce key in the spec -> PKCE stays on (the secure default)."""
+        runner = CliRunner()
+        mock_load_spec.return_value = {
+            "connection": {
+                "parameters": [
+                    {"name": "client_id", "type": "string", "required": True},
+                    {"name": "client_secret", "type": "string", "required": True},
+                ],
+                "oauth": {
+                    "flow": "u2m",
+                    "scopes": "read",
+                    "authorization_url": "https://idp/authorize",
+                    "token_url": "https://idp/token",
+                },
+            },
+            "external_options_allowlist": "",
+        }
+        mock_ws = MagicMock()
+        mock_workspace_client.return_value = mock_ws
+        mock_ws.api_client.do.return_value = {"name": "test", "connection_id": "123"}
+        mock_oauth.return_value = ("CODE", "VER", "http://127.0.0.1:5/callback")
+
+        result = runner.invoke(
+            main,
+            [
+                "create_connection",
+                "demo",
+                "my_conn",
+                "-o",
+                '{"client_id":"cid","client_secret":"csecret"}',
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert mock_oauth.call_args.kwargs["use_pkce"] is True
+        opts = mock_ws.api_client.do.call_args.kwargs["body"]["options"]
+        assert opts["pkce_verifier"] == "VER"
+
 
 class TestMakeWorkspaceClient:
     """Tests for the WorkspaceClient profile-resolution helper."""

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -1259,6 +1259,169 @@ class TestOAuthDefaultsAutoFill:
         assert "community_oauth_flow" not in opts
 
 
+class TestOAuthSpecBlockShape:
+    """With the connector spec declaring its OAuth flow (PR #218 shape), the
+    user no longer passes --auth-type: the CLI takes the auth type from
+    oauth.flow and resolves the spec's human-friendly oauth keys
+    (authorization_url / token_url / scopes / extra_auth_params) into the
+    option names the existing flow uses."""
+
+    _SPEC = {
+        "connection": {
+            "parameters": [
+                {"name": "client_id", "type": "string", "required": True},
+                {"name": "client_secret", "type": "string", "required": True},
+                {"name": "user_id", "type": "string", "required": False},
+            ],
+            "oauth": {
+                "flow": "u2m",
+                "pkce": False,
+                "scopes": "https://www.googleapis.com/auth/gmail.readonly",
+                "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth",
+                "token_url": "https://oauth2.googleapis.com/token",
+                "extra_auth_params": {"access_type": "offline", "prompt": "consent"},
+            },
+        },
+        "external_options_allowlist": "",
+    }
+
+    @patch(
+        "databricks.labs.community_connector_cli.cli.run_u2m_authorization_code_flow"
+    )
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_auth_type_derived_from_spec_flow_no_flag_needed(
+        self, mock_workspace_client, mock_load_spec, mock_oauth
+    ):
+        """No --auth-type: the u2m flow runs (from oauth.flow), spec keys map to
+        the RFC names, extra_auth_params reach the flow, and flow-control keys
+        are not stored on the connection."""
+        runner = CliRunner()
+        mock_load_spec.return_value = self._SPEC
+        mock_ws = MagicMock()
+        mock_workspace_client.return_value = mock_ws
+        mock_ws.api_client.do.return_value = {"name": "test", "connection_id": "123"}
+        mock_oauth.return_value = ("CODE", "VERIFIER", "http://127.0.0.1:5/callback")
+
+        result = runner.invoke(
+            main,
+            [
+                "create_connection",
+                "gmail",
+                "my_conn",
+                "-o",
+                '{"client_id":"cid","client_secret":"csecret"}',
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        # The u2m flow ran even though --auth-type was not passed.
+        mock_oauth.assert_called_once()
+        kwargs = mock_oauth.call_args.kwargs
+        assert kwargs["authorization_endpoint"] == (
+            "https://accounts.google.com/o/oauth2/v2/auth"
+        )
+        assert kwargs["scope"] == "https://www.googleapis.com/auth/gmail.readonly"
+        assert kwargs["extra_auth_params"] == {
+            "access_type": "offline",
+            "prompt": "consent",
+        }
+
+        opts = mock_ws.api_client.do.call_args.kwargs["body"]["options"]
+        assert opts["authorization_endpoint"] == (
+            "https://accounts.google.com/o/oauth2/v2/auth"
+        )
+        assert opts["token_endpoint"] == "https://oauth2.googleapis.com/token"
+        assert opts["oauth_scope"] == "https://www.googleapis.com/auth/gmail.readonly"
+        assert opts["community_oauth_flow"] == "u2m"
+        # Flow-control keys must never be stored on the connection.
+        for leaked in ("flow", "pkce", "extra_auth_params", "scopes",
+                       "authorization_url", "token_url"):
+            assert leaked not in opts
+
+    @patch(
+        "databricks.labs.community_connector_cli.cli.run_u2m_authorization_code_flow"
+    )
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_oauth_mode_enforces_connector_required_params(
+        self, mock_workspace_client, mock_load_spec, mock_oauth
+    ):
+        """A connector-specific required param missing errors out (like static
+        mode) before the browser flow runs — the OAuth fields are exempt, but
+        connector params are not."""
+        runner = CliRunner()
+        spec = {
+            "connection": {
+                "parameters": [
+                    {"name": "client_id", "type": "string", "required": True},
+                    {"name": "client_secret", "type": "string", "required": True},
+                    # A connector-specific required option, not an OAuth field.
+                    {"name": "region", "type": "string", "required": True},
+                ],
+                "oauth": {
+                    "flow": "u2m",
+                    "scopes": "read",
+                    "authorization_url": "https://idp/authorize",
+                    "token_url": "https://idp/token",
+                },
+            },
+            "external_options_allowlist": "",
+        }
+        mock_load_spec.return_value = spec
+        mock_ws = MagicMock()
+        mock_workspace_client.return_value = mock_ws
+
+        result = runner.invoke(
+            main,
+            [
+                "create_connection",
+                "demo",
+                "my_conn",
+                "-o",
+                '{"client_id":"cid","client_secret":"csecret"}',
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "region" in result.output
+        # The browser flow must not run when required options are missing.
+        mock_oauth.assert_not_called()
+        mock_ws.api_client.do.assert_not_called()
+
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_explicit_auth_type_overrides_spec_flow(
+        self, mock_workspace_client, mock_load_spec
+    ):
+        """An explicit --auth-type wins over the spec's oauth.flow."""
+        runner = CliRunner()
+        mock_load_spec.return_value = self._SPEC
+        mock_ws = MagicMock()
+        mock_workspace_client.return_value = mock_ws
+        mock_ws.api_client.do.return_value = {"name": "test", "connection_id": "123"}
+
+        result = runner.invoke(
+            main,
+            [
+                "create_connection",
+                "gmail",
+                "my_conn",
+                "--auth-type",
+                "static",
+                "-o",
+                '{"client_id":"cid","client_secret":"csecret"}',
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        opts = mock_ws.api_client.do.call_args.kwargs["body"]["options"]
+        # static wins: no OAuth flow stamped, oauth defaults not applied.
+        assert "community_oauth_flow" not in opts
+        assert "authorization_endpoint" not in opts
+
+
 class TestMakeWorkspaceClient:
     """Tests for the WorkspaceClient profile-resolution helper."""
 

--- a/tools/community_connector/tests/test_oauth_flow.py
+++ b/tools/community_connector/tests/test_oauth_flow.py
@@ -11,6 +11,7 @@ import pytest
 from databricks.labs.community_connector_cli import oauth_flow
 from databricks.labs.community_connector_cli.oauth_flow import (
     _generate_pkce,
+    _merge_extra_auth_params,
     _pick_free_port,
     run_u2m_authorization_code_flow,
 )
@@ -190,3 +191,76 @@ def test_run_u2m_flow_propagates_idp_error(monkeypatch):
             timeout_seconds=5,
             echo=lambda *_args, **_kw: None,
         )
+
+
+def test_merge_extra_auth_params_does_not_clobber_flow_params():
+    """Extra params fill gaps but never overwrite the flow-critical params."""
+    base = {"response_type": "code", "client_id": "cid", "scope": "repo"}
+    merged = _merge_extra_auth_params(
+        base,
+        {"access_type": "offline", "client_id": "EVIL", "prompt": "consent"},
+    )
+    assert merged["access_type"] == "offline"
+    assert merged["prompt"] == "consent"
+    # Attempt to clobber a flow-critical param is ignored.
+    assert merged["client_id"] == "cid"
+
+
+def test_merge_extra_auth_params_handles_none():
+    base = {"response_type": "code"}
+    assert _merge_extra_auth_params(base, None) == {"response_type": "code"}
+
+
+def _run_flow_capturing_auth_url(monkeypatch, **kwargs):
+    """Drive run_u2m with a fake browser that completes the flow and returns the
+    captured authorization-URL query string."""
+    port = _pick_free_port()
+    captured = {}
+
+    def fake_open(url):
+        from urllib.parse import urlparse, parse_qs
+
+        qs = parse_qs(urlparse(url).query)
+        captured["qs"] = qs
+
+        def hit_callback():
+            time.sleep(0.1)
+            cb = f"{qs['redirect_uri'][0]}?code=THE_CODE&state={qs['state'][0]}"
+            urllib.request.urlopen(cb, timeout=5).read()
+
+        threading.Thread(target=hit_callback, daemon=True).start()
+        return True
+
+    monkeypatch.setattr(oauth_flow.webbrowser, "open", fake_open)
+    result = run_u2m_authorization_code_flow(
+        client_id="cid",
+        authorization_endpoint="https://example.com/authorize",
+        scope="repo",
+        redirect_port=port,
+        open_browser=True,
+        timeout_seconds=5,
+        echo=lambda *_a, **_k: None,
+        **kwargs,
+    )
+    return result, captured["qs"]
+
+
+def test_run_u2m_without_pkce_omits_challenge_and_returns_empty_verifier(monkeypatch):
+    (_, verifier, _), qs = _run_flow_capturing_auth_url(monkeypatch, use_pkce=False)
+    assert verifier == ""
+    assert "code_challenge" not in qs
+    assert "code_challenge_method" not in qs
+
+
+def test_run_u2m_with_pkce_includes_challenge(monkeypatch):
+    (_, verifier, _), qs = _run_flow_capturing_auth_url(monkeypatch, use_pkce=True)
+    assert 43 <= len(verifier) <= 128
+    assert qs["code_challenge_method"] == ["S256"]
+
+
+def test_run_u2m_folds_extra_auth_params_into_url(monkeypatch):
+    _, qs = _run_flow_capturing_auth_url(
+        monkeypatch, extra_auth_params={"access_type": "offline", "prompt": "consent"}
+    )
+    assert qs["access_type"] == ["offline"]
+    assert qs["prompt"] == ["consent"]


### PR DESCRIPTION
## Summary

Make the `community-connector` CLI work with the new Gmail connector spec (#220/#221), which declares its OAuth flow in the spec. Behaves like before for every existing connector; two user-facing differences:

### 1. `--auth-type` is now optional
When omitted, the auth type is taken from the spec's `oauth.flow` (or `static` when the spec has no oauth block). Passing `--auth-type` still works and overrides the spec.

```bash
# Gmail spec declares oauth.flow: u2m — no --auth-type needed:
community-connector create_connection gmail my_gmail_conn \
  -o '{"client_id":"...","client_secret":"..."}'
```

### 2. OAuth modes now validate connector-spec params (like static mode)
Previously OAuth modes skipped connector-spec parameter validation entirely. Now they validate it **before** any browser flow runs, so a missing connector-specific **required** option errors out just like static mode. Only the keys the OAuth layer / UC supply are exempt from the required + unknown-parameter checks:
- OAuth fields: `client_id`, `client_secret`, endpoints, `oauth_scope`, `authorization_code`, `pkce_verifier`, … (the `OAUTH_OPTION_KEYS` set)
- UC-injected runtime tokens: `access_token`, `refresh_token`

So e.g. a spec requiring `region` will error if the user omits it, without opening the browser.

### Plumbing
The CLI resolves the spec's oauth block into the option names the existing flow already uses — `authorization_url → authorization_endpoint`, `token_url → token_endpoint`, `scopes → oauth_scope` (RFC-named specs pass through unchanged) — folds `extra_auth_params` (e.g. `access_type=offline`) into the authorization request, and keeps `flow` / `pkce` / `extra_auth_params` out of the stored connection options. `validate_connection_options` gains `additional_known_keys` / `skip_required` to express the exemptions.

## Test plan

- [x] `TestOAuthSpecBlockShape`: auth type derived from `oauth.flow` with no `--auth-type`; explicit `--auth-type` overrides; **missing connector-specific required option errors before the flow runs**; spec keys mapped to RFC names; `extra_auth_params` reach the flow; flow-control keys not stored.
- [x] Full `tools/community_connector` suite — 186 passed.

## Related
- #220 / #221 — the Gmail spec this enables.

This pull request and its description were written by Isaac.