### PR TITLE
Fix masked error reporting in HubSpot connector

### DIFF
--- a/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
+++ b/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
@@ -48,7 +48,6 @@ from pyspark.sql.types import (
     VariantVal,
 )
 import base64
-import random
 import requests
 
 

--- a/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
+++ b/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
@@ -28,7 +28,25 @@ from pyspark.sql.datasource import (
     SimpleDataSourceStreamReader,
 )
 from pyspark.sql.streaming.datasource import ReadAllAvailable, SupportsTriggerAvailableNow
-from pyspark.sql.types import *
+from pyspark.sql.types import (
+    ArrayType,
+    BinaryType,
+    BooleanType,
+    DataType,
+    DateType,
+    DecimalType,
+    DoubleType,
+    FloatType,
+    IntegerType,
+    LongType,
+    MapType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+    VariantType,
+    VariantVal,
+)
 import base64
 import random
 import requests
@@ -756,7 +774,10 @@ def register_lakeflow_source(spark):
             """
             supported_tables = self.list_tables()
             if table_name not in supported_tables:
-                raise ValueError(f"Unsupported table: {table_name}. Supported tables are: {supported_tables}")
+                raise ValueError(
+                    f"Unsupported table: {table_name}. "
+                    f"Supported tables are: {supported_tables}"
+                )
 
             # Check cache first
             if table_name in self._schema_cache:
@@ -805,7 +826,10 @@ def register_lakeflow_source(spark):
             """
             supported_tables = self.list_tables()
             if table_name not in supported_tables:
-                raise ValueError(f"Unsupported table: {table_name}. Supported tables are: {supported_tables}")
+                raise ValueError(
+                    f"Unsupported table: {table_name}. "
+                    f"Supported tables are: {supported_tables}"
+                )
 
             # Check cache first
             if table_name in self._metadata_cache:
@@ -962,14 +986,22 @@ def register_lakeflow_source(spark):
             """
             supported_tables = self.list_tables()
             if table_name not in supported_tables:
-                raise ValueError(f"Unsupported table: {table_name}. Supported tables are: {supported_tables}")
+                raise ValueError(
+                    f"Unsupported table: {table_name}. "
+                    f"Supported tables are: {supported_tables}"
+                )
 
             # Determine if this is an incremental read
             is_incremental = (
                 start_offset is not None and start_offset.get("updatedAt") is not None
             )
 
-            return self._read_data(table_name, start_offset, incremental=is_incremental, table_options=table_options)
+            return self._read_data(
+                table_name,
+                start_offset,
+                incremental=is_incremental,
+                table_options=table_options,
+            )
 
         def read_table_deletes(
             self, table_name: str, start_offset: dict, table_options: Dict[str, str]
@@ -994,7 +1026,10 @@ def register_lakeflow_source(spark):
             """
             supported_tables = self.list_tables()
             if table_name not in supported_tables:
-                raise ValueError(f"Unsupported table: {table_name}. Supported tables are: {supported_tables}")
+                raise ValueError(
+                    f"Unsupported table: {table_name}. "
+                    f"Supported tables are: {supported_tables}"
+                )
 
             # Short-circuit once the cursor has caught up to the init-time cap,
             # so Trigger.AvailableNow can terminate.

--- a/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
+++ b/src/databricks/labs/community_connector/sources/hubspot/_generated_hubspot_python_source.py
@@ -912,11 +912,19 @@ def register_lakeflow_source(spark):
             try:
                 resp = requests.get(url, headers=self.auth_header, timeout=60)
                 if resp.status_code != 200:
-                    raise Exception("API error: {resp.status_code} {resp.text}")
+                    raise RuntimeError(
+                        f"HubSpot Properties API error for {object_type}: "
+                        f"{resp.status_code} {resp.text}"
+                    )
 
                 return resp.json()
             except Exception as e:
-                return {"error": f"Failed to get object properties: {str(e)}"}
+                # Re-raise (don't return an error dict): callers iterate this as a
+                # list of property dicts, so a dict here turns a real API error into
+                # an unrelated TypeError far downstream.
+                raise RuntimeError(
+                    f"Failed to get object properties for {object_type}: {e}"
+                ) from e
 
         def _map_hubspot_type_to_spark(self, hubspot_type: str) -> DataType:
             """

--- a/src/databricks/labs/community_connector/sources/hubspot/hubspot.py
+++ b/src/databricks/labs/community_connector/sources/hubspot/hubspot.py
@@ -1,8 +1,7 @@
 import json
-import random
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterator, List, Tuple
+from typing import Dict, Iterator, List, Tuple
 
 import requests
 from pyspark.sql.types import (

--- a/src/databricks/labs/community_connector/sources/hubspot/hubspot.py
+++ b/src/databricks/labs/community_connector/sources/hubspot/hubspot.py
@@ -1,10 +1,20 @@
-import requests
 import json
-from pyspark.sql.types import *
-from datetime import datetime, timezone
-import time
 import random
-from typing import Dict, List, Tuple, Iterator, Any
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterator, List, Tuple
+
+import requests
+from pyspark.sql.types import (
+    ArrayType,
+    BooleanType,
+    DataType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+)
+
 from databricks.labs.community_connector.interface import LakeflowConnect
 
 
@@ -181,8 +191,11 @@ class HubspotLakeflowConnect(LakeflowConnect):
         """
         supported_tables = self.list_tables()
         if table_name not in supported_tables:
-            raise ValueError(f"Unsupported table: {table_name}. Supported tables are: {supported_tables}")
-        
+            raise ValueError(
+                f"Unsupported table: {table_name}. "
+                f"Supported tables are: {supported_tables}"
+            )
+
         # Check cache first
         if table_name in self._schema_cache:
             return self._schema_cache[table_name]
@@ -230,8 +243,11 @@ class HubspotLakeflowConnect(LakeflowConnect):
         """
         supported_tables = self.list_tables()
         if table_name not in supported_tables:
-            raise ValueError(f"Unsupported table: {table_name}. Supported tables are: {supported_tables}")
-        
+            raise ValueError(
+                f"Unsupported table: {table_name}. "
+                f"Supported tables are: {supported_tables}"
+            )
+
         # Check cache first
         if table_name in self._metadata_cache:
             return self._metadata_cache[table_name]
@@ -387,14 +403,22 @@ class HubspotLakeflowConnect(LakeflowConnect):
         """
         supported_tables = self.list_tables()
         if table_name not in supported_tables:
-            raise ValueError(f"Unsupported table: {table_name}. Supported tables are: {supported_tables}")
+            raise ValueError(
+                f"Unsupported table: {table_name}. "
+                f"Supported tables are: {supported_tables}"
+            )
 
         # Determine if this is an incremental read
         is_incremental = (
             start_offset is not None and start_offset.get("updatedAt") is not None
         )
 
-        return self._read_data(table_name, start_offset, incremental=is_incremental, table_options=table_options)
+        return self._read_data(
+            table_name,
+            start_offset,
+            incremental=is_incremental,
+            table_options=table_options,
+        )
 
     def read_table_deletes(
         self, table_name: str, start_offset: dict, table_options: Dict[str, str]
@@ -404,7 +428,7 @@ class HubspotLakeflowConnect(LakeflowConnect):
 
         HubSpot uses "archived" status to represent deleted records. This method
         fetches all archived records and filters them client-side for incremental reads.
-        
+
         Internally uses archivedAt for filtering, but copies it to updatedAt in the
         output records and offset for consistency with the normal read flow cursor.
 
@@ -419,7 +443,10 @@ class HubspotLakeflowConnect(LakeflowConnect):
         """
         supported_tables = self.list_tables()
         if table_name not in supported_tables:
-            raise ValueError(f"Unsupported table: {table_name}. Supported tables are: {supported_tables}")
+            raise ValueError(
+                f"Unsupported table: {table_name}. "
+                f"Supported tables are: {supported_tables}"
+            )
 
         # Short-circuit once the cursor has caught up to the init-time cap,
         # so Trigger.AvailableNow can terminate.
@@ -688,7 +715,7 @@ class HubspotLakeflowConnect(LakeflowConnect):
 
     def _sanitize_properties(self, properties: Dict) -> Dict:
         """Convert empty strings to None in properties dict.
-        
+
         HubSpot API returns empty strings "" instead of null for many fields,
         which causes issues when parsing to typed schemas (e.g., LongType).
         """

--- a/src/databricks/labs/community_connector/sources/hubspot/hubspot.py
+++ b/src/databricks/labs/community_connector/sources/hubspot/hubspot.py
@@ -337,11 +337,19 @@ class HubspotLakeflowConnect(LakeflowConnect):
         try:
             resp = requests.get(url, headers=self.auth_header, timeout=60)
             if resp.status_code != 200:
-                raise Exception("API error: {resp.status_code} {resp.text}")
+                raise RuntimeError(
+                    f"HubSpot Properties API error for {object_type}: "
+                    f"{resp.status_code} {resp.text}"
+                )
 
             return resp.json()
         except Exception as e:
-            return {"error": f"Failed to get object properties: {str(e)}"}
+            # Re-raise (don't return an error dict): callers iterate this as a
+            # list of property dicts, so a dict here turns a real API error into
+            # an unrelated TypeError far downstream.
+            raise RuntimeError(
+                f"Failed to get object properties for {object_type}: {e}"
+            ) from e
 
     def _map_hubspot_type_to_spark(self, hubspot_type: str) -> DataType:
         """


### PR DESCRIPTION
## What

Fixes masked error reporting in the HubSpot connector's `_get_object_properties`.

Two problems on the error path:

1. **Non-f-string raise** (`hubspot.py:340`): `raise Exception("API error: {resp.status_code} {resp.text}")` — missing the `f` prefix, so the real status code and body never appeared; the message was a literal template.
2. **Swallowed exception** (`hubspot.py:343-344`): the `except` returned `{"error": ...}` (a dict). But both callers (`:267-268`, `:290`) iterate the result as a list of property dicts (`[prop["name"] for prop in properties]`), so a genuine API error surfaced as an unrelated `TypeError: string indices must be integers` far downstream — the actual failure was lost.

## Fix

- Make the message an f-string that includes the real status and body.
- Re-raise with context (`raise RuntimeError(...) from e`) instead of returning a sentinel dict, so failures surface where they happen.
- Regenerated the merged `_generated_hubspot_python_source.py`.

## Testing

Simulate-mode suite: **9 passed, 4 skipped** (`pytest tests/unit/sources/hubspot/`). Only the error path changed; the success path (`return resp.json()`) is untouched.

## How it was found

Surfaced by an AI connector-diagnosis tool pointed at this connector (it had never seen it before) — flagged the masked-error pattern by reading the source.

---

