### PR TITLE
Pin actions/checkout to v6.0.2 in fork-PR workflows

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -70,7 +70,7 @@ jobs:
         fi
         echo "::error title=Fork PR not authorized::Apply (or re-apply) the 'safe-to-test' label to authorize CI on this commit. See CONTRIBUTING.md."
         exit 1
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         # pull_request_target defaults to checking out the base ref; we want
         # to lint the PR's actual code. For push/same-repo events the empty

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
           fi
           echo "::error title=Fork PR not authorized::Apply (or re-apply) the 'safe-to-test' label to authorize CI on this commit. See CONTRIBUTING.md."
           exit 1
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       # cannot use dorny because of ip allowlisting
       # - uses: dorny/paths-filter@v3
         with:
@@ -210,7 +210,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python ${{ matrix.python-version }}
@@ -243,7 +243,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python ${{ matrix.python-version }}
@@ -276,7 +276,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python ${{ matrix.python-version }}
@@ -309,7 +309,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python ${{ matrix.python-version }}
@@ -344,7 +344,7 @@ jobs:
         source: ${{ fromJson(needs.changes.outputs.sources) }}
       fail-fast: false
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python 3.10

--- a/.github/workflows/verify-locks.yml
+++ b/.github/workflows/verify-locks.yml
@@ -61,7 +61,7 @@ jobs:
           fi
           echo "::error title=Fork PR not authorized::Apply (or re-apply) the 'safe-to-test' label to authorize CI on this commit. See CONTRIBUTING.md."
           exit 1
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION
## Problem

CI is broken for all external **fork** pull requests (e.g. #128). The `build`, `verify`, and `changes` jobs fail within ~5–7s at the checkout step with:

> `##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow. … To opt in … set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.`

and the `summary` aggregator then fails with "Required jobs did not pass".

## Root cause

`actions/checkout` **v7.0.0** (#233; the guard was also present in **v6.0.3**, #212) introduced a security guard that refuses to check out fork PR code from `pull_request_target` workflows unless `allow-unsafe-pr-checkout: true` is set. Our `pull_request_target` workflows check out the fork head (`ref: ${{ github.event.pull_request.head.sha }}`), so every fork-PR run now hard-fails at checkout. The last release *without* the guard is **v6.0.2**.

## Fix

Pin the checkout steps in the three `pull_request_target` workflows back to v6.0.2:

- `tests.yml` (6 steps)
- `verify-locks.yml`
- `pylint.yml`

Other workflows are left on their current version. The existing **`safe-to-test`** label gate remains the authorization control for running CI on untrusted fork code, so we are not relying on the checkout guard for that protection.

## Note

This is the deliberate tradeoff of pinning to the pre-guard version: v6.0.2 does not itself block untrusted fork checkout on `pull_request_target`. The `safe-to-test` gate is what mitigates the pwn-request risk here. A future follow-up could move to v7.0.0 + explicit `allow-unsafe-pr-checkout: true` to keep the newer action while being explicit about the opt-in.

This pull request and its description were written by Isaac.