### PR TITLE
Gmail: drop in-code refresh_token auth path, keep only access_token

### DIFF
--- a/src/databricks/labs/community_connector/source_simulator/specs/gmail/corpus/oauth_token.json
+++ b/src/databricks/labs/community_connector/source_simulator/specs/gmail/corpus/oauth_token.json
@@ -1,1 +1,0 @@
-{"access_token": "simulator-fake-access-token", "token_type": "Bearer", "expires_in": 3600, "scope": "https://www.googleapis.com/auth/gmail.readonly"}

--- a/src/databricks/labs/community_connector/source_simulator/specs/gmail/endpoints.yaml
+++ b/src/databricks/labs/community_connector/source_simulator/specs/gmail/endpoints.yaml
@@ -1,21 +1,11 @@
 # Gmail API v1 (uses ``requests`` directly, not the Google SDK).
 #
-# Two auth modes are exercised:
-# * Pre-issued access_token (UC COMMUNITY u2m flow) — the connector never
-#   hits Google's /token endpoint.
-# * In-code refresh (older connections) — the connector posts to the
-#   /token endpoint below to exchange a refresh_token for an access_token.
-# Hosts:
-# * https://oauth2.googleapis.com/token — OAuth refresh (refresh mode only)
+# Auth: the connector receives a pre-issued access_token (injected by the UC
+# COMMUNITY u2m / u2m_per_user flow) and never hits Google's /token endpoint.
+# Host:
 # * https://gmail.googleapis.com/gmail/v1/...
 
 endpoints:
-  # ---- OAuth refresh (refresh mode only; lazy on first API call) ----
-  - path: /token
-    method: POST
-    corpus: oauth_token
-    response: {single_entity: true, pagination_style: none}
-
   # ---- Batch endpoint — force fallback to sequential ----
   - path: /batch/gmail/v1
     method: POST

--- a/src/databricks/labs/community_connector/sources/gmail/README.md
+++ b/src/databricks/labs/community_connector/sources/gmail/README.md
@@ -6,7 +6,7 @@ This documentation describes how to configure and use the **Gmail** Lakeflow com
 
 - **Google Account**: A Google account with Gmail access (personal Gmail or Google Workspace).
 - **Google Cloud Project**: A project in Google Cloud Console with the Gmail API enabled.
-- **Google OAuth client** (Web application): a `client_id` + `client_secret` pair you'll register with Databricks at connection-creation time. Databricks runs the user-facing OAuth flow against this client; you never paste a refresh token into the connector yourself.
+- **Google OAuth client** (Web application): a `client_id` + `client_secret` pair you'll register with Databricks at connection-creation time. Databricks runs the user-facing OAuth flow against this client; you never paste a token into the connector yourself.
 - **OAuth scope** (must be granted at consent time): `https://www.googleapis.com/auth/gmail.readonly`
 - **Network access**: The cluster must be able to reach `https://gmail.googleapis.com`.
 - **Lakeflow / Databricks environment**: A workspace where you can register a Lakeflow community connector and run ingestion pipelines.

--- a/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
+++ b/src/databricks/labs/community_connector/sources/gmail/_generated_gmail_python_source.py
@@ -941,75 +941,29 @@ def register_lakeflow_source(spark):
 
 
     class GmailApiClient:
-        """Gmail HTTP client supporting two OAuth modes.
+        """Gmail HTTP client authenticated with a pre-issued access token.
 
-        Pass a pre-issued ``access_token`` (UC COMMUNITY u2m / u2m_per_user flow
-        injects it) for the opaque-token mode, or pass ``client_id`` +
-        ``client_secret`` + ``refresh_token`` for the in-code refresh mode used
-        by connections created before the u2m migration. The access-token mode
-        takes precedence when both are present.
+        The ``access_token`` is injected by the Unity Catalog COMMUNITY
+        connection's u2m / u2m_per_user OAuth flow and treated as opaque — the
+        client never refreshes it or contacts a token endpoint.
         """
 
         BASE_URL = "https://gmail.googleapis.com/gmail/v1"
         BATCH_URL = "https://gmail.googleapis.com/batch/gmail/v1"
-        TOKEN_URL = "https://oauth2.googleapis.com/token"
 
         def __init__(
             self,
-            access_token: Optional[str] = None,
+            access_token: str,
             user_id: str = "me",
-            *,
-            client_id: Optional[str] = None,
-            client_secret: Optional[str] = None,
-            refresh_token: Optional[str] = None,
         ) -> None:
             self.user_id = user_id
             self._session = requests.Session()
-
-            # Mode 1: opaque pre-issued bearer token (no refresh in code).
             self.access_token = access_token
-
-            # Mode 2: in-code refresh credentials + cached short-lived token.
-            self.client_id = client_id
-            self.client_secret = client_secret
-            self.refresh_token = refresh_token
-            self._refreshed_token: Optional[str] = None
-            self._token_expires_at = 0.0
-
-        def get_access_token(self) -> str:
-            """Return a valid bearer token for the active auth mode.
-
-            Opaque-token mode returns the injected token verbatim. Refresh mode
-            exchanges the refresh token at Google's token endpoint, caching the
-            result until ~60s before expiry.
-            """
-            if self.access_token:
-                return self.access_token
-
-            if self._refreshed_token and time.time() < self._token_expires_at - 60:
-                return self._refreshed_token
-
-            response = requests.post(
-                self.TOKEN_URL,
-                data={
-                    "client_id": self.client_id,
-                    "client_secret": self.client_secret,
-                    "refresh_token": self.refresh_token,
-                    "grant_type": "refresh_token",
-                },
-                timeout=30,
-            )
-            response.raise_for_status()
-            data = response.json()
-
-            self._refreshed_token = data["access_token"]
-            self._token_expires_at = time.time() + data.get("expires_in", 3600)
-            return self._refreshed_token
 
         def get_headers(self) -> Dict[str, str]:
             """Bearer-token headers for Gmail API calls."""
             return {
-                "Authorization": f"Bearer {self.get_access_token()}",
+                "Authorization": f"Bearer {self.access_token}",
                 "Accept": "application/json",
             }
 
@@ -1159,55 +1113,32 @@ def register_lakeflow_source(spark):
 
         def __init__(self, options: dict[str, str]) -> None:
             """
-            Initialize the Gmail connector. Two auth modes are supported,
-            selected by the credentials present in ``options``:
+            Initialize the Gmail connector.
 
-            1. Pre-issued access token (preferred). The Unity Catalog COMMUNITY
-               connection (``community_oauth_flow=u2m`` or ``u2m_per_user``) owns
-               the OAuth dance — Databricks performs the authorization-code
-               exchange (and per-user refresh in u2m_per_user mode) and injects a
-               valid bearer token at query time. The connector treats it as
-               opaque: no client_id/secret, no refresh, no token endpoint. A 401
-               mid-query means the token expired or was revoked; the user
-               re-authorizes through the connection.
-            2. In-code refresh (backward-compat). Connections created before the
-               u2m migration store ``client_id`` + ``client_secret`` +
-               ``refresh_token``; the connector exchanges them for short-lived
-               access tokens at Google's token endpoint itself.
+            Authentication is a pre-issued access token. The Unity Catalog
+            COMMUNITY connection (``community_oauth_flow=u2m`` or
+            ``u2m_per_user``) owns the OAuth dance — Databricks performs the
+            authorization-code exchange (and per-user refresh in u2m_per_user
+            mode) and injects a valid bearer token at query time. The connector
+            treats it as opaque: no client_id/secret, no refresh, no token
+            endpoint. A 401 mid-query means the token expired or was revoked;
+            the user re-authorizes through the connection.
 
             Expected options:
-                - access_token: OAuth 2.0 bearer token (mode 1), OR
-                - refresh_token + client_id + client_secret (mode 2)
+                - access_token: OAuth 2.0 bearer token injected by the connection
                 - user_id (optional): user email or 'me' (default: 'me')
             """
             self.access_token = options.get("access_token")
-            self.refresh_token = options.get("refresh_token")
-            self.client_id = options.get("client_id")
-            self.client_secret = options.get("client_secret")
             self.user_id = options.get("user_id", "me")
 
-            if self.access_token:
-                self.api = GmailApiClient(self.access_token, self.user_id)
-            elif self.refresh_token:
-                if not self.client_id or not self.client_secret:
-                    raise ValueError(
-                        "Gmail refresh-token auth requires 'client_id' and "
-                        "'client_secret' alongside 'refresh_token' in options."
-                    )
-                self.api = GmailApiClient(
-                    user_id=self.user_id,
-                    client_id=self.client_id,
-                    client_secret=self.client_secret,
-                    refresh_token=self.refresh_token,
-                )
-            else:
+            if not self.access_token:
                 raise ValueError(
-                    "Gmail connector requires an OAuth credential in options: "
-                    "either 'access_token' (the Unity Catalog COMMUNITY "
-                    "connection's u2m / u2m_per_user OAuth flow injects it at "
-                    "query time) or 'refresh_token' plus 'client_id' and "
-                    "'client_secret' (in-code refresh for older connections)."
+                    "Gmail connector requires 'access_token' in options. The "
+                    "Unity Catalog COMMUNITY connection's u2m / u2m_per_user "
+                    "OAuth flow injects it at query time."
                 )
+
+            self.api = GmailApiClient(self.access_token, self.user_id)
 
             # Snapshot the mailbox historyId at init time. Gmail's mailbox
             # historyId advances on every write (new mail, reads, label edits),

--- a/src/databricks/labs/community_connector/sources/gmail/gmail.py
+++ b/src/databricks/labs/community_connector/sources/gmail/gmail.py
@@ -37,55 +37,32 @@ class GmailLakeflowConnect(LakeflowConnect):
 
     def __init__(self, options: dict[str, str]) -> None:
         """
-        Initialize the Gmail connector. Two auth modes are supported,
-        selected by the credentials present in ``options``:
+        Initialize the Gmail connector.
 
-        1. Pre-issued access token (preferred). The Unity Catalog COMMUNITY
-           connection (``community_oauth_flow=u2m`` or ``u2m_per_user``) owns
-           the OAuth dance — Databricks performs the authorization-code
-           exchange (and per-user refresh in u2m_per_user mode) and injects a
-           valid bearer token at query time. The connector treats it as
-           opaque: no client_id/secret, no refresh, no token endpoint. A 401
-           mid-query means the token expired or was revoked; the user
-           re-authorizes through the connection.
-        2. In-code refresh (backward-compat). Connections created before the
-           u2m migration store ``client_id`` + ``client_secret`` +
-           ``refresh_token``; the connector exchanges them for short-lived
-           access tokens at Google's token endpoint itself.
+        Authentication is a pre-issued access token. The Unity Catalog
+        COMMUNITY connection (``community_oauth_flow=u2m`` or
+        ``u2m_per_user``) owns the OAuth dance — Databricks performs the
+        authorization-code exchange (and per-user refresh in u2m_per_user
+        mode) and injects a valid bearer token at query time. The connector
+        treats it as opaque: no client_id/secret, no refresh, no token
+        endpoint. A 401 mid-query means the token expired or was revoked;
+        the user re-authorizes through the connection.
 
         Expected options:
-            - access_token: OAuth 2.0 bearer token (mode 1), OR
-            - refresh_token + client_id + client_secret (mode 2)
+            - access_token: OAuth 2.0 bearer token injected by the connection
             - user_id (optional): user email or 'me' (default: 'me')
         """
         self.access_token = options.get("access_token")
-        self.refresh_token = options.get("refresh_token")
-        self.client_id = options.get("client_id")
-        self.client_secret = options.get("client_secret")
         self.user_id = options.get("user_id", "me")
 
-        if self.access_token:
-            self.api = GmailApiClient(self.access_token, self.user_id)
-        elif self.refresh_token:
-            if not self.client_id or not self.client_secret:
-                raise ValueError(
-                    "Gmail refresh-token auth requires 'client_id' and "
-                    "'client_secret' alongside 'refresh_token' in options."
-                )
-            self.api = GmailApiClient(
-                user_id=self.user_id,
-                client_id=self.client_id,
-                client_secret=self.client_secret,
-                refresh_token=self.refresh_token,
-            )
-        else:
+        if not self.access_token:
             raise ValueError(
-                "Gmail connector requires an OAuth credential in options: "
-                "either 'access_token' (the Unity Catalog COMMUNITY "
-                "connection's u2m / u2m_per_user OAuth flow injects it at "
-                "query time) or 'refresh_token' plus 'client_id' and "
-                "'client_secret' (in-code refresh for older connections)."
+                "Gmail connector requires 'access_token' in options. The "
+                "Unity Catalog COMMUNITY connection's u2m / u2m_per_user "
+                "OAuth flow injects it at query time."
             )
+
+        self.api = GmailApiClient(self.access_token, self.user_id)
 
         # Snapshot the mailbox historyId at init time. Gmail's mailbox
         # historyId advances on every write (new mail, reads, label edits),

--- a/src/databricks/labs/community_connector/sources/gmail/gmail_utils.py
+++ b/src/databricks/labs/community_connector/sources/gmail/gmail_utils.py
@@ -1,17 +1,12 @@
 # Gmail API Client Utilities
 # Handles HTTP requests, batch operations, and parallel fetching against the
-# Gmail API. The client supports two auth modes, selected by which
-# credentials the connection supplied:
+# Gmail API.
 #
-# 1. Pre-issued access token — the Unity Catalog COMMUNITY connection
-#    (u2m / u2m_per_user OAuth flow) owns the OAuth dance and injects a fresh
-#    bearer token at query time. Treated as opaque: no refresh, no token
-#    endpoint. A 401 means the token expired / was revoked and the user
-#    re-authorizes through the connection.
-# 2. In-code refresh — a connection created before the u2m migration stores
-#    client_id + client_secret + refresh_token; the client exchanges the
-#    refresh token for short-lived access tokens at Google's token endpoint
-#    and caches them. Keeps those older connections working.
+# Authentication is a pre-issued access token — the Unity Catalog COMMUNITY
+# connection (u2m / u2m_per_user OAuth flow) owns the OAuth dance and injects
+# a fresh bearer token at query time. Treated as opaque: no refresh, no token
+# endpoint. A 401 means the token expired / was revoked and the user
+# re-authorizes through the connection.
 
 import json
 import time
@@ -27,75 +22,29 @@ MAX_WORKERS = 3  # Concurrent workers for parallel fetching
 
 
 class GmailApiClient:
-    """Gmail HTTP client supporting two OAuth modes.
+    """Gmail HTTP client authenticated with a pre-issued access token.
 
-    Pass a pre-issued ``access_token`` (UC COMMUNITY u2m / u2m_per_user flow
-    injects it) for the opaque-token mode, or pass ``client_id`` +
-    ``client_secret`` + ``refresh_token`` for the in-code refresh mode used
-    by connections created before the u2m migration. The access-token mode
-    takes precedence when both are present.
+    The ``access_token`` is injected by the Unity Catalog COMMUNITY
+    connection's u2m / u2m_per_user OAuth flow and treated as opaque — the
+    client never refreshes it or contacts a token endpoint.
     """
 
     BASE_URL = "https://gmail.googleapis.com/gmail/v1"
     BATCH_URL = "https://gmail.googleapis.com/batch/gmail/v1"
-    TOKEN_URL = "https://oauth2.googleapis.com/token"
 
     def __init__(
         self,
-        access_token: Optional[str] = None,
+        access_token: str,
         user_id: str = "me",
-        *,
-        client_id: Optional[str] = None,
-        client_secret: Optional[str] = None,
-        refresh_token: Optional[str] = None,
     ) -> None:
         self.user_id = user_id
         self._session = requests.Session()
-
-        # Mode 1: opaque pre-issued bearer token (no refresh in code).
         self.access_token = access_token
-
-        # Mode 2: in-code refresh credentials + cached short-lived token.
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self.refresh_token = refresh_token
-        self._refreshed_token: Optional[str] = None
-        self._token_expires_at = 0.0
-
-    def get_access_token(self) -> str:
-        """Return a valid bearer token for the active auth mode.
-
-        Opaque-token mode returns the injected token verbatim. Refresh mode
-        exchanges the refresh token at Google's token endpoint, caching the
-        result until ~60s before expiry.
-        """
-        if self.access_token:
-            return self.access_token
-
-        if self._refreshed_token and time.time() < self._token_expires_at - 60:
-            return self._refreshed_token
-
-        response = requests.post(
-            self.TOKEN_URL,
-            data={
-                "client_id": self.client_id,
-                "client_secret": self.client_secret,
-                "refresh_token": self.refresh_token,
-                "grant_type": "refresh_token",
-            },
-            timeout=30,
-        )
-        response.raise_for_status()
-        data = response.json()
-
-        self._refreshed_token = data["access_token"]
-        self._token_expires_at = time.time() + data.get("expires_in", 3600)
-        return self._refreshed_token
 
     def get_headers(self) -> Dict[str, str]:
         """Bearer-token headers for Gmail API calls."""
         return {
-            "Authorization": f"Bearer {self.get_access_token()}",
+            "Authorization": f"Bearer {self.access_token}",
             "Accept": "application/json",
         }
 

--- a/tests/unit/sources/gmail/test_gmail_lakeflow_connect.py
+++ b/tests/unit/sources/gmail/test_gmail_lakeflow_connect.py
@@ -26,27 +26,6 @@ class TestGmailConnector(LakeflowConnectTests):
         assert "emailAddress" in records_list[0]
         assert "@" in records_list[0]["emailAddress"]
 
-    def test_refresh_token_path_reads_via_token_exchange(self):
-        """Backward-compat: a connection supplying refresh_token + client
-        creds (instead of an injected access_token) drives the in-code token
-        exchange against the simulator's /token endpoint and reads normally.
-
-        The simulator installed in setup_class intercepts both the /token
-        exchange and the Gmail API calls, so building a fresh connector here
-        exercises the full refresh path end-to-end.
-        """
-        refresh_connector = GmailLakeflowConnect(
-            {
-                "client_id": "sim-client-id",
-                "client_secret": "sim-client-secret",
-                "refresh_token": "sim-refresh-token",
-            }
-        )
-        records, _offset = refresh_connector.read_table("profile", {}, {})
-        records_list = list(records)
-        assert len(records_list) == 1
-        assert "emailAddress" in records_list[0]
-
     def test_read_labels_has_inbox(self):
         """Test reading labels includes INBOX."""
         records, offset = self.connector.read_table("labels", {}, {})

--- a/tests/unit/sources/gmail/test_gmail_unit.py
+++ b/tests/unit/sources/gmail/test_gmail_unit.py
@@ -37,31 +37,6 @@ class TestGmailConnectorUnit:
         # connection's OAuth flow, not a local credential to set.
         assert "COMMUNITY" in str(info.value)
 
-    def test_unit_initialization_with_refresh_token(self, monkeypatch):
-        """Backward-compat: a connection with refresh_token + client creds
-        uses the in-code refresh path instead of an injected access_token."""
-        monkeypatch.setattr(
-            "databricks.labs.community_connector.sources.gmail.gmail_utils."
-            "GmailApiClient.make_request",
-            lambda self, method, path, **kwargs: {"historyId": "1"},
-        )
-        connector = GmailLakeflowConnect(
-            {
-                "client_id": "cid",
-                "client_secret": "secret",
-                "refresh_token": "refresh",
-            }
-        )
-        assert connector.access_token is None
-        assert connector.refresh_token == "refresh"
-        assert connector.api.client_id == "cid"
-        assert connector.api.refresh_token == "refresh"
-
-    def test_unit_refresh_token_requires_client_credentials(self):
-        """refresh_token without client_id/client_secret fails fast."""
-        with pytest.raises(ValueError, match="client_id"):
-            GmailLakeflowConnect({"refresh_token": "refresh"})
-
     def test_unit_schemas_use_long_type_not_integer(self, connector):
         """Test all numeric fields use LongType instead of IntegerType."""
         for table_name in connector.list_tables():


### PR DESCRIPTION
## Summary

The COMMUNITY OAuth connection support is released: the Unity Catalog connection (`u2m` / `u2m_per_user`) owns the OAuth dance and injects a runtime `access_token` into the connector at query time. The Gmail connector's older **in-code refresh path** — where the connection stored `client_id` + `client_secret` + `refresh_token` and the connector exchanged them at Google's token endpoint itself — is no longer needed. This PR removes it so the connector has a single, simple auth mode: an injected `access_token` treated as opaque.

## Changes

- **`gmail.py`** — `__init__` requires `access_token` only; dropped the `refresh_token` / `client_id` / `client_secret` branch and collapsed the auth handling.
- **`gmail_utils.py`** — `GmailApiClient` takes only `access_token`; removed `TOKEN_URL`, the refresh-token/client fields, and the token-refresh + caching in `get_access_token` (headers now use the injected token directly). `time` is still used for rate-limit backoff.
- **Simulator** — removed the `/token` endpoint and its `oauth_token` corpus; updated the spec header to the single access-token mode.
- **Tests** — dropped the `refresh_token` unit and lakeflow-connect cases; kept the `access_token` happy path and the missing-credential error.
- **README** — stopped referencing a refresh token the user never provides.
- Regenerated `_generated_gmail_python_source.py`.

Net: ~200 lines removed.

## Test plan

- `tests/unit/sources/gmail/` — **23 passed, 1 skipped** (simulate mode, offline).

This pull request and its description were written by Isaac.

This PR is assisted by Isaac Autopilot: [View the full session spec, test plan, and artifacts](http://go/isaac-autopilot/cli-viewer/1781843243671/yong-li_data).