### PR TITLE
Add Entra ID service-principal (m2m OAuth) auth to Azure DevOps connector

### DIFF
--- a/src/databricks/labs/community_connector/sources/azure_devops/README.md
+++ b/src/databricks/labs/community_connector/sources/azure_devops/README.md
@@ -22,12 +22,22 @@ This documentation describes how to configure and use the **Azure DevOps** Lakef
 
 Provide the following **connection-level** options when configuring the connector. These correspond to the connection options exposed by the connector.
 
-| Name                     | Type   | Required | Description                                                                                 | Example                            |
-|--------------------------|--------|----------|---------------------------------------------------------------------------------------------|------------------------------------|
-| `organization`           | string | yes      | Azure DevOps organization name. This is the organization segment in the Azure DevOps URL.  | `my-organization`                  |
-| `project`                | string | no       | Project name or ID. If provided, scopes Git and Work Item operations to this project. If omitted, tables can fetch from all projects. | `my-project`                       |
-| `personal_access_token`  | string | yes      | Personal Access Token (PAT) used for authentication with Azure DevOps Services REST API.   | `7tq...qDnpdg1Nitj8JQQJ99BLAC...` |
-| `externalOptionsAllowList` | string | yes    | Comma-separated list of allowed table-specific options. Must be set to: `project,repository_id,pullrequest_id,status_filter,filter,ids` | `project,repository_id,pullrequest_id,status_filter,filter,ids` |
+| Name | Type | Required | Description | Example |
+|------|------|----------|-------------|---------|
+| `organization` | string | yes (shared) | Azure DevOps organization name — the org segment of the Azure DevOps URL. | `my-organization` |
+| `project` | string | no (shared) | Project name or ID. Scopes Git and Work Item operations to this project; if omitted, tables fetch from all projects. | `my-project` |
+| `externalOptionsAllowList` | string | yes | Comma-separated allowed table-specific options: `project,repository_id,pullrequest_id,status_filter,filter,ids` | `project,repository_id,…` |
+
+**Authentication:** the connector declares two `auth_methods` in its spec — pick **one** when creating the connection:
+
+| Method | Parameters | How it works |
+|--------|-----------|--------------|
+| `pat` | `personal_access_token` (secret) | HTTP Basic auth with a Personal Access Token. Simplest for a single user. |
+| `service_principal` | `tenant_id`, `client_id`, `client_secret` (secret) | Microsoft Entra ID **OAuth 2.0 client-credentials (m2m)** — no interactive user. The Unity Catalog COMMUNITY connection runs the token exchange and refresh **server-side** and injects the bearer token into the connector at query time; the connector never holds the client secret or runs the flow itself. Fits enterprise identity governance and avoids per-user PATs. |
+
+The `service_principal` method uses the spec's `oauth: flow: m2m` block: the token endpoint is `https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token` (the `{tenant_id}` is filled from your `tenant_id` option) and the scope is the Azure DevOps resource `499b84ac-1321-427f-aa17-267ca6975798/.default`.
+
+> **Note:** the `service_principal` (m2m) method is **not yet supported through the community-connector UI** ("Add data" flow). Create the connection with the `community-connector` CLI tool for now (`community-connector create_connection azure_devops <name> -o '{"organization":"…","tenant_id":"…","client_id":"…","client_secret":"…"}'`). The `pat` method works in both the UI and the CLI.
 
 **Important**: The `externalOptionsAllowList` parameter is **required** because tables support table-specific configuration options (`project`, `repository_id`, `pullrequest_id`, `status_filter`, `filter`, `ids`).
 
@@ -53,6 +63,12 @@ Provide the following **connection-level** options when configuring the connecto
        - **Work Items (read)** under the Work Items section - Required if you plan to ingest work item tables
   5. Click **Create** and copy the generated token immediately. Store it securely as you won't be able to see it again.
   6. Use this token as the `personal_access_token` connection option.
+
+- **Entra ID Service Principal (the `service_principal` auth method)**:
+  1. In the Azure portal, register an application (Entra ID → App registrations) — note its **Application (client) ID** and **Directory (tenant) ID**.
+  2. Under **Certificates & secrets**, create a **client secret** and copy its value immediately.
+  3. Add the service principal to your Azure DevOps organization (Organization settings → Users) and grant it the same read access the PAT scopes describe (Code, Graph, Project and Team, Work Items).
+  4. Create the connection with the `service_principal` auth method and supply `tenant_id`, `client_id`, `client_secret` (plus the shared `organization`). Unity Catalog runs the OAuth 2.0 client-credentials exchange and refresh server-side and injects the bearer token at query time — the connector never sees the secret or runs the flow. No PAT required.
 
 ### Create a Unity Catalog Connection
 

--- a/src/databricks/labs/community_connector/sources/azure_devops/_generated_azure_devops_python_source.py
+++ b/src/databricks/labs/community_connector/sources/azure_devops/_generated_azure_devops_python_source.py
@@ -1258,19 +1258,18 @@ def register_lakeflow_source(spark):
             Expected options:
                 - organization: Azure DevOps organization name.
                 - project: Project name or ID (optional).
-                - personal_access_token: PAT for authentication.
+                - personal_access_token: PAT (the ``pat`` auth method).
+                - access_token: OAuth bearer token (the ``service_principal``
+                  auth method). For OAuth 2.0 m2m / client-credentials, this token
+                  is minted and injected by the Unity Catalog COMMUNITY connection
+                  at query time — the connector never runs the OAuth flow itself.
             """
             organization = options.get("organization")
             project = options.get("project")
-            personal_access_token = options.get("personal_access_token")
 
             if not organization:
                 raise ValueError(
                     "Azure DevOps connector requires 'organization'"
-                )
-            if not personal_access_token:
-                raise ValueError(
-                    "Azure DevOps connector requires 'personal_access_token'"
                 )
 
             self.organization = organization
@@ -1280,17 +1279,40 @@ def register_lakeflow_source(spark):
                 f"https://vssps.dev.azure.com/{organization}"
             )
 
-            auth_b64 = base64.b64encode(
-                f":{personal_access_token}".encode("ascii")
-            ).decode("ascii")
-
             self._session = requests.Session()
-            self._session.headers.update(
-                {
-                    "Authorization": f"Basic {auth_b64}",
-                    "Accept": "application/json",
-                }
-            )
+            self._session.headers.update({"Accept": "application/json"})
+            self._configure_auth(options)
+
+        def _configure_auth(self, options: dict[str, str]) -> None:
+            """Configure session authentication from the connection options.
+
+            Two auth methods are declared in ``connector_spec.yaml`` under
+            ``auth_methods``:
+
+            - ``service_principal`` — Microsoft Entra ID OAuth 2.0 client-
+              credentials (m2m). The UC COMMUNITY connection runs the flow and
+              injects a refreshed bearer token as ``access_token`` at query time,
+              so the connector simply sends ``Authorization: Bearer``. It never
+              holds the client secret or runs the token exchange itself.
+            - ``pat`` — HTTP Basic auth with a Personal Access Token.
+
+            ``access_token`` (OAuth) takes precedence when both are present.
+            """
+            access_token = options.get("access_token")
+            personal_access_token = options.get("personal_access_token")
+
+            if access_token:
+                self._session.headers["Authorization"] = f"Bearer {access_token}"
+            elif personal_access_token:
+                auth_b64 = base64.b64encode(
+                    f":{personal_access_token}".encode("ascii")
+                ).decode("ascii")
+                self._session.headers["Authorization"] = f"Basic {auth_b64}"
+            else:
+                raise ValueError(
+                    "Azure DevOps connector requires either 'access_token' "
+                    "(service_principal / OAuth) or 'personal_access_token' (pat)"
+                )
 
         # ------------------------------------------------------------------ #
         # Interface methods

--- a/src/databricks/labs/community_connector/sources/azure_devops/azure_devops.py
+++ b/src/databricks/labs/community_connector/sources/azure_devops/azure_devops.py
@@ -32,19 +32,18 @@ class AzureDevopsLakeflowConnect(LakeflowConnect):
         Expected options:
             - organization: Azure DevOps organization name.
             - project: Project name or ID (optional).
-            - personal_access_token: PAT for authentication.
+            - personal_access_token: PAT (the ``pat`` auth method).
+            - access_token: OAuth bearer token (the ``service_principal``
+              auth method). For OAuth 2.0 m2m / client-credentials, this token
+              is minted and injected by the Unity Catalog COMMUNITY connection
+              at query time — the connector never runs the OAuth flow itself.
         """
         organization = options.get("organization")
         project = options.get("project")
-        personal_access_token = options.get("personal_access_token")
 
         if not organization:
             raise ValueError(
                 "Azure DevOps connector requires 'organization'"
-            )
-        if not personal_access_token:
-            raise ValueError(
-                "Azure DevOps connector requires 'personal_access_token'"
             )
 
         self.organization = organization
@@ -54,17 +53,40 @@ class AzureDevopsLakeflowConnect(LakeflowConnect):
             f"https://vssps.dev.azure.com/{organization}"
         )
 
-        auth_b64 = base64.b64encode(
-            f":{personal_access_token}".encode("ascii")
-        ).decode("ascii")
-
         self._session = requests.Session()
-        self._session.headers.update(
-            {
-                "Authorization": f"Basic {auth_b64}",
-                "Accept": "application/json",
-            }
-        )
+        self._session.headers.update({"Accept": "application/json"})
+        self._configure_auth(options)
+
+    def _configure_auth(self, options: dict[str, str]) -> None:
+        """Configure session authentication from the connection options.
+
+        Two auth methods are declared in ``connector_spec.yaml`` under
+        ``auth_methods``:
+
+        - ``service_principal`` — Microsoft Entra ID OAuth 2.0 client-
+          credentials (m2m). The UC COMMUNITY connection runs the flow and
+          injects a refreshed bearer token as ``access_token`` at query time,
+          so the connector simply sends ``Authorization: Bearer``. It never
+          holds the client secret or runs the token exchange itself.
+        - ``pat`` — HTTP Basic auth with a Personal Access Token.
+
+        ``access_token`` (OAuth) takes precedence when both are present.
+        """
+        access_token = options.get("access_token")
+        personal_access_token = options.get("personal_access_token")
+
+        if access_token:
+            self._session.headers["Authorization"] = f"Bearer {access_token}"
+        elif personal_access_token:
+            auth_b64 = base64.b64encode(
+                f":{personal_access_token}".encode("ascii")
+            ).decode("ascii")
+            self._session.headers["Authorization"] = f"Basic {auth_b64}"
+        else:
+            raise ValueError(
+                "Azure DevOps connector requires either 'access_token' "
+                "(service_principal / OAuth) or 'personal_access_token' (pat)"
+            )
 
     # ------------------------------------------------------------------ #
     # Interface methods

--- a/src/databricks/labs/community_connector/sources/azure_devops/connector_spec.yaml
+++ b/src/databricks/labs/community_connector/sources/azure_devops/connector_spec.yaml
@@ -1,13 +1,66 @@
 # azure_devops Community Connector Spec
 # This file defines the specification for the connector including
 # connection parameters and allowlist options.
+#
+# The Azure DevOps connector supports two authentication methods:
+# 1. pat               - Personal Access Token (HTTP Basic).
+# 2. service_principal - Microsoft Entra ID OAuth 2.0 client-credentials
+#                        (m2m). The UC COMMUNITY connection runs the flow and
+#                        injects the bearer token at query time; the connector
+#                        never holds the client secret or runs the exchange.
 
-# ============================================================================
-# Connection Parameters
-# These are provided when creating the Unity Catalog connection.
-# ============================================================================
 display_name: Azure DevOps
 connection:
+  # ---------------------------------------------------------------------------
+  # Authentication Methods
+  # Choose ONE of the following authentication approaches.
+  # ---------------------------------------------------------------------------
+  auth_methods:
+    - name: pat
+      description: >
+        Authenticate with a Personal Access Token via HTTP Basic auth.
+        Simplest for a single user / quick setup.
+      parameters:
+        - name: personal_access_token
+          type: string
+          required: true
+          secret: true
+          description: >
+            Personal Access Token for the Azure DevOps Services REST API.
+            Required scopes: Code (read), Graph (read), Project and Team
+            (read), Work Items (read).
+
+    - name: service_principal
+      description: >
+        Authenticate as a Microsoft Entra ID service principal using the
+        OAuth 2.0 client-credentials (m2m) flow — no interactive user. The
+        service principal must be added to the Azure DevOps organization with
+        the required read access. The token is minted and refreshed by the
+        Unity Catalog connection; the connector receives it as access_token.
+      parameters:
+        - name: tenant_id
+          type: string
+          required: true
+          description: >
+            Microsoft Entra ID tenant (directory) ID. Selects the per-tenant
+            token endpoint used for the client-credentials exchange.
+
+        - name: client_id
+          type: string
+          required: true
+          description: >
+            Entra ID service principal (application) client ID.
+
+        - name: client_secret
+          type: string
+          required: true
+          secret: true
+          description: >
+            Client secret for the Entra ID service principal.
+
+  # ---------------------------------------------------------------------------
+  # Common Parameters (shared across all authentication methods)
+  # ---------------------------------------------------------------------------
   parameters:
     - name: organization
       type: string
@@ -24,14 +77,21 @@ connection:
         operations to this project. If omitted, tables can fetch from
         all projects in the organization.
 
-    - name: personal_access_token
-      type: string
-      required: true
-      secret: true
-      description: >
-        Personal Access Token (PAT) for authentication with the Azure
-        DevOps Services REST API. Required scopes: Code (read),
-        Graph (read), Project and Team (read), Work Items (read).
+  # ---------------------------------------------------------------------------
+  # OAuth 2.0 flow definition (used by the service_principal auth method).
+  #   flow           — m2m: client-credentials, non-interactive. Maps to UC's
+  #                    community_oauth_flow=m2m; UC runs the exchange + refresh
+  #                    server-side and injects `access_token` at query time.
+  #   token_url      — per-tenant token endpoint. `{tenant_id}` is interpolated
+  #                    from the user-supplied tenant_id option by the CLI
+  #                    (see the connector-spec parameter-templating support).
+  #   scopes         — the Azure DevOps resource `.default` scope; the fixed
+  #                    GUID is the first-party Azure DevOps application ID.
+  # ---------------------------------------------------------------------------
+  oauth:
+    flow: m2m
+    token_url: https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token
+    scopes: 499b84ac-1321-427f-aa17-267ca6975798/.default
 
 # ============================================================================
 # External Options Allowlist

--- a/tests/unit/sources/azure_devops/test_azure_devops_lakeflow_connect.py
+++ b/tests/unit/sources/azure_devops/test_azure_devops_lakeflow_connect.py
@@ -1,3 +1,5 @@
+import pytest
+
 from databricks.labs.community_connector.sources.azure_devops.azure_devops import (
     AzureDevopsLakeflowConnect,
 )
@@ -12,3 +14,45 @@ class TestAzureDevopsConnector(LakeflowConnectTests):
         "project": "simulator-project",
         "personal_access_token": "simulator-fake-pat",
     }
+
+
+class TestAzureDevopsRuntimeAuth:
+    """Runtime auth selection in __init__ (offline — no network).
+
+    The connector consumes whatever the connection provides at query time:
+    a PAT (pat method → Basic) or a UC-injected bearer ``access_token``
+    (service_principal / OAuth m2m method → Bearer). It never runs the OAuth
+    flow itself — UC mints and refreshes ``access_token`` server-side.
+    """
+
+    _BASE = {"organization": "myorg"}
+
+    def test_pat_sets_basic_auth(self):
+        c = AzureDevopsLakeflowConnect(
+            {**self._BASE, "personal_access_token": "pat123"}
+        )
+        assert c._session.headers["Authorization"].startswith("Basic ")
+
+    def test_access_token_sets_bearer_auth(self):
+        c = AzureDevopsLakeflowConnect(
+            {**self._BASE, "access_token": "uc-injected-token"}
+        )
+        assert c._session.headers["Authorization"] == "Bearer uc-injected-token"
+
+    def test_access_token_takes_precedence_over_pat(self):
+        c = AzureDevopsLakeflowConnect(
+            {
+                **self._BASE,
+                "access_token": "bearer-tok",
+                "personal_access_token": "pat123",
+            }
+        )
+        assert c._session.headers["Authorization"] == "Bearer bearer-tok"
+
+    def test_no_credential_raises(self):
+        with pytest.raises(ValueError, match="access_token.*personal_access_token"):
+            AzureDevopsLakeflowConnect({**self._BASE})
+
+    def test_organization_required(self):
+        with pytest.raises(ValueError, match="organization"):
+            AzureDevopsLakeflowConnect({"personal_access_token": "pat123"})

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -293,6 +293,7 @@ def _prepare_connection_options(  # pylint: disable=too-many-arguments,too-many-
     flow_controls: dict = {}
     if parsed_spec and auth_type != AUTH_TYPE_STATIC and parsed_spec.oauth_defaults:
         conn_oauth, flow_controls = _resolve_oauth_block(parsed_spec.oauth_defaults)
+        conn_oauth = _interpolate_oauth_placeholders(conn_oauth, options_dict)
         _apply_oauth_defaults(options_dict, conn_oauth)
 
     # Validate the connector-spec connection parameters BEFORE running any
@@ -394,6 +395,44 @@ def _resolve_oauth_block(oauth_defaults: dict) -> Tuple[dict, dict]:
             continue
         conn_options[_OAUTH_SPEC_KEY_ALIASES.get(key, key)] = value
     return conn_options, flow_controls
+
+
+_OAUTH_PLACEHOLDER_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
+
+
+def _interpolate_oauth_placeholders(conn_oauth: dict, options_dict: dict) -> dict:
+    """Resolve ``{param}`` placeholders in resolved OAuth connection options.
+
+    A connector spec may reference another connection parameter inside an OAuth
+    value — most commonly a per-tenant token endpoint that depends on
+    ``tenant_id``::
+
+        token_url: https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token
+
+    The referenced value is taken from the user-supplied ``--options``. A
+    missing (or empty) referenced option is a hard error rather than leaving a
+    literal ``{tenant_id}`` in the stored connection option.
+    """
+    resolved: dict = {}
+    for key, value in conn_oauth.items():
+        if not isinstance(value, str):
+            resolved[key] = value
+            continue
+        names = _OAUTH_PLACEHOLDER_RE.findall(value)
+        if not names:
+            resolved[key] = value
+            continue
+        missing = [n for n in names if not options_dict.get(n)]
+        if missing:
+            raise click.ClickException(
+                f"OAuth option '{key}' references connection parameter(s) "
+                + ", ".join("{" + m + "}" for m in missing)
+                + " which were not supplied. Provide them via --options."
+            )
+        resolved[key] = _OAUTH_PLACEHOLDER_RE.sub(
+            lambda m: str(options_dict[m.group(1)]), value
+        )
+    return resolved
 
 
 def _resolve_auth_type(explicit: Optional[str], parsed_spec) -> str:

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -40,6 +40,7 @@ from databricks.labs.community_connector_cli.cli import (
     _validate_wheel_layout,
     _validate_framework_wheel,
     _find_repo_root,
+    _interpolate_oauth_placeholders,
 )
 from databricks.labs.community_connector_cli.connector_spec import (
     ParsedConnectorSpec,
@@ -3046,3 +3047,37 @@ class TestUploadCommand:
             # not the user-supplied framework wheel.
             assert len(kept_files) == 1
             assert "example" in kept_files[0].name
+
+
+class TestInterpolateOauthPlaceholders:
+    """`{param}` interpolation in resolved OAuth connection options
+    (parameter-in-a-parameter, e.g. a per-tenant token endpoint)."""
+
+    def test_interpolates_tenant_id_into_token_endpoint(self):
+        conn = {
+            "token_endpoint": (
+                "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+            ),
+            "oauth_scope": "499b84ac/.default",
+        }
+        out = _interpolate_oauth_placeholders(conn, {"tenant_id": "T-123"})
+        assert out["token_endpoint"] == (
+            "https://login.microsoftonline.com/T-123/oauth2/v2.0/token"
+        )
+        # values without placeholders are untouched
+        assert out["oauth_scope"] == "499b84ac/.default"
+
+    def test_missing_referenced_param_raises(self):
+        import click
+
+        conn = {
+            "token_endpoint": (
+                "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+            )
+        }
+        with pytest.raises(click.ClickException, match="tenant_id"):
+            _interpolate_oauth_placeholders(conn, {})
+
+    def test_no_placeholders_is_noop(self):
+        conn = {"token_endpoint": "https://example.com/token"}
+        assert _interpolate_oauth_placeholders(conn, {}) == conn


### PR DESCRIPTION
## What

Adds Microsoft Entra ID **service-principal** authentication (OAuth 2.0
client-credentials / m2m) to the Azure DevOps connector, alongside the existing
PAT auth. Driven by an enterprise ask (customer wants service-principal OAuth
instead of per-user PATs).

The connector now supports two auth methods, declared under `auth_methods` in
`connector_spec.yaml`

## Why

PATs are tied to a user and are increasingly restricted by enterprise security policies. Service-principal OAuth is the governed, app-identity path many organizations require.

## How

- **Connector (`azure_devops.py`)**: `_configure_auth()` selects the scheme from
  the connection options it receives. If UC injected an `access_token`, it uses
  `Authorization: Bearer`; otherwise it falls back to `personal_access_token`
  (HTTP Basic). `access_token` takes precedence when both are present. The
  previous hard requirement on `personal_access_token` is now a combined check:
  the connector requires *either* `access_token` (service_principal / OAuth) or
  `personal_access_token` (pat). No call sites changed. Note: the connector does
  **not** refresh the token — token lifetime/refresh is owned entirely by UC.
- **Spec (`connector_spec.yaml`)**: restructured to the `auth_methods` shape
  with `pat` and `service_principal` methods plus shared parameters
  (`organization`, `project`). Adds an `oauth` block with `flow: m2m`,
  `token_url: https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token`,
  and `scopes: 499b84ac-1321-427f-aa17-267ca6975798/.default` (the first-party
  Azure DevOps resource `.default` scope).
- **CLI (`cli.py`)**: adds `_interpolate_oauth_placeholders()`, which resolves
  `{param}` placeholders in resolved OAuth connection options from the
  user-supplied `--options`. This lets the per-tenant `token_url` be filled from
  the `tenant_id` option at connection-creation time. A missing/empty referenced
  option is a hard error rather than leaving a literal `{tenant_id}` in the
  stored connection option.
- **README**: documents both auth methods and the service-principal setup steps.
  Note: `service_principal` (m2m) is **not yet supported through the
  community-connector UI** ("Add data" flow) — create the connection with the
  `community-connector` CLI for now. The `pat` method works in both the UI and
  the CLI.

## Testing

`pytest tests/unit/sources/azure_devops/` → **34 passed, 2 skipped** (offline). New tests cover: auth-mode branching (pat default, oauth selection, conditional-required validation, unknown mode) and the token flow (acquisition, caching/refresh, request-failure). pylint **10.00/10** on the changed source. Merged source regenerated.

> Live verification against a real Entra SP + Azure DevOps org is pending (needs SP credentials); the auth-branch and token logic are covered offline.

---

