### PR TITLE
Document COMMUNITY OAuth connection support in dev skills and docs

### DIFF
--- a/.claude/skills/authenticate-source/SKILL.md
+++ b/.claude/skills/authenticate-source/SKILL.md
@@ -34,6 +34,8 @@ Check if `src/databricks/labs/community_connector/sources/{{source_name}}/connec
 Run this step directly — not as a subagent.
 This step is **interactive** — the script blocks until the user submits the browser form.
 
+> **OAuth connectors**: when `connector_spec.yaml` declares a `connection.oauth` block, the script runs the OAuth 2.0 authorization-code flow — the user supplies `client_id` + `client_secret`, then logs in and authorizes in the browser, and the token is obtained automatically (the source's OAuth app must have the redirect URI registered). The steps below are otherwise unchanged.
+
 2a. Ensure venv:
    ```bash
    python3.10 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"

--- a/.claude/skills/authenticate-source/SKILL.md
+++ b/.claude/skills/authenticate-source/SKILL.md
@@ -34,7 +34,7 @@ Check if `src/databricks/labs/community_connector/sources/{{source_name}}/connec
 Run this step directly — not as a subagent.
 This step is **interactive** — the script blocks until the user submits the browser form.
 
-> **OAuth connectors**: when `connector_spec.yaml` declares a `connection.oauth` block, the script runs the OAuth 2.0 authorization-code flow — the user supplies `client_id` + `client_secret`, then logs in and authorizes in the browser, and the token is obtained automatically (the source's OAuth app must have the redirect URI registered). The steps below are otherwise unchanged.
+> **OAuth connectors**: when `connector_spec.yaml` declares a `connection.oauth` block with an interactive flow (`u2m` / `u2m_per_user`), the script runs the OAuth 2.0 authorization-code flow — the user supplies `client_id` + `client_secret`, then logs in and authorizes in the browser, and the token is obtained automatically (the source's OAuth app must have the redirect URI registered). For an `m2m` connector the user just supplies `client_id` + `client_secret` (no browser). The steps below are otherwise unchanged.
 
 2a. Ensure venv:
    ```bash

--- a/.claude/skills/collect-credentials/SKILL.md
+++ b/.claude/skills/collect-credentials/SKILL.md
@@ -62,7 +62,7 @@ The port may differ from 9876 if that port is already in use.
 
 ## Important Notes
 
-- **OAuth connectors**: when `connector_spec.yaml` declares a `connection.oauth` block, the script runs the OAuth 2.0 authorization-code flow instead of a plain form — the user provides their `client_id` + `client_secret`, then logs in and authorizes in the browser, and the script obtains the token automatically. The OAuth app in the source must have the script's redirect URI registered. Otherwise the steps are identical.
+- **OAuth connectors**: when `connector_spec.yaml` declares a `connection.oauth` block with an interactive flow (`u2m` / `u2m_per_user`), the script runs the OAuth 2.0 authorization-code flow instead of a plain form — the user provides their `client_id` + `client_secret`, then logs in and authorizes in the browser, and the script obtains the token automatically. The OAuth app in the source must have the script's redirect URI registered. (The script does not run the `m2m` client-credentials grant; for an `m2m` connector the user just supplies `client_id` + `client_secret`.) Otherwise the steps are identical.
 - This skill is **interactive** — the script blocks until the user submits the browser form.
 - The caller must be able to run Bash in the background and communicate with the user (e.g., via `AskUserQuestion`) while the script is running.
 - The script automatically shuts down after the user submits the form.

--- a/.claude/skills/collect-credentials/SKILL.md
+++ b/.claude/skills/collect-credentials/SKILL.md
@@ -62,6 +62,7 @@ The port may differ from 9876 if that port is already in use.
 
 ## Important Notes
 
+- **OAuth connectors**: when `connector_spec.yaml` declares a `connection.oauth` block, the script runs the OAuth 2.0 authorization-code flow instead of a plain form — the user provides their `client_id` + `client_secret`, then logs in and authorizes in the browser, and the script obtains the token automatically. The OAuth app in the source must have the script's redirect URI registered. Otherwise the steps are identical.
 - This skill is **interactive** — the script blocks until the user submits the browser form.
 - The caller must be able to run Bash in the background and communicate with the user (e.g., via `AskUserQuestion`) while the script is running.
 - The script automatically shuts down after the user submits the form.

--- a/.claude/skills/create-connector-document/SKILL.md
+++ b/.claude/skills/create-connector-document/SKILL.md
@@ -17,4 +17,5 @@ Produce a Markdown file strictly following the standard template at `templates/c
 - Please use the code implementation as the source of truth.
 - Use the source API documentation to cover anything missing.
 - Always include a section about how to configure the parameters needed to connect to the source system.
+- If the `connector_spec.yaml` declares a `connection.oauth` block, document the connection as **OAuth-based**: the user registers an OAuth app in the source and supplies its `client_id` + `client_secret` (not a token); the connection runs the login/consent flow and supplies the token automatically. Cover how to create the OAuth app in the source (including the redirect URI to register) and which scopes to grant. See the Gmail connector README for the reference pattern.
 - AVOID mentioning internal implementation terms such as function or argument names from the `LakeflowConnect`.

--- a/.claude/skills/create-connector-document/SKILL.md
+++ b/.claude/skills/create-connector-document/SKILL.md
@@ -17,5 +17,9 @@ Produce a Markdown file strictly following the standard template at `templates/c
 - Please use the code implementation as the source of truth.
 - Use the source API documentation to cover anything missing.
 - Always include a section about how to configure the parameters needed to connect to the source system.
-- If the `connector_spec.yaml` declares a `connection.oauth` block, document the connection as **OAuth-based**: the user registers an OAuth app in the source and supplies its `client_id` + `client_secret` (not a token); the connection runs the login/consent flow and supplies the token automatically. Cover how to create the OAuth app in the source (including the redirect URI to register) and which scopes to grant. See the Gmail connector README for the reference pattern.
+- If the `connector_spec.yaml` declares a `connection.oauth` block, document the connection as **OAuth-based**: the user registers an OAuth app in the source and supplies its `client_id` + `client_secret` (not a token); the connection obtains the token automatically. Cover how to create the OAuth app in the source and which scopes to grant. Tailor the wording to the spec's `flow`:
+  - **`m2m`** (client-credentials): a machine-to-machine token exchange — no user login, no browser, no redirect URI.
+  - **`u2m` / `u2m_per_user`**: an interactive login/consent flow — creating the connection opens a browser for the user to authorize, so also document the redirect URI to register on the OAuth app.
+
+  See the Gmail connector README for the reference pattern (a `u2m` connector).
 - AVOID mentioning internal implementation terms such as function or argument names from the `LakeflowConnect`.

--- a/.claude/skills/create-connector-document/SKILL.md
+++ b/.claude/skills/create-connector-document/SKILL.md
@@ -17,9 +17,9 @@ Produce a Markdown file strictly following the standard template at `templates/c
 - Please use the code implementation as the source of truth.
 - Use the source API documentation to cover anything missing.
 - Always include a section about how to configure the parameters needed to connect to the source system.
-- If the `connector_spec.yaml` declares a `connection.oauth` block, document the connection as **OAuth-based**: the user registers an OAuth app in the source and supplies its `client_id` + `client_secret` (not a token); the connection obtains the token automatically. Cover how to create the OAuth app in the source and which scopes to grant. Tailor the wording to the spec's `flow`:
-  - **`m2m`** (client-credentials): a machine-to-machine token exchange — no user login, no browser, no redirect URI.
-  - **`u2m` / `u2m_per_user`**: an interactive login/consent flow — creating the connection opens a browser for the user to authorize, so also document the redirect URI to register on the OAuth app.
+- If the `connector_spec.yaml` declares a `connection.oauth` block, document the connection as **OAuth-based**: the user registers an OAuth app in the source and supplies its `client_id` + `client_secret` (not a token); the connection obtains the token automatically. Cover how to create the OAuth app in the source and which scopes to grant. Describe the *user experience*, not the internal flow name — **do not mention `m2m` / `u2m` / `u2m_per_user`** in end-user docs (users don't configure those; the flow is fixed by the spec). Let the spec's `flow` decide only what you describe:
+  - client-credentials: the connection authenticates machine-to-machine — no browser login, no redirect URI to register.
+  - interactive: creating the connection opens a browser for the user to sign in and authorize, so also document the redirect URI to register on the OAuth app.
 
-  See the Gmail connector README for the reference pattern (a `u2m` connector).
+  See the Gmail connector README for the reference pattern. (Only surface a flow choice if the connector genuinely supports more than one and the user must pick.)
 - AVOID mentioning internal implementation terms such as function or argument names from the `LakeflowConnect`.

--- a/.claude/skills/deploy-connector/SKILL.md
+++ b/.claude/skills/deploy-connector/SKILL.md
@@ -79,7 +79,7 @@ If `{{connection_name}}` provided, use it. Otherwise ask if the user has one.
   ```
   List each required/optional **credential** parameter from the spec (e.g. `token`, `api_key`) with a short description. Do **not** ask for `externalOptionsAllowList` — the CLI reads the connector spec and adds it automatically. Ask the user to run the command and provide the connection name.
 
-  The command is the same whether the connector uses static credentials or OAuth — the CLI reads the auth mode from the spec's `connection.oauth` block. For OAuth connectors, note two differences for the user: (1) when setting up the OAuth app in the source, they must register the redirect URI the connection flow uses; and (2) a `u2m` flow opens a browser at connection creation for the user to log in and authorize.
+  The command is the same whether the connector uses static credentials or OAuth — the CLI reads the auth mode and its required options from the spec's `connection.oauth` block, so you don't choose a mode here. The one runtime difference to flag for the user: an interactive flow (`u2m` / `u2m_per_user`) opens a browser at connection creation for them to log in and authorize (and the source's OAuth app must have the redirect URI registered), whereas `m2m` completes machine-to-machine with no browser.
 
 ### 2b. Default destination catalog and schema
 

--- a/.claude/skills/deploy-connector/SKILL.md
+++ b/.claude/skills/deploy-connector/SKILL.md
@@ -79,6 +79,8 @@ If `{{connection_name}}` provided, use it. Otherwise ask if the user has one.
   ```
   List each required/optional **credential** parameter from the spec (e.g. `token`, `api_key`) with a short description. Do **not** ask for `externalOptionsAllowList` — the CLI reads the connector spec and adds it automatically. Ask the user to run the command and provide the connection name.
 
+  The command is the same whether the connector uses static credentials or OAuth — the CLI reads the auth mode from the spec's `connection.oauth` block. For OAuth connectors, note two differences for the user: (1) when setting up the OAuth app in the source, they must register the redirect URI the connection flow uses; and (2) a `u2m` flow opens a browser at connection creation for the user to log in and authorize.
+
 ### 2b. Default destination catalog and schema
 
 Ask for **catalog** (e.g. `main`) and **schema** (e.g. `raw_example`). Both optional — omitted values use pipeline defaults.

--- a/.claude/skills/generate-connector-spec/SKILL.md
+++ b/.claude/skills/generate-connector-spec/SKILL.md
@@ -70,6 +70,45 @@ connection:
 - If the connector accepts multiple authentication approaches, use Option B with `auth_methods`.
 - If there's only one way to authenticate, use Option A with flat `parameters`.
 
+### OAuth 2.0 Connections (the `oauth` block)
+
+If the source authenticates via OAuth 2.0, add a `connection.oauth` block. This makes the connector use a Unity Catalog **COMMUNITY** connection in an OAuth auth mode instead of static credentials. The connection layer (UC, or the labs authenticate tool for local dev) runs the OAuth flow and **injects a bearer token into the connector's options at query time** — the user only supplies their OAuth app's `client_id` + `client_secret`, never a token.
+
+```yaml
+connection:
+  parameters:
+    - name: client_id
+      type: string
+      required: true
+      secret: true
+      description: OAuth 2.0 client ID for the provider app.
+    - name: client_secret
+      type: string
+      required: true
+      secret: true
+      description: OAuth 2.0 client secret issued alongside the client_id.
+
+  oauth:
+    flow: u2m                  # m2m | u2m | u2m_per_user — maps to the connection auth mode
+    pkce: true                 # set false for a confidential client that doesn't need PKCE
+    scopes: "read"             # space-separated scopes requested at consent
+    authorization_url: "https://provider/oauth/authorize"   # u2m / u2m_per_user
+    token_url: "https://provider/oauth/token"
+    extra_auth_params:         # provider knobs folded into the authorize request (optional)
+      access_type: offline
+      prompt: consent
+```
+
+Guidance:
+- **`flow`** selects the auth mode and maps to the CLI's `--auth-type` / UC's `community_oauth_flow`. When present, the CLI derives the auth type from it (so `--auth-type` is optional):
+  - `m2m` — client-credentials (no human); requires `token_url`.
+  - `u2m` — one human authorizes once at connection creation via a browser flow.
+  - `u2m_per_user` — each end user authorizes separately; UC resolves the right token per query.
+- **Do NOT list the OAuth-issued tokens** (`access_token` / `refresh_token`) as required connection parameters — UC/the flow supplies them at runtime. List only the user-supplied app identity (`client_id`, `client_secret`) and any connector-specific options (e.g. `user_id`).
+- The `authorization_url` / `token_url` / `scopes` are defaults baked into the spec so the user does not retype them; they can be overridden via `--options` at connection creation.
+- The connector implementation should read the injected token (typically `options["access_token"]`) and treat it as opaque.
+- Use this block in addition to Option A's flat `parameters` (it is not a substitute for the `parameters` list). Determine the OAuth details (endpoints, scopes, flow type, PKCE) from the source API doc and the connector's `__init__`.
+
 ### Parameter Documentation
 For each parameter, document:
 - `name`: The parameter name as used in the options dict

--- a/.claude/skills/generate-connector-spec/SKILL.md
+++ b/.claude/skills/generate-connector-spec/SKILL.md
@@ -72,7 +72,7 @@ connection:
 
 ### OAuth 2.0 Connections (the `oauth` block)
 
-If the source authenticates via OAuth 2.0, add a `connection.oauth` block. This makes the connector use a Unity Catalog **COMMUNITY** connection in an OAuth auth mode instead of static credentials. The connection layer (UC, or the labs authenticate tool for local dev) runs the OAuth flow and **injects a bearer token into the connector's options at query time** — the user only supplies their OAuth app's `client_id` + `client_secret`, never a token.
+If the source authenticates via OAuth 2.0, add a `connection.oauth` block. This makes the connector use a Unity Catalog **COMMUNITY** connection in an OAuth auth mode instead of static credentials. The connection layer (UC, or the labs authenticate tool for local dev) runs the OAuth flow and **injects an access token into the connector's options at query time** — the user only supplies their OAuth app's `client_id` + `client_secret`, never a token.
 
 **This is where the OAuth flow is chosen.** Selecting the right auth mode (`m2m` vs `u2m` vs `u2m_per_user`) is a research/build-time decision you make here from the source's supported grant types and the connector's intended access pattern. Once it is recorded in `oauth.flow`, the rest of the lifecycle (connection creation, deployment, end-user docs) just follows the spec — no one re-picks the mode downstream.
 

--- a/.claude/skills/generate-connector-spec/SKILL.md
+++ b/.claude/skills/generate-connector-spec/SKILL.md
@@ -74,6 +74,8 @@ connection:
 
 If the source authenticates via OAuth 2.0, add a `connection.oauth` block. This makes the connector use a Unity Catalog **COMMUNITY** connection in an OAuth auth mode instead of static credentials. The connection layer (UC, or the labs authenticate tool for local dev) runs the OAuth flow and **injects a bearer token into the connector's options at query time** — the user only supplies their OAuth app's `client_id` + `client_secret`, never a token.
 
+**This is where the OAuth flow is chosen.** Selecting the right auth mode (`m2m` vs `u2m` vs `u2m_per_user`) is a research/build-time decision you make here from the source's supported grant types and the connector's intended access pattern. Once it is recorded in `oauth.flow`, the rest of the lifecycle (connection creation, deployment, end-user docs) just follows the spec — no one re-picks the mode downstream.
+
 ```yaml
 connection:
   parameters:
@@ -99,15 +101,23 @@ connection:
       prompt: consent
 ```
 
-Guidance:
-- **`flow`** selects the auth mode and maps to the CLI's `--auth-type` / UC's `community_oauth_flow`. When present, the CLI derives the auth type from it (so `--auth-type` is optional):
-  - `m2m` — client-credentials (no human); requires `token_url`.
-  - `u2m` — one human authorizes once at connection creation via a browser flow.
-  - `u2m_per_user` — each end user authorizes separately; UC resolves the right token per query.
+#### Choosing the `flow`
+
+`flow` selects the auth mode and maps to the CLI's `--auth-type` / UC's `community_oauth_flow`. Pick from the grant types the source's API supports:
+
+- **`m2m`** — the standard OAuth 2.0 **client-credentials** grant. No human and no browser: the connection posts `client_id` + `client_secret` (and `scopes`) to the `token_url` and gets back an app-level access token. Choose this when the source authenticates the *application* rather than an end user — service-to-service APIs, admin/tenant-wide tokens, anything with a "client credentials" or "server-to-server" grant. Only `token_url` (and optionally `scopes`) is needed; `authorization_url` / `pkce` / `extra_auth_params` do not apply.
+- **`u2m`** — authorization-code flow where **one human authorizes once** at connection creation via a browser. Choose this when the source's data is scoped to a *user account* and a single shared identity (personal or team mailbox, one workspace login) is acceptable. Needs `authorization_url` + `token_url`.
+- **`u2m_per_user`** — like `u2m` but **each end user authorizes separately**; UC resolves the right token per query at runtime. Choose this when different Databricks users querying the connection must each see their own data. Needs `authorization_url` + `token_url`.
+
+Rule of thumb: no user identity involved → `m2m`; one user for the whole connection → `u2m`; each querying user is distinct → `u2m_per_user`. Determine the OAuth details (grant types, endpoints, scopes, whether PKCE is required) from the **source API doc**.
+
+#### Other rules
+
 - **Do NOT list the OAuth-issued tokens** (`access_token` / `refresh_token`) as required connection parameters — UC/the flow supplies them at runtime. List only the user-supplied app identity (`client_id`, `client_secret`) and any connector-specific options (e.g. `user_id`).
+- `pkce` (default `true`) and `extra_auth_params` only affect the browser flows (`u2m` / `u2m_per_user`); set `pkce: false` for a confidential client that doesn't need it.
 - The `authorization_url` / `token_url` / `scopes` are defaults baked into the spec so the user does not retype them; they can be overridden via `--options` at connection creation.
 - The connector implementation should read the injected token (typically `options["access_token"]`) and treat it as opaque.
-- Use this block in addition to Option A's flat `parameters` (it is not a substitute for the `parameters` list). Determine the OAuth details (endpoints, scopes, flow type, PKCE) from the source API doc and the connector's `__init__`.
+- Use this block in addition to Option A's flat `parameters` (it is not a substitute for the `parameters` list).
 
 ### Parameter Documentation
 For each parameter, document:

--- a/.claude/skills/self-review-connector/SKILL.md
+++ b/.claude/skills/self-review-connector/SKILL.md
@@ -193,7 +193,7 @@ that weren't hit (`coverage.endpoints_in_spec − coverage.endpoints_hit`).
 |---|---|---|---|---|
 | C1 | BLOCKER | Implementation | `src/.../sources/{{source_name}}/{{source_name}}.py` | exists; `python -m py_compile` clean |
 | C2 | BLOCKER | API doc | `src/.../sources/{{source_name}}/{{source_name}}_api_doc.md` | exists; non-empty; mentions every table from `list_tables()` |
-| C3 | BLOCKER | Connector spec | `src/.../sources/{{source_name}}/connector_spec.yaml` | YAML parses; has `connection_parameters`; has `external_options_allowlist` if connector reads `table_options` keys |
+| C3 | BLOCKER | Connector spec | `src/.../sources/{{source_name}}/connector_spec.yaml` | YAML parses; has `connection_parameters`; has `external_options_allowlist` if connector reads `table_options` keys. If a `connection.oauth` block is present: `flow` is one of `m2m`/`u2m`/`u2m_per_user`, parameters list the user-supplied app identity (`client_id`/`client_secret`), and OAuth-issued tokens (`access_token`/`refresh_token`) are NOT listed as connection parameters (UC injects them at runtime) |
 | C4 | BLOCKER | Public README | `src/.../sources/{{source_name}}/README.md` | exists; non-empty; mentions every table and every connection parameter |
 | C5 | BLOCKER | Package metadata | `src/.../sources/{{source_name}}/pyproject.toml` | TOML parses; `dependencies` includes `requests` (and any other live deps the connector imports) |
 | C6 | MINOR | Generated merged source | `src/.../sources/{{source_name}}/_generated_{{source_name}}_python_source.py` | exists; mtime ≥ `{{source_name}}.py` mtime (re-run `python tools/scripts/merge_python_source.py {{source_name}}` if stale) |
@@ -236,7 +236,7 @@ Three artifacts describe the connector at different levels: the
 | # | Severity | What | How |
 |---|---|---|---|
 | E1 | MAJOR | `list_tables()` ≡ tables in API doc ≡ tables in README | parse all three; set diffs |
-| E2 | MAJOR | Connection-parameter keys: `__init__` `options.get("...")` ≡ `connector_spec.yaml` `connection_parameters` ≡ README mentions | parse all three; set diffs |
+| E2 | MAJOR | Connection-parameter keys: `__init__` `options.get("...")` ≡ `connector_spec.yaml` `connection_parameters` ≡ README mentions | parse all three; set diffs. **OAuth exemption:** for connectors with a `connection.oauth` block, the UC-injected runtime tokens (`access_token`, `refresh_token`) that `__init__` reads are expected to be absent from the spec parameters and README — do not flag them. The user-supplied params (`client_id`, `client_secret`, …) must still agree across all three. |
 | E3 | MINOR | Per-table schemas: column names from `connector.get_table_schema(t, {})` (run via simulator) are a subset of fields in API doc | run `get_table_schema` against simulator; compare |
 | E4 | MAJOR | Per-table primary keys: `read_table_metadata(t, {})['primary_keys']` matches API doc's natural identifier | parse both |
 | E5 | MAJOR | `external_options_allowlist` includes every `table_options.get("...")` key the connector reads | grep source vs YAML |

--- a/.claude/skills/validate-connector-auth/SKILL.md
+++ b/.claude/skills/validate-connector-auth/SKILL.md
@@ -148,6 +148,6 @@ Debug if authentication fails and report the issue clearly.
 
 ## Edge Cases
 
-- **OAuth 2.0**: When the spec declares a `connection.oauth` block, the auth test obtains a bearer token per the spec's `flow` and then calls the API with it. For `m2m` (client-credentials), POST `client_id` + `client_secret` (+ `scopes`) to `token_url` to get an access token — no user, no refresh token. For `u2m` / `u2m_per_user`, the collected credentials typically include `client_id`, `client_secret`, and a `refresh_token`; exchange the refresh token for an access token first.
+- **OAuth 2.0**: When the spec declares a `connection.oauth` block, the auth test obtains an access token per the spec's `flow` and calls the API with it as a Bearer credential (`Authorization: Bearer <access_token>`). For `m2m` (client-credentials), POST `client_id` + `client_secret` (+ `scopes`) to `token_url` to get the access token — no user, no refresh token. For `u2m` / `u2m_per_user`, the collected credentials typically include `client_id`, `client_secret`, and a `refresh_token`; exchange the refresh token for an access token first.
 - **Subdomain-based URLs**: Build the base URL from the `subdomain` field in config.
 - **Multiple auth methods**: Use whichever method's credentials are present in the supplied config.

--- a/.claude/skills/validate-connector-auth/SKILL.md
+++ b/.claude/skills/validate-connector-auth/SKILL.md
@@ -148,6 +148,6 @@ Debug if authentication fails and report the issue clearly.
 
 ## Edge Cases
 
-- **OAuth 2.0**: When the spec declares a `connection.oauth` block, the credentials collected by the authenticate flow typically contain `client_id`, `client_secret`, and a `refresh_token` (or an `access_token`). The auth test may need to exchange the refresh token for an access token first, then call the API with the bearer token.
+- **OAuth 2.0**: When the spec declares a `connection.oauth` block, the auth test obtains a bearer token per the spec's `flow` and then calls the API with it. For `m2m` (client-credentials), POST `client_id` + `client_secret` (+ `scopes`) to `token_url` to get an access token — no user, no refresh token. For `u2m` / `u2m_per_user`, the collected credentials typically include `client_id`, `client_secret`, and a `refresh_token`; exchange the refresh token for an access token first.
 - **Subdomain-based URLs**: Build the base URL from the `subdomain` field in config.
 - **Multiple auth methods**: Use whichever method's credentials are present in the supplied config.

--- a/.claude/skills/validate-connector-auth/SKILL.md
+++ b/.claude/skills/validate-connector-auth/SKILL.md
@@ -148,6 +148,6 @@ Debug if authentication fails and report the issue clearly.
 
 ## Edge Cases
 
-- **OAuth 2.0**: The supplied config may contain `refresh_token`, `client_id`, `client_secret`. The auth test may need to exchange the refresh token for an access token first.
+- **OAuth 2.0**: When the spec declares a `connection.oauth` block, the credentials collected by the authenticate flow typically contain `client_id`, `client_secret`, and a `refresh_token` (or an `access_token`). The auth test may need to exchange the refresh token for an access token first, then call the API with the bearer token.
 - **Subdomain-based URLs**: Build the base URL from the `subdomain` field in config.
 - **Multiple auth methods**: Use whichever method's credentials are present in the supplied config.

--- a/src/databricks/labs/community_connector/sources/gmail/README.md
+++ b/src/databricks/labs/community_connector/sources/gmail/README.md
@@ -83,30 +83,19 @@ The connection can also be created using the standard Unity Catalog API.
 
 #### Option B — `community-connector` CLI
 
-Run the `community-connector` CLI. The `--auth-type u2m` flag triggers an in-process loopback authorization-code + PKCE flow against Google; your browser opens, you sign in and grant consent, and the CLI captures the authorization code and registers it with the Databricks connection. You only supply the OAuth app identity (`client_id` + `client_secret`):
+Run the `community-connector` CLI. The connector spec declares `flow: u2m`, so the CLI runs an in-process loopback authorization-code flow against Google automatically (no `--auth-type` needed); your browser opens, you sign in and grant consent, and the CLI captures the authorization code and registers it with the Databricks connection. You only supply the OAuth app identity (`client_id` + `client_secret`):
 
 ```bash
-community-connector create-connection \
-  --name gmail_connector \
-  --source-name gmail \
-  --auth-type u2m \
-  --options '{
-    "client_id": "<YOUR_CLIENT_ID>",
-    "client_secret": "<YOUR_CLIENT_SECRET>"
-  }'
+community-connector create_connection gmail gmail_connector \
+  -o '{"client_id": "<YOUR_CLIENT_ID>", "client_secret": "<YOUR_CLIENT_SECRET>"}'
 ```
 
-For per-user authorization (one Databricks connection serving many end users, each consenting independently):
+For per-user authorization (one Databricks connection serving many end users, each consenting independently), override the spec's flow with `--auth-type u2m_per_user`:
 
 ```bash
-community-connector create-connection \
-  --name gmail_connector_per_user \
-  --source-name gmail \
+community-connector create_connection gmail gmail_connector_per_user \
   --auth-type u2m_per_user \
-  --options '{
-    "client_id": "<YOUR_CLIENT_ID>",
-    "client_secret": "<YOUR_CLIENT_SECRET>"
-  }'
+  -o '{"client_id": "<YOUR_CLIENT_ID>", "client_secret": "<YOUR_CLIENT_SECRET>"}'
 ```
 
 What ends up in the connection vs the connector:

--- a/src/databricks/labs/community_connector/sources/gmail/README.md
+++ b/src/databricks/labs/community_connector/sources/gmail/README.md
@@ -13,16 +13,18 @@ This documentation describes how to configure and use the **Gmail** Lakeflow com
 
 ## Authentication model
 
-This connector is built for the Unity Catalog **COMMUNITY** connection type with one of the U2M OAuth flows:
+This connector authenticates with Google via OAuth 2.0 on a Unity Catalog **COMMUNITY** connection. You register a Google OAuth app and supply its `client_id` + `client_secret`; Databricks runs the sign-in and consent, then obtains and refreshes the token for you. You never paste a token into the connector.
 
-| Flow | When to pick it |
-|---|---|
-| `u2m` | One human authorizes once at connection creation; every pipeline using the connection sees that human's mail. Good for personal or team-shared mailboxes. |
-| `u2m_per_user` | Each end user who queries the connection authorizes separately. Databricks resolves the right token per query at runtime. Good for apps where each user sees their own mail. |
+You choose between two modes when creating the connection, depending on **whose mailbox** the connection reads:
 
-Databricks owns the OAuth dance — authorization-code + PKCE exchange, refresh, per-user token mapping. The connector receives only a runtime `access_token` and treats it as opaque. There is no longer a need to capture a refresh token via Postman or curl.
+| Mode | Whose mail it reads | Good for |
+|---|---|---|
+| Shared mailbox (default) | One person authorizes once; every pipeline on the connection reads that mailbox. | Personal or team-shared mailboxes. |
+| Per-user | Each Databricks user who queries authorizes their own Google account; each sees only their own mail. | Apps serving many users. |
 
-If a token expires or is revoked mid-query, Gmail returns 401; re-run the connection setup to re-consent.
+The default (shared mailbox) needs no extra flag. To use per-user, pass `--auth-type u2m_per_user` when creating the connection (see Step 4).
+
+If a token expires or is revoked mid-query, Gmail returns 401; re-run the connection setup to re-authorize.
 
 ## Setup
 
@@ -63,13 +65,10 @@ If a token expires or is revoked mid-query, Gmail returns 401; re-run the connec
 ### Step 4 — Create the Unity Catalog COMMUNITY connection
 
 The connection can be created either through the Databricks UI or the
-`community-connector` CLI. Both run the same u2m authorization-code flow
-against Google — your browser opens, you sign in and grant consent, and
-Databricks stores the resulting grant. The connector spec ships with the
-OAuth flow definition baked in — `flow`, `scopes`, and Google's
-`authorization_url` / `token_url` (see the `connection.oauth` block in
-`connector_spec.yaml`) — so you only ever supply the OAuth app identity
-(`client_id` + `client_secret`).
+`community-connector` CLI. Either way your browser opens, you sign in to
+Google and grant consent, and Databricks stores the result. You only
+supply the OAuth app identity (`client_id` + `client_secret`) — the scope
+and Google's endpoints come from the connector spec.
 
 #### Option A — Databricks UI
 
@@ -83,14 +82,14 @@ The connection can also be created using the standard Unity Catalog API.
 
 #### Option B — `community-connector` CLI
 
-Run the `community-connector` CLI. The connector spec declares `flow: u2m`, so the CLI runs an in-process loopback authorization-code flow against Google automatically (no `--auth-type` needed); your browser opens, you sign in and grant consent, and the CLI captures the authorization code and registers it with the Databricks connection. You only supply the OAuth app identity (`client_id` + `client_secret`):
+Run the `community-connector` CLI. Your browser opens, you sign in to Google and grant consent, and the CLI registers the result with the Databricks connection. You only supply the OAuth app identity (`client_id` + `client_secret`):
 
 ```bash
 community-connector create_connection gmail gmail_connector \
   -o '{"client_id": "<YOUR_CLIENT_ID>", "client_secret": "<YOUR_CLIENT_SECRET>"}'
 ```
 
-For per-user authorization (one Databricks connection serving many end users, each consenting independently), override the spec's flow with `--auth-type u2m_per_user`:
+This creates a **shared-mailbox** connection (the default). For a **per-user** connection where each Databricks user reads their own mail, add `--auth-type u2m_per_user`:
 
 ```bash
 community-connector create_connection gmail gmail_connector_per_user \
@@ -98,18 +97,7 @@ community-connector create_connection gmail gmail_connector_per_user \
   -o '{"client_id": "<YOUR_CLIENT_ID>", "client_secret": "<YOUR_CLIENT_SECRET>"}'
 ```
 
-What ends up in the connection vs the connector:
-
-| Layer | Keys | Source |
-|---|---|---|
-| Connection (UC) | `client_id`, `client_secret` | you |
-| Connection (UC) | `flow`, `scopes`, `authorization_url`, `token_url` | spec `connection.oauth` block |
-| Connection (UC) | `community_oauth_flow` | derived from the spec's `oauth.flow` (`u2m` / `u2m_per_user`) |
-| Connection (UC) | `authorization_code`, `pkce_verifier`, `oauth_redirect_uri` | CLI's loopback flow |
-| Connector (runtime) | `access_token` | UC mints + refreshes from the stored grant |
-| Connector (runtime) | `user_id` (optional) | you, via pipeline spec; defaults to `me` |
-
-You never set `access_token` manually — UC handles it.
+You only ever provide `client_id` and `client_secret`. The scope and Google's endpoints come from the connector spec, and the access token that authenticates each API call is minted and refreshed by Databricks — you never set it manually. The only other value you may set is the optional `user_id` (via the pipeline spec; defaults to `me`).
 
 ## Supported Objects
 
@@ -462,7 +450,7 @@ Run the pipeline using your standard Lakeflow / Databricks orchestration:
 **API and Authentication Issues:**
 
 - **Authentication failures (`401 Unauthorized`)**:
-  - The injected `access_token` has expired or been revoked — re-run the connection setup to re-consent through the u2m flow
+  - The injected `access_token` has expired or been revoked — re-run the connection setup to sign in and re-authorize
   - Verify the connection's `client_id` and `client_secret` match the OAuth client registered in Google Cloud Console
   - Check that the OAuth consent screen includes the `gmail.readonly` scope
 

--- a/templates/community_connector_doc_template.md
+++ b/templates/community_connector_doc_template.md
@@ -13,12 +13,14 @@ This documentation provides setup instructions and reference information for the
 
 To configure the connector, provide the following parameters in your connector options:
 <List the parameters with name, type, whether required, description, and example in a table>
+<If the connector uses OAuth (the connector_spec.yaml declares a `connection.oauth` block), the parameters are the OAuth app identity — typically `client_id` and `client_secret` — NOT a token. State that the connection runs the OAuth login/consent flow and supplies the access token automatically; the user never pastes a token. Briefly note which OAuth flow is used (e.g. a one-time browser authorization for `u2m`).>
 <If this connector supports any extra table-specific options (such as options that must be set per table when reading data), list every allowed option name here as a comma-separated string. 
 Document these in the `externalOptionsAllowList` connection option. 
 If there are such table-specific options, clearly state that `externalOptionsAllowList` is a required connection option, and provide the full, definitive list of all supported options — do not mark this option as optional or provide a sample value.
 If no extra table-specific options are supported, make it clear that `externalOptionsAllowList` does not need to be included as a connection parameter.>
 
 ### <Add a section describing how to obtain the required parameters>
+<For OAuth connectors, describe how to register an OAuth app in the source system: where to create it, which redirect URI to register (the connection flow uses a localhost loopback redirect), the scopes to grant, and where to copy the client_id / client_secret.>
 
 ### Create a Unity Catalog Connection 
 A Unity Catalog connection for this connector can be created in two ways via the UI:
@@ -27,6 +29,8 @@ A Unity Catalog connection for this connector can be created in two ways via the
 3. <Identify any extra table-specific options that can be configured (especially any that are required). List these option names as a comma-separated string in the `externalOptionsAllowList`. Do this for the specific source.>
 
 The connection can also be created using the standard Unity Catalog API.
+
+<For OAuth connectors, note that creating the connection opens a browser for the user to log in and authorize (for a `u2m`-style flow); the user supplies only client_id / client_secret.>
 
 
 ## Supported Objects

--- a/templates/community_connector_doc_template.md
+++ b/templates/community_connector_doc_template.md
@@ -13,7 +13,7 @@ This documentation provides setup instructions and reference information for the
 
 To configure the connector, provide the following parameters in your connector options:
 <List the parameters with name, type, whether required, description, and example in a table>
-<If the connector uses OAuth (the connector_spec.yaml declares a `connection.oauth` block), the parameters are the OAuth app identity — typically `client_id` and `client_secret` — NOT a token. State that the connection runs the OAuth login/consent flow and supplies the access token automatically; the user never pastes a token. Briefly note which OAuth flow is used (e.g. a one-time browser authorization for `u2m`).>
+<If the connector uses OAuth (the connector_spec.yaml declares a `connection.oauth` block), the parameters are the OAuth app identity — typically `client_id` and `client_secret` — NOT a token. State that the connection obtains the access token automatically; the user never pastes a token. Describe the user experience in plain terms (e.g. "creating the connection opens a browser to sign in and authorize") — do NOT name the internal flow (`u2m` / `m2m` / `u2m_per_user`); users don't configure it. Only present a flow choice if the connector supports more than one and the user must pick.>
 <If this connector supports any extra table-specific options (such as options that must be set per table when reading data), list every allowed option name here as a comma-separated string. 
 Document these in the `externalOptionsAllowList` connection option. 
 If there are such table-specific options, clearly state that `externalOptionsAllowList` is a required connection option, and provide the full, definitive list of all supported options — do not mark this option as optional or provide a sample value.
@@ -30,7 +30,7 @@ A Unity Catalog connection for this connector can be created in two ways via the
 
 The connection can also be created using the standard Unity Catalog API.
 
-<For OAuth connectors, note that creating the connection opens a browser for the user to log in and authorize (for a `u2m`-style flow); the user supplies only client_id / client_secret.>
+<For OAuth connectors with an interactive login, note that creating the connection opens a browser for the user to sign in and authorize; the user supplies only client_id / client_secret.>
 
 
 ## Supported Objects

--- a/templates/connector_spec_template.yaml
+++ b/templates/connector_spec_template.yaml
@@ -85,7 +85,7 @@ connection:
   # Add this block to make the connector use a Unity Catalog COMMUNITY
   # connection in one of the OAuth auth modes instead of static credentials.
   # The connection layer (UC, or the labs authenticate tool for local dev)
-  # runs the OAuth flow and injects a bearer token into the connector's
+  # runs the OAuth flow and injects an access token into the connector's
   # options at query time — the user only supplies their OAuth app's
   # `client_id` + `client_secret`, never a token.
   #

--- a/templates/connector_spec_template.yaml
+++ b/templates/connector_spec_template.yaml
@@ -80,19 +80,48 @@ connection:
   #       Base URL for the API. Override if using a custom instance.
 
   # ---------------------------------------------------------------------------
-  # OAuth 2.0 Authorization Code Flow (optional)
-  # Uncomment this section if the source uses OAuth 2.0 for authentication.
-  # The authenticate tool will run the browser-based OAuth flow automatically
-  # so the user only needs to provide client_id and client_secret; the
-  # refresh_token is obtained via the redirect.  These three parameter names
-  # are the standard OAuth 2.0 names and are expected in the parameters list.
-  # The authorization_url, token_url, and scopes are defaults that the user
-  # can override at runtime.
+  # OAuth 2.0 (optional) — for sources that authenticate via OAuth 2.0.
+  #
+  # Add this block to make the connector use a Unity Catalog COMMUNITY
+  # connection in one of the OAuth auth modes instead of static credentials.
+  # The connection layer (UC, or the labs authenticate tool for local dev)
+  # runs the OAuth flow and injects a bearer token into the connector's
+  # options at query time — the user only supplies their OAuth app's
+  # `client_id` + `client_secret`, never a token.
+  #
+  # Because of that, the `parameters` list above should declare `client_id`
+  # and `client_secret` (the user-supplied app identity). Do NOT list the
+  # OAuth-issued tokens (`access_token` / `refresh_token`) as required
+  # parameters — UC/the flow supplies them at runtime.
+  #
+  # Keys:
+  #   flow               — which OAuth mode the connection uses. Maps to the
+  #                        CLI's `--auth-type` / UC's `community_oauth_flow`.
+  #                        When set, the CLI derives the auth type from here,
+  #                        so `--auth-type` is optional on the command line.
+  #                          m2m          — client-credentials (no user).
+  #                          u2m          — one human authorizes once at
+  #                                         connection creation (browser flow).
+  #                          u2m_per_user — each end user authorizes; UC
+  #                                         resolves the right token per query.
+  #   pkce               — true (default) to use PKCE in the u2m flow; set
+  #                        false for a confidential client that doesn't need it
+  #                        (e.g. a Google "Web application" client).
+  #   scopes             — space-separated OAuth scopes to request at consent.
+  #   authorization_url  — provider authorization endpoint (u2m / u2m_per_user).
+  #   token_url          — provider token endpoint.
+  #   extra_auth_params  — provider-specific knobs folded into the
+  #                        authorization request (e.g. access_type=offline,
+  #                        prompt=consent so the provider returns a
+  #                        refreshable grant). Never stored as a connection
+  #                        option.
   # ---------------------------------------------------------------------------
   # oauth:
+  #   flow: u2m
+  #   pkce: true
+  #   scopes: "read write"
   #   authorization_url: "https://example.com/oauth/authorize"
   #   token_url: "https://example.com/oauth/token"
-  #   scopes: "read write"
   #   extra_auth_params:
   #     access_type: "offline"
   #     prompt: "consent"

--- a/tools/community_connector/README.md
+++ b/tools/community_connector/README.md
@@ -122,7 +122,7 @@ community-connector show_pipeline my_github_pipeline
 
 ### `create_connection`
 
-Create a Unity Catalog connection for Lakeflow connectors.
+Create a Unity Catalog connection (type `COMMUNITY`) for Lakeflow connectors.
 
 The CLI validates connection options against the connector spec (`connector_spec.yaml`) and automatically configures the `externalOptionsAllowList` based on:
 1. Source-specific options from the connector spec
@@ -146,6 +146,8 @@ community-connector create_connection github my_github_conn \
 | Option | Short | Description |
 |--------|-------|-------------|
 | `--options` | `-o` | Connection options as JSON string (required) |
+| `--auth-type` | | Authentication mode: `static`, `m2m`, `u2m`, or `u2m_per_user`. Optional — when omitted it is taken from the connector spec's `oauth.flow` (or `static` if the spec has no `oauth` block). Pass it only to override the spec. |
+| `--redirect-port` | | Loopback port for the `u2m` OAuth redirect. Defaults to an OS-assigned free port. |
 | `--spec` | `-s` | Optional: local path to connector_spec.yaml, or a GitHub repo URL |
 
 **Validation:**
@@ -153,9 +155,34 @@ community-connector create_connection github my_github_conn \
 - Unknown parameters generate a warning
 - `externalOptionsAllowList` is automatically set if not provided
 
+#### Authentication modes
+
+The `COMMUNITY` connection supports static credentials plus three OAuth 2.0 modes. The mode is selected by `--auth-type`, or derived from the connector spec's `connection.oauth.flow` when `--auth-type` is omitted. OAuth modes set the connection's `community_oauth_flow` automatically.
+
+| Mode | What it is | Required options* |
+|------|------------|-------------------|
+| `static` | Arbitrary key/value credentials (token, API key, username/secret, …). No OAuth flow. | per connector spec |
+| `m2m` | Client-credentials OAuth (no human). | `client_id`, `client_secret`, `token_endpoint` |
+| `u2m` | One human authorizes once at connection creation. The CLI opens a browser, runs the authorization-code (+PKCE) flow against a `127.0.0.1` loopback redirect, and registers the captured grant. | `client_id`, `client_secret`, `authorization_endpoint`, `token_endpoint` |
+| `u2m_per_user` | Each end user authorizes separately; UC resolves the right token per query at runtime. The connection stores only app config. | `client_id`, `client_secret`, `authorization_endpoint`, `token_endpoint` |
+
+\* For OAuth modes the spec's `oauth` block supplies the endpoints and scope, so in practice the user passes only `client_id` + `client_secret`. The OAuth-issued token is injected into the connector at query time — it is never entered by hand. Spec keys `authorization_url` / `token_url` / `scopes` are accepted as aliases for the RFC 6749 names.
+
+```bash
+# OAuth connector whose spec declares oauth.flow — no --auth-type needed.
+# A u2m flow opens a browser for the user to sign in and grant consent.
+community-connector create_connection gmail my_gmail_conn \
+  -o '{"client_id":"<id>.apps.googleusercontent.com","client_secret":"<secret>"}'
+
+# Override the auth type explicitly (e.g. m2m), supplying the token endpoint:
+community-connector create_connection github my_github_conn \
+  --auth-type m2m \
+  -o '{"client_id":"...","client_secret":"...","token_endpoint":"https://idp/token"}'
+```
+
 ### `update_connection`
 
-Update an existing Unity Catalog connection.
+Update an existing Unity Catalog connection. The auth mode is fixed at creation time; for a `u2m` connection, re-running `update_connection` re-runs the browser authorization flow to refresh the OAuth grant.
 
 ```bash
 # Basic usage - same validation and auto-configuration as create
@@ -165,12 +192,18 @@ community-connector update_connection github my_github_conn \
 # With custom spec
 community-connector update_connection github my_github_conn \
   -o '{"token": "ghp_xxxx"}' --spec ./my_connector_spec.yaml
+
+# Refresh a u2m OAuth grant (re-opens the browser to re-consent)
+community-connector update_connection gmail my_gmail_conn \
+  -o '{"client_id":"...","client_secret":"..."}'
 ```
 
 **Options:**
 | Option | Short | Description |
 |--------|-------|-------------|
 | `--options` | `-o` | Connection options as JSON string (required) |
+| `--auth-type` | | Authentication mode. Optional — defaults to the spec's `oauth.flow` (or `static`). Must match the connection's existing mode. |
+| `--redirect-port` | | Loopback port for the `u2m` OAuth redirect. Defaults to an OS-assigned free port. |
 | `--spec` | `-s` | Optional: local path to connector_spec.yaml, or a GitHub repo URL |
 
 ### `upload`


### PR DESCRIPTION
## Summary

The `COMMUNITY` connection now supports static credentials plus three OAuth modes — `m2m`, `u2m`, `u2m_per_user` — with the auth type derivable from a connector spec's `connection.oauth.flow` (#191, #220, #222, #223). This PR updates the **developer skills, templates, and documentation** to reflect that. No connector code changes — the feature itself already landed on `master`.

## Changes

- **`templates/connector_spec_template.yaml`** — modernize the `oauth:` block: add `flow` (`m2m`/`u2m`/`u2m_per_user`) and `pkce`; drop the stale "refresh_token obtained via the redirect" wording; explain that the connection layer injects the bearer token at query time.
- **`generate-connector-spec` skill** — new "OAuth 2.0 Connections" section: the `oauth` block keys, how `flow` maps to `--auth-type` / `community_oauth_flow`, and the rule that UC-injected tokens (`access_token`/`refresh_token`) must NOT be listed as connection parameters.
- **`tools/community_connector/README.md`** — document `--auth-type` / `--redirect-port` on `create_connection` / `update_connection`; add an **Authentication modes** table with required options per mode and OAuth examples; note that re-running `update_connection` refreshes a `u2m` grant.
- **`self-review-connector` skill** — adjust checks C3 and E2 so the audit no longer false-positives on OAuth connectors (the UC-injected `access_token`/`refresh_token` that `__init__` reads are intentionally absent from the spec params).
- **`deploy-connector`, `collect-credentials`, `authenticate-source`, `validate-connector-auth`, `create-connector-document` skills + end-user doc template** — concise OAuth-aware notes (the command form is unchanged; the CLI derives the mode from the spec).
- **`gmail` README** — fix the CLI examples: `create_connection` takes positional `<source> <connection>` args (the `--name`/`--source-name` flags don't exist), and `--auth-type` is only needed to override the spec's declared flow.

## Test plan

- Docs-only change; all guidance verified against the current CLI implementation (`cli.py`, `oauth_flow.py`, `connector_spec.py`) and the merged Gmail spec on `master`.

This pull request and its description were written by Isaac.