### PR TITLE
Add managed ingestion pipeline support to community-connector CLI

### DIFF
--- a/.claude/skills/deploy-connector/SKILL.md
+++ b/.claude/skills/deploy-connector/SKILL.md
@@ -93,6 +93,11 @@ If multiple tables share options (e.g. same `owner`/`repo`), ask once and reuse 
 
 ## Step 3 — Generate the full pipeline spec
 
+> If the user just wants an **empty pipeline** (a connection but no tables yet,
+> to add later), skip the spec entirely: run `create_pipeline` with only
+> `-n <CONNECTION_NAME> -c <CATALOG> -t <SCHEMA>` (see Step 5). Otherwise build
+> the spec below.
+
 Build a **complete pipeline spec** as JSON or YAML. The CLI sends it to the
 pipelines API as-is, only adding the managed-ingestion configuration flag, the
 `ingestion_definition.source_type`, and the connector wheel `environment`. Since
@@ -165,6 +170,12 @@ automatically.
    community-connector create_pipeline {{source_name}} <PIPELINE_NAME> \
      -ps tests/unit/sources/{{source_name}}/configs/{PIPELINE_NAME}_spec.yaml \
      [-v <VOLUME_PATH>]
+   ```
+
+   **Create empty pipeline (no spec, add tables later):**
+   ```bash
+   community-connector create_pipeline {{source_name}} <PIPELINE_NAME> \
+     -n <CONNECTION_NAME> -c <CATALOG> -t <SCHEMA>
    ```
 
    **Update mode:**

--- a/.claude/skills/deploy-connector/SKILL.md
+++ b/.claude/skills/deploy-connector/SKILL.md
@@ -14,14 +14,11 @@ args:
   - name: pipeline_name
     description: The name of the existing pipeline to update. Only used when mode is 'update'. If omitted in update mode, the user will be prompted.
     required: false
-  - name: use_local_source
-    description: "Defaults to false. When true, uploads local source files to overwrite the source directory in the cloned workspace repo. Use when the connector has not been published to the remote repo yet. The CLI still clones the repo (for framework/interface code), then uploads local *.py, README.md, and connector_spec.yaml on top. Do not prompt the user for this — only set to true if the user explicitly requests it."
-    required: false
 ---
 
 # Deploy Connector
 
-Create or update an ingestion pipeline for **{{source_name}}** by reading its docs, interactively building a pipeline spec, and running the CLI.
+Create or update a **managed ingestion pipeline** for **{{source_name}}** by reading its docs, interactively building a full pipeline spec, and running the CLI. The CLI builds the connector's Python wheels, uploads them to a UC Volume, and creates a pipeline whose `ingestion_definition` is set from the spec — no repo clone.
 
 ## Prerequisites
 
@@ -35,21 +32,6 @@ Create or update an ingestion pipeline for **{{source_name}}** by reading its do
 If `{{mode}}` is `create` or `update`, use it. Otherwise ask via `AskUserQuestion`.
 
 If **update**, also collect the pipeline name (unless `{{pipeline_name}}` was provided).
-
----
-
-## Step 0.5 — Prepare local source (if requested)
-
-If `{{use_local_source}}` is true:
-
-1. Check whether the generated file exists: `src/databricks/labs/community_connector/sources/{{source_name}}/_generated_{{source_name}}_python_source.py`
-2. If it does **not** exist, run the merge script to generate it:
-   ```bash
-   python tools/scripts/merge_python_source.py {{source_name}}
-   ```
-3. You will pass `--use-local-source` to the CLI in Step 5. The CLI still clones the Git repo (for framework/interface code), then uploads the local source files on top — overwriting the source directory in the workspace repo. This is used when the connector has not been published to the remote repo yet.
-
-If `{{use_local_source}}` is not true, skip this step — the default deployment assumes the connector source is already in the remote Git repo.
 
 ---
 
@@ -83,7 +65,7 @@ If `{{connection_name}}` provided, use it. Otherwise ask if the user has one.
 
 ### 2b. Default destination catalog and schema
 
-Ask for **catalog** (e.g. `main`) and **schema** (e.g. `raw_example`). Both optional — omitted values use pipeline defaults.
+Ask for **catalog** (e.g. `main`) and **schema** (e.g. `raw_example`). These set the pipeline-level `catalog`/`schema` and serve as the **default** destination for each table. Individual tables can override them with per-table `destination_catalog`/`destination_schema` (see 2e).
 
 ### 2c. Pipeline name
 
@@ -95,42 +77,64 @@ Present the supported tables from Step 1 with brief descriptions. Let the user p
 
 ### 2e. Per-table configuration
 
-For each selected table, check the README for two categories of options:
+For each selected table, check the README for three categories of options:
 
-**Destination overrides** (`destination_catalog`, `destination_schema`, `destination_table`) — set on the `table` object. Mention these are available but don't actively prompt; only include if the user requests per-table overrides.
+**Destination overrides** (`destination_table`, and optionally `destination_catalog`/`destination_schema`) — set on the `table` object. `destination_catalog`/`destination_schema` default to the values from 2b; only override per table if the user asks. Mention `destination_table` is available but don't actively prompt.
 
-**Source-specific and common options** (set inside `table_configuration`):
-- **Required**: list each with description, ask for values (e.g. `category` for products, `window_seconds` for metrics)
-- **Optional**: list each with description and default, ask if the user wants to set any (includes `scd_type`, `primary_keys`, `sequence_by`, plus source-specific options e.g. `start_date` to filter, `max_records_per_batch` to control batch size)
+**Source-specific options** (set inside `connector_options.community_connector_options.options`):
+- **Required**: list each with description, ask for values (e.g. `owner`/`repo` for GitHub, `category` for products, `window_seconds` for metrics)
+- **Optional**: list each with description and default, ask if the user wants to set any (e.g. `start_date` to filter, `max_records_per_batch` to control batch size)
+
+**Ingestion controls** (set inside `table_configuration`): `scd_type`, `primary_keys`, `sequence_by`. Ask only if the user wants to override the connector defaults.
 
 If multiple tables share options (e.g. same `owner`/`repo`), ask once and reuse — confirm with user.
 
 ---
 
-## Step 3 — Generate the pipeline spec
+## Step 3 — Generate the full pipeline spec
 
-Build the spec JSON:
+Build a **complete pipeline spec** as JSON or YAML. The CLI sends it to the
+pipelines API as-is, only adding the managed-ingestion configuration flag, the
+`ingestion_definition.source_type`, and the connector wheel `environment`. Since
+the CLI does not backfill per-table destinations in full-spec mode, spell out
+`destination_catalog`/`destination_schema` on every table (using the 2b values).
 
-```json
-{
-  "connection_name": "<CONNECTION_NAME>",
-  "objects": [
-    {
-      "table": {
-        "source_table": "<TABLE_NAME>",
-        "destination_catalog": "<CATALOG>",
-        "destination_schema": "<SCHEMA>",
-        "destination_table": "<TABLE>",
-        "table_configuration": { "<key>": "<value>" }
-      }
-    }
-  ]
-}
+```yaml
+name: <PIPELINE_NAME>
+catalog: <CATALOG>
+schema: <SCHEMA>
+serverless: true
+channel: PREVIEW
+ingestion_definition:
+  connection_name: <CONNECTION_NAME>
+  objects:
+    - table:
+        source_schema: default
+        source_table: <TABLE_NAME>
+        destination_catalog: <CATALOG>
+        destination_schema: <SCHEMA>
+        destination_table: <TABLE>          # optional; defaults to source_table
+        connector_options:
+          community_connector_options:
+            options:
+              <source_option_key>: <value>  # e.g. owner, repo, start_date
+        table_configuration:                 # optional ingestion controls
+          scd_type: SCD_TYPE_1
+          primary_keys: [<col>]
 ```
 
-- `connection_name` and `source_table` are always required.
-- Omit `destination_*` fields unless the user set per-table overrides.
-- Omit `table_configuration` if empty.
+- Top-level `name`, `catalog`, `schema` are required; keep `serverless: true`
+  and `channel: PREVIEW`.
+- `connection_name` and `source_table` are always required per definition/table.
+- `source_schema` defaults to `default` if omitted.
+- **Source-specific options** (e.g. `owner`, `repo`, `start_date`) go under
+  `connector_options.community_connector_options.options` — NOT
+  `table_configuration`.
+- `table_configuration` carries only ingestion controls (`scd_type`,
+  `primary_keys`, `sequence_by`). Omit if empty.
+- Do **not** add an `environment` block — the CLI builds and attaches the
+  connector wheels. (Only include one if the wheels are already on a Volume and
+  you want to skip the build; that suppresses the automatic wheel upload.)
 
 Show the spec to the user for review before proceeding.
 
@@ -148,27 +152,34 @@ cd tools/community_connector && pip install -e . && cd ../..
 
 ## Step 5 — Deploy the pipeline
 
-Use `create_pipeline` or `update_pipeline` based on the mode from Step 0.
+Use `create_pipeline` or `update_pipeline` based on the mode from Step 0. Both
+run managed ingestion, which builds + uploads the connector wheels
+automatically.
 
-1. Write the spec to `tests/unit/sources/{{source_name}}/configs/{PIPELINE_NAME}_spec.json`.
+1. Write the spec to `tests/unit/sources/{{source_name}}/configs/{PIPELINE_NAME}_spec.yaml`.
 
 2. Run the appropriate command:
 
    **Create mode:**
    ```bash
    community-connector create_pipeline {{source_name}} <PIPELINE_NAME> \
-     -ps tests/unit/sources/{{source_name}}/configs/{PIPELINE_NAME}_spec.json \
-     [-c <CATALOG>] [-t <TARGET>] [--use-local-source]
+     -ps tests/unit/sources/{{source_name}}/configs/{PIPELINE_NAME}_spec.yaml \
+     [-v <VOLUME_PATH>]
    ```
 
-   **Update mode** (no source_name needed):
+   **Update mode:**
    ```bash
    community-connector update_pipeline <PIPELINE_NAME> \
-     -ps tests/unit/sources/{{source_name}}/configs/{PIPELINE_NAME}_spec.json
+     -ps tests/unit/sources/{{source_name}}/configs/{PIPELINE_NAME}_spec.yaml \
+     -s {{source_name}}
    ```
 
-   - Include `-c`/`-t` only if catalog/schema were provided in Step 2b (create mode only).
-   - Include `--use-local-source` if `{{use_local_source}}` is true (create mode only, from Step 0.5).
+   - The full spec carries `name`, `catalog`, `schema`, and `connection_name`,
+     so CLI options for those are optional.
+   - `-v` overrides the wheel upload volume path (defaults to
+     `/Volumes/<catalog>/<schema>/community_connector/packages`).
+   - Pass `-p <WHEEL>` to reuse pre-built wheels instead of building.
+   - `-s {{source_name}}` on update tells the CLI which connector wheels to build.
 
 3. After success, delete the spec file.
 

--- a/.claude/skills/deploy-connector/SKILL.md
+++ b/.claude/skills/deploy-connector/SKILL.md
@@ -179,7 +179,10 @@ automatically.
    - `-v` overrides the wheel upload volume path (defaults to
      `/Volumes/<catalog>/<schema>/community_connector/packages`).
    - Pass `-p <WHEEL>` to reuse pre-built wheels instead of building.
-   - `-s {{source_name}}` on update tells the CLI which connector wheels to build.
+   - `-s {{source_name}}` on update tells the CLI which connector wheels to
+     build. **Omit both `-s` and `-p` on update to leave the packages
+     untouched** — the CLI reuses the pipeline's existing
+     `environment.dependencies` and only applies the new spec.
 
 3. After success, delete the spec file.
 

--- a/tools/community_connector/README.md
+++ b/tools/community_connector/README.md
@@ -51,22 +51,42 @@ This installs the `community-connector` command globally.
 
 ### `create_pipeline`
 
-Create a community connector pipeline with a Git repo and DLT pipeline.
+Create a community connector pipeline. By default this creates a **managed
+ingestion** pipeline: the connector's Python wheels are built and uploaded to a
+UC Volume, and the pipeline's `ingestion_definition` is set from the spec — no
+Git repo is cloned. Pass `--use-workspace-pipeline` for the legacy mode that
+clones the repo into the workspace and runs `ingest.py`.
+
+Managed mode accepts either `--pipeline-spec` or `--connection-name`:
+- `--pipeline-spec` may be a **bare** ingestion definition (`connection_name` +
+  `objects`) or a **full** pipeline spec (containing an `ingestion_definition`
+  block). If a full spec already declares an `environment`, the wheel
+  build/upload is skipped and the spec's dependencies are used as-is.
+- With only `--connection-name` (no spec), an **empty** pipeline is created (a
+  connection but no tables) that you can use the Databricks ingestion wizard UI
+  or populate later with `update_pipeline`.
+
+Wheels are built from the local source tree unless `--package` supplies
+pre-built ones.
 
 ```bash
-# Basic usage with connection name (uses default template)
-community-connector create_pipeline github my_github_pipeline -n my_github_conn
-
-# With catalog and schema
-community-connector create_pipeline stripe my_stripe_pipeline -n stripe_conn \
-  --catalog main --target raw_data
-
-# With pipeline spec file
-community-connector create_pipeline github my_pipeline -ps pipeline_spec.yaml
-
-# With inline JSON spec
+# Managed ingestion (default): bare spec with catalog/schema
 community-connector create_pipeline github my_pipeline \
-  -ps '{"connection_name": "my_conn", "objects": [{"table": {"source_table": "users"}}]}'
+  -ps spec.yaml -n my_conn -c main -t raw
+
+# Managed ingestion: full pipeline spec (self-contained)
+community-connector create_pipeline github my_pipeline -ps full_pipeline.yaml
+
+# Empty managed pipeline (add tables later with update_pipeline)
+community-connector create_pipeline github my_pipeline -n my_conn -c main -t raw
+
+# Bring your own pre-built wheels instead of building from source
+community-connector create_pipeline github my_pipeline \
+  -ps spec.yaml -p framework.whl -p connector.whl
+
+# Legacy workspace pipeline (clones the repo, runs ingest.py)
+community-connector create_pipeline github my_pipeline \
+  -n my_conn --use-workspace-pipeline
 ```
 
 **Options:**
@@ -76,29 +96,54 @@ community-connector create_pipeline github my_pipeline \
 | `--pipeline-spec` | `-ps` | Pipeline spec as JSON string or path to .yaml/.json file |
 | `--catalog` | `-c` | Unity Catalog name for the pipeline |
 | `--target` | `-t` | Target schema for the pipeline |
-| `--repo-url` | `-r` | Git repository URL (overrides default) |
+| `--package` | `-p` | Pre-built connector wheel; skip building from source (managed mode). Repeatable. |
+| `--volume-path` | `-v` | UC Volume directory for the connector wheels (managed mode). Defaults to `/Volumes/<catalog>/<schema>/community_connector/packages`. |
+| `--use-workspace-pipeline` | | Use the legacy workspace pipeline mode (clone repo, run `ingest.py`) instead of managed ingestion. |
+| `--repo-url` | `-r` | Git repository URL (legacy workspace mode; overrides default). |
 | `--config` | `-f` | Path to custom config file |
 
 ### `update_pipeline`
 
-Update the `ingest.py` configuration for an existing pipeline. This command modifies only the pipeline spec in the workspace file; other pipeline settings remain unchanged.
+Update an existing community connector pipeline. By default this updates a
+**managed ingestion** pipeline: `--pipeline-spec` is rebuilt into the pipeline's
+`ingestion_definition`. Because the pipelines PUT is a full-settings replace, the
+existing pipeline settings the CLI does not manage (tags, notifications, budget
+policy, channel, serverless, …) are preserved.
+
+Connector wheels are rebuilt and re-uploaded only when `--source-name` or
+`--package` is given; otherwise the pipeline's existing packages are reused
+untouched. A full spec that already declares an `environment` keeps its own
+dependencies.
+
+Pass `--use-workspace-pipeline` for the legacy mode that rewrites `ingest.py`
+and/or updates package dependencies. Managed mode requires `--pipeline-spec`;
+legacy mode requires at least one of `--pipeline-spec` or `--package`.
 
 ```bash
-# Update with a YAML spec file
-community-connector update_pipeline my_github_pipeline -ps pipeline_spec.yaml
+# Managed ingestion (default): update the ingested tables, reuse existing wheels
+community-connector update_pipeline my_pipeline -ps spec.yaml
 
-# Update with a JSON spec file
-community-connector update_pipeline my_github_pipeline -ps pipeline_spec.json
+# Managed ingestion: also rebuild and re-upload the connector wheels
+community-connector update_pipeline my_pipeline -ps spec.yaml -s github
 
-# Update with inline JSON spec
-community-connector update_pipeline my_github_pipeline \
-  -ps '{"connection_name": "my_conn", "objects": [{"table": {"source_table": "users"}}]}'
+# Legacy workspace pipeline
+community-connector update_pipeline my_pipeline -ps spec.yaml \
+  --use-workspace-pipeline
+community-connector update_pipeline my_pipeline -p connector.whl \
+  --use-workspace-pipeline
 ```
 
 **Options:**
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--pipeline-spec` | `-ps` | Pipeline spec as JSON string or path to .yaml/.json file (required) |
+| `--pipeline-spec` | `-ps` | Pipeline spec as JSON string or path to .yaml/.json file (required in managed mode) |
+| `--source-name` | `-s` | Connector source name; triggers rebuilding the wheels in managed mode. |
+| `--connection-name` | `-n` | UC connection name (managed mode). |
+| `--catalog` | `-c` | UC target catalog (managed mode). |
+| `--schema` | `-t` | Target schema (managed mode). |
+| `--package` | `-p` | Pre-built connector wheel; upload and use as pipeline dependency. Repeatable. |
+| `--volume-path` | `-v` | UC Volume directory for the connector wheels (managed mode). Defaults to `/Volumes/<catalog>/<schema>/community_connector/packages`. |
+| `--use-workspace-pipeline` | | Use the legacy workspace pipeline mode (rewrite `ingest.py` / update packages) instead of managed ingestion. |
 
 ### `run_pipeline`
 
@@ -314,12 +359,16 @@ The CLI uses a layered configuration system:
 ### Default Configuration
 
 The bundled defaults include:
-- Workspace path: `/Users/{CURRENT_USER}/.lakeflow_community_connectors/{PIPELINE_NAME}`
-- Git repo: `https://github.com/databrickslabs/lakeflow-community-connectors.git`
-- Sparse checkout patterns for connector source files
+- Workspace path: `/Users/{CURRENT_USER}/.lakeflow_community_connectors/{PIPELINE_NAME}` (legacy workspace mode)
+- Git repo: `https://github.com/databrickslabs/lakeflow-community-connectors.git` (legacy workspace mode)
+- Sparse checkout patterns for connector source files (legacy workspace mode)
 - Serverless mode enabled
 - Development mode enabled
 - Connection external options allowlist: Common table config options (e.g., `tableName`, `tableNameList`, `isDeleteFlow`)
+
+> The workspace path, Git repo, and sparse-checkout settings apply only to the
+> legacy `--use-workspace-pipeline` mode. Managed ingestion (the default) does
+> not clone a repo.
 
 ### Custom Config File
 

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -42,6 +42,13 @@ from databricks.labs.community_connector_cli.oauth_flow import (
     OAUTH_OPTION_KEYS,
     run_u2m_authorization_code_flow,
 )
+from databricks.labs.community_connector_cli.managed_pipeline import (
+    ManagedPipelineSpecError,
+    augment_full_pipeline_body,
+    build_bare_pipeline_body,
+    is_full_pipeline_spec,
+    validate_ingestion_definition,
+)
 from databricks.labs.community_connector_cli.pipeline_client import PipelineClient
 from databricks.labs.community_connector_cli.pipeline_spec_validator import (
     PipelineSpecValidationError,
@@ -1406,6 +1413,188 @@ def _create_and_show_pipeline(
         raise click.ClickException(f"Failed to create pipeline: {e}")
 
 
+# ---- Managed ingestion pipeline helpers --------------------------------------
+
+# Defaults applied to a bare-mode managed pipeline body. Managed ingestion runs
+# on serverless; PREVIEW is the channel community connectors are validated on.
+_MANAGED_DEFAULT_CHANNEL = "PREVIEW"
+_MANAGED_DEFAULT_SERVERLESS = True
+
+
+def _parse_managed_pipeline_spec(spec_input: str) -> dict:
+    """Parse a managed-mode spec from a JSON string or .yaml/.json file.
+
+    Unlike ``_parse_pipeline_spec`` this does not run the friendly-spec
+    validator: a managed spec is either a bare ``ingestion_definition`` (whose
+    connection_name may come from ``--connection-name`` rather than the file) or
+    a full pipeline object, neither of which matches that validator's shape.
+    """
+    if spec_input.endswith((".yaml", ".yml", ".json")):
+        try:
+            with open(spec_input, "r") as f:
+                if spec_input.endswith(".json"):
+                    spec = json.load(f)
+                else:
+                    spec = yaml.safe_load(f)
+        except FileNotFoundError:
+            raise click.ClickException(f"Pipeline spec file not found: {spec_input}")
+        except Exception as e:
+            raise click.ClickException(f"Failed to parse pipeline spec file: {e}")
+    else:
+        try:
+            spec = json.loads(spec_input)
+        except json.JSONDecodeError as e:
+            raise click.ClickException(f"Invalid JSON for --pipeline-spec: {e}")
+
+    if not isinstance(spec, dict):
+        raise click.ClickException("Pipeline spec must be a JSON/YAML object")
+    return spec
+
+
+def _resolve_managed_dest_dir(
+    workspace_client, volume_path: Optional[str],
+    catalog: Optional[str], schema: Optional[str], debug: bool,
+) -> str:
+    """Resolve (and create) the UC Volume directory for managed wheel uploads.
+
+    An explicit ``--volume-path`` wins. Otherwise the destination is derived as
+    ``/Volumes/<catalog>/<schema>/community_connector/packages``, falling back
+    to ``main``/``default`` when catalog/schema were not supplied — the wheels
+    only need *a* readable volume, independent of the pipeline's destination.
+    """
+    if volume_path:
+        return _ensure_volume_directory(workspace_client, volume_path, debug)
+    vol_catalog = catalog or "main"
+    vol_schema = schema or "default"
+    return _ensure_package_volume(workspace_client, vol_catalog, vol_schema, debug)
+
+
+def _build_and_upload_managed_wheels(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    workspace_client, source_name: Optional[str], dest_dir: str,
+    package_paths: tuple, debug: bool,
+) -> List[str]:
+    """Upload connector wheels to ``dest_dir`` for use as pipeline dependencies.
+
+    When ``--package`` wheels are supplied they are uploaded as-is. Otherwise the
+    framework + connector wheels are built from the local source tree (reusing
+    the ``upload`` command's build helpers) and then uploaded.
+    """
+    click.echo("\nPreparing connector packages...")
+    if package_paths:
+        click.echo(f"  Using pre-built packages: {', '.join(package_paths)}")
+        return [
+            _upload_wheel(workspace_client, Path(p), dest_dir) for p in package_paths
+        ]
+
+    if not source_name:
+        raise click.ClickException(
+            "Building connector wheels requires a source name. "
+            "Pass --package with pre-built wheels, or provide the source name."
+        )
+
+    src = _resolve_source_dir(source_name, None)
+    repo_root = _resolve_repo_root_for_upload(
+        src, skip_framework=False, framework_wheel_path=None
+    )
+    cleanup_dir = Path(tempfile.mkdtemp(prefix=f"cc-build-{source_name}-"))
+    try:
+        wheels = _prepare_upload_wheels(
+            source_name, src, repo_root, None, None, False, cleanup_dir, debug,
+        )
+        return [
+            _upload_wheel(workspace_client, wheel, dest_dir)
+            for wheel, _kind, _built in wheels
+        ]
+    finally:
+        if cleanup_dir.exists():
+            shutil.rmtree(cleanup_dir, ignore_errors=True)
+
+
+def _managed_dependencies(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    workspace_client, spec: dict, is_full: bool, source_name: Optional[str],
+    volume_path: Optional[str], catalog: Optional[str], schema: Optional[str],
+    package_paths: tuple, debug: bool,
+) -> Optional[List[str]]:
+    """Decide whether to build/upload wheels and return their volume paths.
+
+    A full spec that already declares an ``environment`` block is left untouched
+    (the user handles dependencies), so no build/upload happens and ``None`` is
+    returned. In every other case the connector wheels are uploaded and their
+    paths returned for ``environment.dependencies``.
+    """
+    if is_full and "environment" in spec:
+        click.echo(
+            "\nPipeline spec already declares an 'environment'; "
+            "skipping wheel build/upload."
+        )
+        return None
+
+    dest_dir = _resolve_managed_dest_dir(
+        workspace_client, volume_path, catalog, schema, debug
+    )
+    return _build_and_upload_managed_wheels(
+        workspace_client, source_name, dest_dir, package_paths, debug
+    )
+
+
+def _create_managed_pipeline(workspace_client, body: dict, debug: bool) -> str:
+    """POST a raw managed-ingestion pipeline body and return the new pipeline id.
+
+    The body is sent verbatim because the installed SDK cannot model the
+    COMMUNITY source type or community_connector_options.
+    """
+    if debug:
+        click.echo(f"[DEBUG] Managed pipeline body:\n{json.dumps(body, indent=2)}")
+    response = workspace_client.api_client.do(
+        "POST", "/api/2.0/pipelines", body=body
+    )
+    return response.get("pipeline_id")
+
+
+def _update_managed_pipeline(
+    workspace_client, pipeline_id: str, body: dict, debug: bool
+) -> None:
+    """PUT a raw managed-ingestion pipeline body to replace an existing pipeline."""
+    body = {**body, "id": pipeline_id}
+    if debug:
+        click.echo(f"[DEBUG] Managed pipeline body:\n{json.dumps(body, indent=2)}")
+    workspace_client.api_client.do(
+        "PUT", f"/api/2.0/pipelines/{pipeline_id}", body=body
+    )
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+def _build_managed_pipeline_body(
+    workspace_client, spec: dict, pipeline_name: Optional[str], source_name: Optional[str],
+    connection_name: Optional[str], catalog: Optional[str], schema: Optional[str],
+    volume_path: Optional[str], package_paths: tuple, debug: bool,
+) -> dict:
+    """Build the full managed-ingestion pipeline body (bare or full spec)."""
+    is_full = is_full_pipeline_spec(spec)
+    if not is_full:
+        try:
+            validate_ingestion_definition(spec)
+        except ManagedPipelineSpecError as e:
+            raise click.ClickException(f"Invalid ingestion definition: {e}")
+
+    dependencies = _managed_dependencies(
+        workspace_client, spec, is_full, source_name,
+        volume_path, catalog, schema, package_paths, debug,
+    )
+
+    if is_full:
+        return augment_full_pipeline_body(
+            spec, pipeline_name, connection_name, catalog, schema, dependencies,
+        )
+    return build_bare_pipeline_body(
+        spec, pipeline_name, connection_name, catalog, schema, dependencies,
+        channel=_MANAGED_DEFAULT_CHANNEL, serverless=_MANAGED_DEFAULT_SERVERLESS,
+    )
+
+
+# ---- end managed ingestion helpers -------------------------------------------
+
+
 @click.group(cls=OrderedGroup)
 @click.option("--debug", is_flag=True, help="Enable debug output")
 @click.pass_context
@@ -1421,6 +1610,44 @@ def main(ctx: click.Context, debug: bool):
     """
     ctx.ensure_object(dict)
     ctx.obj["debug"] = debug
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+def _create_managed_pipeline_cmd(
+    pipeline_name: str,
+    source_name: Optional[str],
+    pipeline_spec_input: Optional[str],
+    connection_name: Optional[str],
+    catalog: Optional[str],
+    schema: Optional[str],
+    volume_path: Optional[str],
+    package_paths: tuple,
+    debug: bool,
+) -> None:
+    """Create a managed ingestion pipeline (default mode of create_pipeline)."""
+    if not pipeline_spec_input:
+        raise click.ClickException(
+            "--pipeline-spec is required for managed ingestion pipelines. "
+            "Pass --use-workspace-pipeline for the legacy workspace mode."
+        )
+
+    click.echo(f"Creating managed ingestion pipeline: {pipeline_name}")
+    spec = _parse_managed_pipeline_spec(pipeline_spec_input)
+
+    workspace_client = _make_workspace_client()
+    body = _build_managed_pipeline_body(
+        workspace_client, spec, pipeline_name, source_name, connection_name,
+        catalog, schema, volume_path, package_paths, debug,
+    )
+
+    click.echo("\nCreating pipeline...")
+    try:
+        pipeline_id = _create_managed_pipeline(workspace_client, body, debug)
+    except Exception as e:
+        _handle_api_error(e, "create pipeline for", debug)
+        return
+    click.echo("  ✓ Pipeline created!")
+    _print_pipeline_url(workspace_client, pipeline_id)
 
 
 def _echo_create_pipeline_summary(
@@ -1486,6 +1713,23 @@ def _echo_create_pipeline_summary(
     help="Upload local source files (*.py, README.md, connector_spec.yaml) "
     "to sources/{source_name} in the workspace repo.",
 )
+@click.option(
+    "--use-workspace-pipeline",
+    "use_workspace_pipeline",
+    is_flag=True,
+    default=False,
+    help="Use the legacy workspace pipeline mode (clone the repo into the "
+    "workspace and run ingest.py) instead of the default managed ingestion "
+    "pipeline.",
+)
+@click.option(
+    "--volume-path",
+    "-v",
+    "volume_path",
+    default=None,
+    help="UC Volume directory for the connector wheels in managed mode. "
+    "Defaults to /Volumes/<catalog>/<schema>/community_connector/packages.",
+)
 @click.pass_context
 # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
 def create_pipeline(
@@ -1500,6 +1744,8 @@ def create_pipeline(
     schema: Optional[str],
     package_paths: tuple,
     use_local_source: bool,
+    use_workspace_pipeline: bool,
+    volume_path: Optional[str],
 ):
     """
     Create a community connector pipeline.
@@ -1508,28 +1754,48 @@ def create_pipeline(
 
     PIPELINE_NAME is a unique name for this pipeline instance.
 
-    When --package is provided, the pipeline uses the uploaded wheel packages
-    as dependencies and creates a workspace directory (no Git repo clone).
-    Otherwise, a Git repo is cloned into the workspace.
+    By default this creates a *managed ingestion* pipeline: the connector's
+    Python wheels are built and uploaded to a UC Volume, and the pipeline's
+    ``ingestion_definition`` is set from --pipeline-spec. Pass
+    --use-workspace-pipeline for the legacy mode that clones the repo into the
+    workspace and runs ingest.py.
 
-    Either --connection-name or --pipeline-spec must be provided.
-    If using --pipeline-spec, it must include 'connection_name'.
+    Managed mode: --pipeline-spec is required and may be either a bare
+    ingestion definition (connection_name + objects) or a full pipeline spec
+    (containing an 'ingestion_definition' block). Wheels are built from the
+    local source unless --package supplies pre-built ones. If a full spec
+    already declares an 'environment', wheel build/upload is skipped.
 
-    Configuration is loaded from bundled defaults and can be overridden
-    with --config file or individual CLI options.
-
-    When --use-local-source is provided, the local source files (*.py, README.md,
-    connector_spec.yaml) are uploaded to sources/{source_name} in the workspace.
+    Workspace mode: either --connection-name or --pipeline-spec must be
+    provided; when --package is given the uploaded wheels are used and no repo
+    is cloned; otherwise a Git repo is cloned into the workspace.
 
     \b
     Example:
-        community-connector create_pipeline github my_github_pipeline -n my_conn
-        community-connector create_pipeline stripe my_stripe -n stripe_conn -c main
-        community-connector create_pipeline github my_pipeline -ps spec.yaml
-        community-connector create_pipeline github my_pipeline -p pkg1.whl -p pkg2.whl
-        community-connector create_pipeline github my_pipeline -n my_conn --use-local-source
+        # Managed ingestion (default):
+        community-connector create_pipeline github my_pipeline \\
+            -ps spec.yaml -n my_conn -c main -t raw
+        community-connector create_pipeline github my_pipeline \\
+            -ps full_pipeline.yaml
+        # Legacy workspace pipeline:
+        community-connector create_pipeline github my_pipeline \\
+            -n my_conn --use-workspace-pipeline
     """
     debug = ctx.obj.get("debug", False)
+
+    if not use_workspace_pipeline:
+        _create_managed_pipeline_cmd(
+            pipeline_name=pipeline_name,
+            source_name=source_name,
+            pipeline_spec_input=pipeline_spec_input,
+            connection_name=connection_name,
+            catalog=catalog,
+            schema=schema,
+            volume_path=volume_path,
+            package_paths=package_paths,
+            debug=debug,
+        )
+        return
 
     if not connection_name and not pipeline_spec_input:
         raise click.ClickException(
@@ -1705,6 +1971,50 @@ def _print_pipeline_success(workspace_client, pipeline_id: str) -> None:
     click.echo("\nNote: Run the pipeline to apply the new configuration.")
 
 
+# pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+def _update_managed_pipeline_cmd(
+    pipeline_name: str,
+    source_name: Optional[str],
+    pipeline_spec_input: Optional[str],
+    connection_name: Optional[str],
+    catalog: Optional[str],
+    schema: Optional[str],
+    volume_path: Optional[str],
+    package_paths: tuple,
+    debug: bool,
+) -> None:
+    """Update a managed ingestion pipeline (default mode of update_pipeline)."""
+    if not pipeline_spec_input:
+        raise click.ClickException(
+            "--pipeline-spec is required for managed ingestion pipelines. "
+            "Pass --use-workspace-pipeline for the legacy workspace mode."
+        )
+
+    click.echo(f"Updating managed ingestion pipeline: {pipeline_name}")
+    spec = _parse_managed_pipeline_spec(pipeline_spec_input)
+
+    workspace_client = _make_workspace_client()
+    try:
+        pipeline_id = _find_pipeline_by_name(workspace_client, pipeline_name)
+        click.echo(f"  ✓ Found pipeline ID: {pipeline_id}")
+
+        body = _build_managed_pipeline_body(
+            workspace_client, spec, pipeline_name, source_name, connection_name,
+            catalog, schema, volume_path, package_paths, debug,
+        )
+
+        click.echo("\nUpdating pipeline...")
+        _update_managed_pipeline(workspace_client, pipeline_id, body, debug)
+        click.echo("  ✓ Pipeline updated!")
+        _print_pipeline_success(workspace_client, pipeline_id)
+    except click.ClickException:
+        raise
+    except Exception as e:
+        if debug:
+            click.echo(f"\n[DEBUG] Full exception: {traceback.format_exc()}", err=True)
+        raise click.ClickException(f"Failed to update pipeline: {e}")
+
+
 def _update_ingest_from_spec(
     workspace_client, pipeline_info, pipeline_spec_input: str, debug: bool,
 ) -> None:
@@ -1791,32 +2101,86 @@ def _upload_packages_for_update(
     help="Path to a local connector python wheel package. Can be specified multiple times. "
     "If provided, packages are uploaded and the pipeline is updated to use them.",
 )
+@click.option(
+    "--source-name",
+    "-s",
+    "source_name",
+    default=None,
+    help="Connector source name, used to build wheels in managed mode.",
+)
+@click.option("--connection-name", "-n", "connection_name", default=None,
+              help="UC connection name (managed mode).")
+@click.option("--catalog", "-c", default=None, help="UC target catalog (managed mode).")
+@click.option("--schema", "-t", default=None, help="Target schema (managed mode).")
+@click.option(
+    "--volume-path",
+    "-v",
+    "volume_path",
+    default=None,
+    help="UC Volume directory for the connector wheels in managed mode. "
+    "Defaults to /Volumes/<catalog>/<schema>/community_connector/packages.",
+)
+@click.option(
+    "--use-workspace-pipeline",
+    "use_workspace_pipeline",
+    is_flag=True,
+    default=False,
+    help="Use the legacy workspace pipeline mode (update ingest.py / packages) "
+    "instead of the default managed ingestion pipeline.",
+)
 @click.pass_context
+# pylint: disable=too-many-arguments,too-many-positional-arguments
 def update_pipeline(
     ctx: click.Context,
     pipeline_name: str,
     pipeline_spec_input: Optional[str],
     package_paths: tuple,
+    source_name: Optional[str],
+    connection_name: Optional[str],
+    catalog: Optional[str],
+    schema: Optional[str],
+    volume_path: Optional[str],
+    use_workspace_pipeline: bool,
 ):
     """
     Update an existing community connector pipeline.
 
     PIPELINE_NAME is the name of the pipeline to update.
 
-    When --pipeline-spec is provided, the ingest.py file is updated with the
-    new spec. When --package is provided, packages are uploaded and the pipeline
-    dependencies are updated. Both can be used together or independently.
+    By default this updates a *managed ingestion* pipeline: --pipeline-spec is
+    rebuilt into the pipeline's ingestion_definition and the connector wheels
+    are rebuilt/uploaded (unless a full spec already declares an
+    'environment'). Pass --use-workspace-pipeline for the legacy mode that
+    rewrites ingest.py and/or updates package dependencies.
 
-    At least one of --pipeline-spec or --package must be provided.
+    Managed mode requires --pipeline-spec. Legacy mode requires at least one of
+    --pipeline-spec or --package.
 
     \b
     Example:
-        community-connector update_pipeline my_pipeline -ps spec.yaml
-        community-connector update_pipeline my_pipeline -p connector.whl
-        community-connector update_pipeline my_pipeline -p a.whl -p b.whl
-        community-connector update_pipeline my_pipeline -ps spec.yaml -p pkg.whl
+        # Managed ingestion (default):
+        community-connector update_pipeline my_pipeline -ps spec.yaml -s github
+        # Legacy workspace pipeline:
+        community-connector update_pipeline my_pipeline -ps spec.yaml \\
+            --use-workspace-pipeline
+        community-connector update_pipeline my_pipeline -p connector.whl \\
+            --use-workspace-pipeline
     """
     debug = ctx.obj.get("debug", False)
+
+    if not use_workspace_pipeline:
+        _update_managed_pipeline_cmd(
+            pipeline_name=pipeline_name,
+            source_name=source_name,
+            pipeline_spec_input=pipeline_spec_input,
+            connection_name=connection_name,
+            catalog=catalog,
+            schema=schema,
+            volume_path=volume_path,
+            package_paths=package_paths,
+            debug=debug,
+        )
+        return
 
     if not pipeline_spec_input and not package_paths:
         raise click.ClickException(

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -1677,14 +1677,24 @@ def _create_managed_pipeline_cmd(
     debug: bool,
 ) -> None:
     """Create a managed ingestion pipeline (default mode of create_pipeline)."""
-    if not pipeline_spec_input:
+    if not pipeline_spec_input and not connection_name:
         raise click.ClickException(
-            "--pipeline-spec is required for managed ingestion pipelines. "
-            "Pass --use-workspace-pipeline for the legacy workspace mode."
+            "Either --pipeline-spec or --connection-name must be provided for "
+            "managed ingestion pipelines. Pass --use-workspace-pipeline for the "
+            "legacy workspace mode."
         )
 
     click.echo(f"Creating managed ingestion pipeline: {pipeline_name}")
-    spec = _parse_managed_pipeline_spec(pipeline_spec_input)
+    if pipeline_spec_input:
+        spec = _parse_managed_pipeline_spec(pipeline_spec_input)
+    else:
+        # No spec: create an empty ingestion pipeline (connection only, no
+        # objects). Tables can be added later with update_pipeline.
+        click.echo(
+            "  No --pipeline-spec given; creating an empty pipeline "
+            "(no tables) from --connection-name."
+        )
+        spec = {"connection_name": connection_name, "objects": []}
 
     workspace_client = _make_workspace_client()
     body = _build_managed_pipeline_body(
@@ -1812,11 +1822,14 @@ def create_pipeline(
     --use-workspace-pipeline for the legacy mode that clones the repo into the
     workspace and runs ingest.py.
 
-    Managed mode: --pipeline-spec is required and may be either a bare
-    ingestion definition (connection_name + objects) or a full pipeline spec
-    (containing an 'ingestion_definition' block). Wheels are built from the
-    local source unless --package supplies pre-built ones. If a full spec
-    already declares an 'environment', wheel build/upload is skipped.
+    Managed mode: provide either --pipeline-spec or --connection-name.
+    --pipeline-spec may be a bare ingestion definition (connection_name +
+    objects) or a full pipeline spec (containing an 'ingestion_definition'
+    block). With only --connection-name (no spec) an empty pipeline is created
+    (a connection but no tables) that you can populate later with
+    update_pipeline. Wheels are built from the local source unless --package
+    supplies pre-built ones. If a full spec already declares an 'environment',
+    wheel build/upload is skipped.
 
     Workspace mode: either --connection-name or --pipeline-spec must be
     provided; when --package is given the uploaded wheels are used and no repo
@@ -1829,6 +1842,9 @@ def create_pipeline(
             -ps spec.yaml -n my_conn -c main -t raw
         community-connector create_pipeline github my_pipeline \\
             -ps full_pipeline.yaml
+        # Empty managed pipeline (add tables later):
+        community-connector create_pipeline github my_pipeline \\
+            -n my_conn -c main -t raw
         # Legacy workspace pipeline:
         community-connector create_pipeline github my_pipeline \\
             -n my_conn --use-workspace-pipeline

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -615,6 +615,9 @@ def _parse_pipeline_spec(spec_input: str, validate: bool = True) -> dict:
         except json.JSONDecodeError as e:
             raise click.ClickException(f"Invalid JSON for --pipeline-spec: {e}")
 
+    if not isinstance(spec, dict):
+        raise click.ClickException("Pipeline spec must be a JSON/YAML object")
+
     # Validate the spec (connection_name is always required in spec)
     if validate:
         try:
@@ -1424,31 +1427,12 @@ _MANAGED_DEFAULT_SERVERLESS = True
 def _parse_managed_pipeline_spec(spec_input: str) -> dict:
     """Parse a managed-mode spec from a JSON string or .yaml/.json file.
 
-    Unlike ``_parse_pipeline_spec`` this does not run the friendly-spec
-    validator: a managed spec is either a bare ``ingestion_definition`` (whose
+    Unlike the default call, this does not run the friendly-spec validator: a
+    managed spec is either a bare ``ingestion_definition`` (whose
     connection_name may come from ``--connection-name`` rather than the file) or
     a full pipeline object, neither of which matches that validator's shape.
     """
-    if spec_input.endswith((".yaml", ".yml", ".json")):
-        try:
-            with open(spec_input, "r") as f:
-                if spec_input.endswith(".json"):
-                    spec = json.load(f)
-                else:
-                    spec = yaml.safe_load(f)
-        except FileNotFoundError:
-            raise click.ClickException(f"Pipeline spec file not found: {spec_input}")
-        except Exception as e:
-            raise click.ClickException(f"Failed to parse pipeline spec file: {e}")
-    else:
-        try:
-            spec = json.loads(spec_input)
-        except json.JSONDecodeError as e:
-            raise click.ClickException(f"Invalid JSON for --pipeline-spec: {e}")
-
-    if not isinstance(spec, dict):
-        raise click.ClickException("Pipeline spec must be a JSON/YAML object")
-    return spec
+    return _parse_pipeline_spec(spec_input, validate=False)
 
 
 def _resolve_managed_dest_dir(

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -1510,23 +1510,35 @@ def _build_and_upload_managed_wheels(  # pylint: disable=too-many-arguments,too-
             shutil.rmtree(cleanup_dir, ignore_errors=True)
 
 
-def _existing_pipeline_dependencies(
+def _get_existing_pipeline_spec(
     workspace_client, pipeline_id: str, debug: bool
-) -> Optional[List[str]]:
-    """Return the existing pipeline's ``environment.dependencies``, or None.
+) -> Optional[dict]:
+    """Return the existing pipeline's spec as a plain dict, or None.
 
-    Used on update when the caller does not ask to rebuild wheels, so the
-    pipeline keeps the connector packages it was already pointing at.
+    Used on update: the pipelines PUT is a full-settings replace, so we merge
+    the managed fields onto this existing spec to preserve everything the CLI
+    does not manage (tags, notifications, budget policy, channel, serverless,
+    existing dependencies, …) instead of wiping it.
     """
     try:
         pipeline_info = workspace_client.pipelines.get(pipeline_id)
     except Exception as e:  # pragma: no cover - network/permission errors
         raise click.ClickException(f"Failed to read existing pipeline: {e}")
     spec = getattr(pipeline_info, "spec", None)
-    environment = getattr(spec, "environment", None) if spec else None
-    dependencies = getattr(environment, "dependencies", None) if environment else None
+    if spec is None:
+        return None
+    spec_dict = spec.as_dict() if hasattr(spec, "as_dict") else dict(spec)
     if debug:
-        click.echo(f"[DEBUG] Existing pipeline dependencies: {dependencies}")
+        click.echo(f"[DEBUG] Existing pipeline spec: {spec_dict}")
+    return spec_dict
+
+
+def _dependencies_from_spec(spec_dict: Optional[dict]) -> Optional[List[str]]:
+    """Extract ``environment.dependencies`` from an existing pipeline spec dict."""
+    if not spec_dict:
+        return None
+    environment = spec_dict.get("environment")
+    dependencies = environment.get("dependencies") if isinstance(environment, dict) else None
     return list(dependencies) if dependencies else None
 
 
@@ -1580,7 +1592,12 @@ def _create_managed_pipeline(workspace_client, body: dict, debug: bool) -> str:
     response = workspace_client.api_client.do(
         "POST", "/api/2.0/pipelines", body=body
     )
-    return response.get("pipeline_id")
+    pipeline_id = (response or {}).get("pipeline_id")
+    if not pipeline_id:
+        raise click.ClickException(
+            f"Pipeline create API returned no pipeline_id. Response: {response}"
+        )
+    return pipeline_id
 
 
 def _update_managed_pipeline(
@@ -1595,19 +1612,24 @@ def _update_managed_pipeline(
     )
 
 
-def _resolve_managed_catalog_schema(
+def _resolve_managed_catalog_schema(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     spec: dict, is_full: bool, catalog: Optional[str], schema: Optional[str],
+    base_spec: Optional[dict] = None,
 ) -> Tuple[Optional[str], Optional[str]]:
     """Resolve the effective catalog/schema for a managed pipeline.
 
-    An explicit ``--catalog``/``--schema`` wins. Otherwise, for a full pipeline
-    spec, fall back to the spec's top-level ``catalog``/``schema`` so the wheel
-    volume and any backfilled destinations track what the user declared rather
-    than defaulting to ``main``/``default``.
+    Precedence: explicit ``--catalog``/``--schema`` win; then, for a full
+    pipeline spec, the spec's top-level ``catalog``/``schema``; then the
+    existing pipeline's ``catalog``/``schema`` on update (``base_spec``). This
+    keeps the wheel volume and per-object destination backfill tracking real
+    values rather than defaulting to ``main``/``default`` or dropping them.
     """
     if is_full:
         catalog = catalog or spec.get("catalog")
         schema = schema or spec.get("schema")
+    if base_spec:
+        catalog = catalog or base_spec.get("catalog")
+        schema = schema or base_spec.get("schema")
     return catalog, schema
 
 
@@ -1616,9 +1638,15 @@ def _build_managed_pipeline_body(
     workspace_client, spec: dict, pipeline_name: Optional[str], source_name: Optional[str],
     connection_name: Optional[str], catalog: Optional[str], schema: Optional[str],
     volume_path: Optional[str], package_paths: tuple, debug: bool,
-    build_wheels: bool = True, existing_dependencies: Optional[List[str]] = None,
+    build_wheels: bool = True, base_spec: Optional[dict] = None,
 ) -> dict:
-    """Build the full managed-ingestion pipeline body (bare or full spec)."""
+    """Build the full managed-ingestion pipeline body (bare or full spec).
+
+    ``base_spec`` is the existing pipeline spec on update (None on create). For
+    a bare spec it is the merge base so the full-replace PUT preserves unmanaged
+    fields; for either shape it supplies catalog/schema and dependency
+    fallbacks.
+    """
     is_full = is_full_pipeline_spec(spec)
     if not is_full:
         try:
@@ -1626,21 +1654,28 @@ def _build_managed_pipeline_body(
         except ManagedPipelineSpecError as e:
             raise click.ClickException(f"Invalid ingestion definition: {e}")
 
-    catalog, schema = _resolve_managed_catalog_schema(spec, is_full, catalog, schema)
+    catalog, schema = _resolve_managed_catalog_schema(
+        spec, is_full, catalog, schema, base_spec
+    )
 
     dependencies = _managed_dependencies(
         workspace_client, spec, is_full, source_name,
         volume_path, catalog, schema, package_paths, debug,
-        build_wheels=build_wheels, existing_dependencies=existing_dependencies,
+        build_wheels=build_wheels,
+        existing_dependencies=_dependencies_from_spec(base_spec),
     )
 
     if is_full:
         return augment_full_pipeline_body(
             spec, pipeline_name, connection_name, catalog, schema, dependencies,
         )
+    # On update (base_spec set) omit the managed channel/serverless defaults so
+    # the pipeline's existing values are preserved by the merge.
     return build_bare_pipeline_body(
         spec, pipeline_name, connection_name, catalog, schema, dependencies,
-        channel=_MANAGED_DEFAULT_CHANNEL, serverless=_MANAGED_DEFAULT_SERVERLESS,
+        channel=None if base_spec else _MANAGED_DEFAULT_CHANNEL,
+        serverless=None if base_spec else _MANAGED_DEFAULT_SERVERLESS,
+        base=base_spec,
     )
 
 
@@ -1698,16 +1733,21 @@ def _create_managed_pipeline_cmd(
 
     workspace_client = _make_workspace_client()
     body = _build_managed_pipeline_body(
-        workspace_client, spec, pipeline_name, source_name, connection_name,
-        catalog, schema, volume_path, package_paths, debug,
+        workspace_client, spec,
+        pipeline_name=pipeline_name, source_name=source_name,
+        connection_name=connection_name, catalog=catalog, schema=schema,
+        volume_path=volume_path, package_paths=package_paths, debug=debug,
     )
 
     click.echo("\nCreating pipeline...")
     try:
         pipeline_id = _create_managed_pipeline(workspace_client, body, debug)
+    except click.ClickException:
+        raise
     except Exception as e:
-        _handle_api_error(e, "create pipeline for", debug)
-        return
+        if debug:
+            click.echo(f"\n[DEBUG] Full exception: {traceback.format_exc()}", err=True)
+        raise click.ClickException(f"Failed to create pipeline: {e}")
     click.echo("  ✓ Pipeline created!")
     _print_pipeline_url(workspace_client, pipeline_id)
 
@@ -2066,19 +2106,22 @@ def _update_managed_pipeline_cmd(
         pipeline_id = _find_pipeline_by_name(workspace_client, pipeline_name)
         click.echo(f"  ✓ Found pipeline ID: {pipeline_id}")
 
-        # On update, only rebuild wheels when the caller asked for it via
-        # --source-name or --package. Otherwise reuse the pipeline's existing
-        # environment.dependencies so the packages are left untouched.
+        # Fetch the existing spec so the full-replace PUT preserves unmanaged
+        # fields (tags, notifications, budget, channel, serverless, …) and so
+        # catalog/schema/dependencies fall back to the live pipeline.
+        base_spec = _get_existing_pipeline_spec(workspace_client, pipeline_id, debug)
+
+        # Only rebuild wheels when the caller asked for it via --source-name or
+        # --package; otherwise the existing dependencies (from base_spec) are
+        # reused so the packages are left untouched.
         build_wheels = bool(source_name or package_paths)
-        existing_dependencies = (
-            None if build_wheels
-            else _existing_pipeline_dependencies(workspace_client, pipeline_id, debug)
-        )
 
         body = _build_managed_pipeline_body(
-            workspace_client, spec, pipeline_name, source_name, connection_name,
-            catalog, schema, volume_path, package_paths, debug,
-            build_wheels=build_wheels, existing_dependencies=existing_dependencies,
+            workspace_client, spec,
+            pipeline_name=pipeline_name, source_name=source_name,
+            connection_name=connection_name, catalog=catalog, schema=schema,
+            volume_path=volume_path, package_paths=package_paths, debug=debug,
+            build_wheels=build_wheels, base_spec=base_spec,
         )
 
         click.echo("\nUpdating pipeline...")

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -1510,17 +1510,42 @@ def _build_and_upload_managed_wheels(  # pylint: disable=too-many-arguments,too-
             shutil.rmtree(cleanup_dir, ignore_errors=True)
 
 
-def _managed_dependencies(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+def _existing_pipeline_dependencies(
+    workspace_client, pipeline_id: str, debug: bool
+) -> Optional[List[str]]:
+    """Return the existing pipeline's ``environment.dependencies``, or None.
+
+    Used on update when the caller does not ask to rebuild wheels, so the
+    pipeline keeps the connector packages it was already pointing at.
+    """
+    try:
+        pipeline_info = workspace_client.pipelines.get(pipeline_id)
+    except Exception as e:  # pragma: no cover - network/permission errors
+        raise click.ClickException(f"Failed to read existing pipeline: {e}")
+    spec = getattr(pipeline_info, "spec", None)
+    environment = getattr(spec, "environment", None) if spec else None
+    dependencies = getattr(environment, "dependencies", None) if environment else None
+    if debug:
+        click.echo(f"[DEBUG] Existing pipeline dependencies: {dependencies}")
+    return list(dependencies) if dependencies else None
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def _managed_dependencies(
     workspace_client, spec: dict, is_full: bool, source_name: Optional[str],
     volume_path: Optional[str], catalog: Optional[str], schema: Optional[str],
     package_paths: tuple, debug: bool,
+    build_wheels: bool = True, existing_dependencies: Optional[List[str]] = None,
 ) -> Optional[List[str]]:
     """Decide whether to build/upload wheels and return their volume paths.
 
-    A full spec that already declares an ``environment`` block is left untouched
-    (the user handles dependencies), so no build/upload happens and ``None`` is
-    returned. In every other case the connector wheels are uploaded and their
-    paths returned for ``environment.dependencies``.
+    - A full spec that already declares an ``environment`` block is left
+      untouched (the user handles dependencies): returns ``None``.
+    - When ``build_wheels`` is False (update with no ``--source-name`` /
+      ``--package``), the connector wheels are not rebuilt and the existing
+      pipeline dependencies are reused instead.
+    - Otherwise the connector wheels are built/uploaded and their paths returned
+      for ``environment.dependencies``.
     """
     if is_full and "environment" in spec:
         click.echo(
@@ -1528,6 +1553,13 @@ def _managed_dependencies(  # pylint: disable=too-many-arguments,too-many-positi
             "skipping wheel build/upload."
         )
         return None
+
+    if not build_wheels:
+        click.echo(
+            "\nNo --source-name or --package given; reusing the pipeline's "
+            "existing connector packages."
+        )
+        return existing_dependencies
 
     dest_dir = _resolve_managed_dest_dir(
         workspace_client, volume_path, catalog, schema, debug
@@ -1584,6 +1616,7 @@ def _build_managed_pipeline_body(
     workspace_client, spec: dict, pipeline_name: Optional[str], source_name: Optional[str],
     connection_name: Optional[str], catalog: Optional[str], schema: Optional[str],
     volume_path: Optional[str], package_paths: tuple, debug: bool,
+    build_wheels: bool = True, existing_dependencies: Optional[List[str]] = None,
 ) -> dict:
     """Build the full managed-ingestion pipeline body (bare or full spec)."""
     is_full = is_full_pipeline_spec(spec)
@@ -1598,6 +1631,7 @@ def _build_managed_pipeline_body(
     dependencies = _managed_dependencies(
         workspace_client, spec, is_full, source_name,
         volume_path, catalog, schema, package_paths, debug,
+        build_wheels=build_wheels, existing_dependencies=existing_dependencies,
     )
 
     if is_full:
@@ -2016,9 +2050,19 @@ def _update_managed_pipeline_cmd(
         pipeline_id = _find_pipeline_by_name(workspace_client, pipeline_name)
         click.echo(f"  ✓ Found pipeline ID: {pipeline_id}")
 
+        # On update, only rebuild wheels when the caller asked for it via
+        # --source-name or --package. Otherwise reuse the pipeline's existing
+        # environment.dependencies so the packages are left untouched.
+        build_wheels = bool(source_name or package_paths)
+        existing_dependencies = (
+            None if build_wheels
+            else _existing_pipeline_dependencies(workspace_client, pipeline_id, debug)
+        )
+
         body = _build_managed_pipeline_body(
             workspace_client, spec, pipeline_name, source_name, connection_name,
             catalog, schema, volume_path, package_paths, debug,
+            build_wheels=build_wheels, existing_dependencies=existing_dependencies,
         )
 
         click.echo("\nUpdating pipeline...")

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -1563,6 +1563,22 @@ def _update_managed_pipeline(
     )
 
 
+def _resolve_managed_catalog_schema(
+    spec: dict, is_full: bool, catalog: Optional[str], schema: Optional[str],
+) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve the effective catalog/schema for a managed pipeline.
+
+    An explicit ``--catalog``/``--schema`` wins. Otherwise, for a full pipeline
+    spec, fall back to the spec's top-level ``catalog``/``schema`` so the wheel
+    volume and any backfilled destinations track what the user declared rather
+    than defaulting to ``main``/``default``.
+    """
+    if is_full:
+        catalog = catalog or spec.get("catalog")
+        schema = schema or spec.get("schema")
+    return catalog, schema
+
+
 # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
 def _build_managed_pipeline_body(
     workspace_client, spec: dict, pipeline_name: Optional[str], source_name: Optional[str],
@@ -1576,6 +1592,8 @@ def _build_managed_pipeline_body(
             validate_ingestion_definition(spec)
         except ManagedPipelineSpecError as e:
             raise click.ClickException(f"Invalid ingestion definition: {e}")
+
+    catalog, schema = _resolve_managed_catalog_schema(spec, is_full, catalog, schema)
 
     dependencies = _managed_dependencies(
         workspace_client, spec, is_full, source_name,

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/managed_pipeline.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/managed_pipeline.py
@@ -141,6 +141,7 @@ def build_bare_pipeline_body(
     dependencies: Optional[List[str]],
     channel: Optional[str] = None,
     serverless: Optional[bool] = None,
+    base: Optional[dict] = None,
 ) -> dict:
     """Assemble a full pipeline body from a bare ingestion definition.
 
@@ -148,10 +149,21 @@ def build_bare_pipeline_body(
     schema, the managed-ingestion configuration flag, and the connector
     ``environment.dependencies`` are all filled in around the user's ingestion
     definition.
+
+    ``base`` is the existing pipeline spec to merge onto (update path). Because
+    the pipelines PUT is a full-settings replace, starting from the existing
+    spec preserves fields the CLI does not manage (tags, notifications, budget
+    policy, development/continuous, channel, serverless, …) instead of wiping
+    them. Managed fields below are overlaid on top. On create, ``base`` is None
+    and the body starts empty. A value already on ``base`` is only overwritten
+    when the corresponding argument is provided, so callers omit ``channel`` /
+    ``serverless`` on update to keep the pipeline's existing values.
     """
     ingestion_def = build_ingestion_definition(spec, connection_name, catalog, schema)
 
-    body: dict = {"name": pipeline_name, "ingestion_definition": ingestion_def}
+    body: dict = copy.deepcopy(base) if base else {}
+    body["name"] = pipeline_name
+    body["ingestion_definition"] = ingestion_def
     if catalog:
         body["catalog"] = catalog
     if schema:
@@ -161,10 +173,18 @@ def build_bare_pipeline_body(
     if serverless is not None:
         body["serverless"] = serverless
 
-    body["configuration"] = {REGISTER_PYTHON_DATA_SOURCE_KEY: "true"}
+    configuration = body.get("configuration")
+    if not isinstance(configuration, dict):
+        configuration = {}
+    configuration[REGISTER_PYTHON_DATA_SOURCE_KEY] = "true"
+    body["configuration"] = configuration
 
     if dependencies:
-        body["environment"] = {"dependencies": list(dependencies)}
+        environment = body.get("environment")
+        if not isinstance(environment, dict):
+            environment = {}
+        environment["dependencies"] = list(dependencies)
+        body["environment"] = environment
 
     return body
 

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/managed_pipeline.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/managed_pipeline.py
@@ -1,0 +1,214 @@
+"""Build managed-ingestion pipeline request bodies for community connectors.
+
+A *managed* ingestion pipeline sets the pipeline's ``ingestion_definition`` (the
+connection, the tables to replicate, and their per-source connector options)
+instead of pointing the pipeline at Python source files cloned into the
+workspace. The connector's Python packages are uploaded to a UC Volume and
+referenced from ``environment.dependencies`` so the serverless cluster installs
+them.
+
+The installed ``databricks-sdk`` cannot represent COMMUNITY managed ingestion:
+its ``IngestionSourceType`` enum has no ``COMMUNITY`` member and its
+``ConnectorOptions`` model has no ``community_connector_options`` field. So the
+bodies produced here are plain dicts, sent verbatim to
+``POST``/``PUT /api/2.0/pipelines`` via ``WorkspaceClient.api_client.do(...)``
+(the same raw-dict path the CLI already uses for the connections API).
+
+Two input shapes are supported, disambiguated by
+:func:`is_full_pipeline_spec`:
+
+* **bare** — the supplied spec *is* the ingestion definition
+  (``connection_name`` + ``objects`` at the top level). The CLI wraps it in a
+  full pipeline body and backfills the pieces the user did not spell out.
+* **full** — the supplied spec is a complete pipeline object that already
+  contains an ``ingestion_definition`` key. The CLI treats it as authoritative
+  and only adds the managed-ingestion ``configuration`` flag, the connector
+  ``environment`` (when absent), and any values passed explicitly on the CLI.
+"""
+
+import copy
+from typing import List, Optional
+
+SOURCE_TYPE_COMMUNITY = "COMMUNITY"
+"""IngestionSourceType value for community connectors (not in the SDK enum)."""
+
+REGISTER_PYTHON_DATA_SOURCE_KEY = "pipelines.managedIngestion.registerPythonDataSource"
+"""Pipeline configuration key that registers the connector's Python data source."""
+
+DEFAULT_SOURCE_SCHEMA = "default"
+"""Source schema assumed for community connectors when a table omits it."""
+
+
+class ManagedPipelineSpecError(Exception):
+    """Raised when a managed ingestion spec is structurally invalid."""
+
+
+def is_full_pipeline_spec(spec: dict) -> bool:
+    """Return True when ``spec`` is a full pipeline object, not a bare ingestion def.
+
+    A full pipeline spec carries a top-level ``ingestion_definition`` block
+    alongside pipeline fields (``name``, ``catalog``, ``configuration``, …). A
+    bare spec *is* the ingestion definition, so its ``objects`` /
+    ``connection_name`` live at the top level and there is no
+    ``ingestion_definition`` key.
+    """
+    return isinstance(spec, dict) and "ingestion_definition" in spec
+
+
+def validate_ingestion_definition(ingestion_def: dict) -> None:
+    """Light structural check for a bare ingestion definition.
+
+    Ensures there is a non-empty ``objects`` list and that each object selects a
+    source via ``table``, ``schema``, or ``report``. Everything else (connector
+    options, destinations) is passed through to the API verbatim.
+    """
+    if not isinstance(ingestion_def, dict):
+        raise ManagedPipelineSpecError("ingestion definition must be a mapping")
+
+    objects = ingestion_def.get("objects")
+    if not isinstance(objects, list) or not objects:
+        raise ManagedPipelineSpecError(
+            "ingestion definition must contain a non-empty 'objects' list"
+        )
+
+    for i, obj in enumerate(objects):
+        if not isinstance(obj, dict) or not any(
+            key in obj for key in ("table", "schema", "report")
+        ):
+            raise ManagedPipelineSpecError(
+                f"objects[{i}] must contain one of 'table', 'schema', or 'report'"
+            )
+
+
+def _backfill_destinations(
+    objects: list, catalog: Optional[str], schema: Optional[str]
+) -> None:
+    """Fill per-object destination catalog/schema (and source_schema) in place.
+
+    The pipelines API requires ``destination_catalog`` / ``destination_schema``
+    on every ``table`` / ``schema`` object. Rather than force the user to repeat
+    them on each object, we backfill from the pipeline-level catalog/schema. A
+    value already present on the object always wins.
+    """
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        for key in ("table", "schema"):
+            target = obj.get(key)
+            if not isinstance(target, dict):
+                continue
+            if catalog and not target.get("destination_catalog"):
+                target["destination_catalog"] = catalog
+            if schema and not target.get("destination_schema"):
+                target["destination_schema"] = schema
+        table = obj.get("table")
+        if isinstance(table, dict) and not table.get("source_schema"):
+            table["source_schema"] = DEFAULT_SOURCE_SCHEMA
+
+
+def build_ingestion_definition(
+    spec: dict,
+    connection_name: Optional[str],
+    catalog: Optional[str],
+    schema: Optional[str],
+) -> dict:
+    """Turn a bare spec into a COMMUNITY ingestion definition (copy, not in place).
+
+    Injects ``source_type: COMMUNITY`` and the connection name (unless the spec
+    already carries one), then backfills per-object destinations.
+    """
+    ingestion_def = copy.deepcopy(spec)
+    ingestion_def.setdefault("source_type", SOURCE_TYPE_COMMUNITY)
+    if connection_name and not ingestion_def.get("connection_name"):
+        ingestion_def["connection_name"] = connection_name
+
+    objects = ingestion_def.get("objects")
+    if isinstance(objects, list):
+        _backfill_destinations(objects, catalog, schema)
+
+    return ingestion_def
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def build_bare_pipeline_body(
+    spec: dict,
+    pipeline_name: str,
+    connection_name: Optional[str],
+    catalog: Optional[str],
+    schema: Optional[str],
+    dependencies: Optional[List[str]],
+    channel: Optional[str] = None,
+    serverless: Optional[bool] = None,
+) -> dict:
+    """Assemble a full pipeline body from a bare ingestion definition.
+
+    The bare mode is the CLI-driven convenience path: pipeline-level catalog /
+    schema, the managed-ingestion configuration flag, and the connector
+    ``environment.dependencies`` are all filled in around the user's ingestion
+    definition.
+    """
+    ingestion_def = build_ingestion_definition(spec, connection_name, catalog, schema)
+
+    body: dict = {"name": pipeline_name, "ingestion_definition": ingestion_def}
+    if catalog:
+        body["catalog"] = catalog
+    if schema:
+        body["schema"] = schema
+    if channel:
+        body["channel"] = channel
+    if serverless is not None:
+        body["serverless"] = serverless
+
+    body["configuration"] = {REGISTER_PYTHON_DATA_SOURCE_KEY: "true"}
+
+    if dependencies:
+        body["environment"] = {"dependencies": list(dependencies)}
+
+    return body
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def augment_full_pipeline_body(
+    spec: dict,
+    pipeline_name: Optional[str] = None,
+    connection_name: Optional[str] = None,
+    catalog: Optional[str] = None,
+    schema: Optional[str] = None,
+    dependencies: Optional[List[str]] = None,
+) -> dict:
+    """Return a copy of a full pipeline spec with the managed-ingestion additions.
+
+    The user's spec is authoritative; this only:
+
+    * ensures ``ingestion_definition.source_type`` is ``COMMUNITY``,
+    * adds the ``registerPythonDataSource`` configuration flag if not set,
+    * sets ``name`` / ``catalog`` / ``schema`` / ``connection_name`` from the
+      values passed on the CLI (each only when explicitly provided), and
+    * adds ``environment.dependencies`` only when the spec did not already
+      include an ``environment`` block.
+    """
+    body = copy.deepcopy(spec)
+
+    ingestion_def = body.get("ingestion_definition")
+    if isinstance(ingestion_def, dict):
+        ingestion_def.setdefault("source_type", SOURCE_TYPE_COMMUNITY)
+        if connection_name:
+            ingestion_def["connection_name"] = connection_name
+
+    if pipeline_name:
+        body["name"] = pipeline_name
+    if catalog:
+        body["catalog"] = catalog
+    if schema:
+        body["schema"] = schema
+
+    configuration = body.get("configuration")
+    if not isinstance(configuration, dict):
+        configuration = {}
+    configuration.setdefault(REGISTER_PYTHON_DATA_SOURCE_KEY, "true")
+    body["configuration"] = configuration
+
+    if "environment" not in body and dependencies:
+        body["environment"] = {"dependencies": list(dependencies)}
+
+    return body

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/managed_pipeline.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/managed_pipeline.py
@@ -43,6 +43,19 @@ class ManagedPipelineSpecError(Exception):
     """Raised when a managed ingestion spec is structurally invalid."""
 
 
+def _dict_field(body: dict, key: str) -> dict:
+    """Return ``body[key]`` as a dict, replacing a missing/non-dict value.
+
+    The returned dict is stored back on ``body`` so callers can mutate it in
+    place. Guards against a spec that carries a non-dict (e.g. null) at ``key``.
+    """
+    value = body.get(key)
+    if not isinstance(value, dict):
+        value = {}
+        body[key] = value
+    return value
+
+
 def is_full_pipeline_spec(spec: dict) -> bool:
     """Return True when ``spec`` is a full pipeline object, not a bare ingestion def.
 
@@ -173,18 +186,10 @@ def build_bare_pipeline_body(
     if serverless is not None:
         body["serverless"] = serverless
 
-    configuration = body.get("configuration")
-    if not isinstance(configuration, dict):
-        configuration = {}
-    configuration[REGISTER_PYTHON_DATA_SOURCE_KEY] = "true"
-    body["configuration"] = configuration
+    _dict_field(body, "configuration")[REGISTER_PYTHON_DATA_SOURCE_KEY] = "true"
 
     if dependencies:
-        environment = body.get("environment")
-        if not isinstance(environment, dict):
-            environment = {}
-        environment["dependencies"] = list(dependencies)
-        body["environment"] = environment
+        _dict_field(body, "environment")["dependencies"] = list(dependencies)
 
     return body
 
@@ -224,11 +229,7 @@ def augment_full_pipeline_body(
     if schema:
         body["schema"] = schema
 
-    configuration = body.get("configuration")
-    if not isinstance(configuration, dict):
-        configuration = {}
-    configuration.setdefault(REGISTER_PYTHON_DATA_SOURCE_KEY, "true")
-    body["configuration"] = configuration
+    _dict_field(body, "configuration").setdefault(REGISTER_PYTHON_DATA_SOURCE_KEY, "true")
 
     if "environment" not in body and dependencies:
         body["environment"] = {"dependencies": list(dependencies)}

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/managed_pipeline.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/managed_pipeline.py
@@ -58,18 +58,20 @@ def is_full_pipeline_spec(spec: dict) -> bool:
 def validate_ingestion_definition(ingestion_def: dict) -> None:
     """Light structural check for a bare ingestion definition.
 
-    Ensures there is a non-empty ``objects`` list and that each object selects a
-    source via ``table``, ``schema``, or ``report``. Everything else (connector
-    options, destinations) is passed through to the API verbatim.
+    ``objects`` may be absent or empty — that produces an "empty" managed
+    pipeline with a connection but no tables yet, which the user can populate
+    later. When ``objects`` is present it must be a list, and each object must
+    select a source via ``table``, ``schema``, or ``report``. Everything else
+    (connector options, destinations) is passed through to the API verbatim.
     """
     if not isinstance(ingestion_def, dict):
         raise ManagedPipelineSpecError("ingestion definition must be a mapping")
 
     objects = ingestion_def.get("objects")
-    if not isinstance(objects, list) or not objects:
-        raise ManagedPipelineSpecError(
-            "ingestion definition must contain a non-empty 'objects' list"
-        )
+    if objects is None:
+        return
+    if not isinstance(objects, list):
+        raise ManagedPipelineSpecError("'objects' must be a list")
 
     for i, obj in enumerate(objects):
         if not isinstance(obj, dict) or not any(

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -2578,6 +2578,38 @@ class TestManagedCreatePipeline:
     @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
     @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
     @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_managed_create_full_spec_catalog_schema_from_spec(
+        self, mock_ws_client, mock_dest_dir, mock_build_upload
+    ):
+        """When --catalog/--schema are omitted, the volume uses the spec's values."""
+        runner = CliRunner()
+        mock_ws = MagicMock()
+        mock_ws_client.return_value = mock_ws
+        mock_ws.config.host = "https://test.databricks.com"
+        mock_ws.api_client.do.return_value = {"pipeline_id": "pl-1"}
+        mock_dest_dir.return_value = "/Volumes/spec_cat/spec_sch/community_connector/packages"
+        mock_build_upload.return_value = ["/Volumes/spec_cat/spec_sch/community_connector/packages/w.whl"]
+
+        full_spec = (
+            '{"name": "p", "catalog": "spec_cat", "schema": "spec_sch", '
+            '"ingestion_definition": {"connection_name": "c", '
+            '"objects": [{"table": {"source_table": "t", '
+            '"destination_catalog": "spec_cat", "destination_schema": "spec_sch"}}]}}'
+        )
+        result = runner.invoke(
+            main, ["create_pipeline", "github", "my_pipeline", "-ps", full_spec]
+        )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        # Volume resolution is called with the spec's catalog/schema, not main/default.
+        # Positional args: (ws, volume_path, catalog, schema, debug)
+        call = mock_dest_dir.call_args
+        assert call.args[2] == "spec_cat"
+        assert call.args[3] == "spec_sch"
+
+    @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
+    @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
     def test_managed_update_uses_put(
         self, mock_ws_client, mock_dest_dir, mock_build_upload
     ):

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -203,7 +203,7 @@ class TestCreatePipelineCommand:
         with patch("databricks.labs.community_connector_cli.cli.WorkspaceClient"):
             result = runner.invoke(
                 main,
-                ['create_pipeline', 'github', 'my_pipeline'],
+                ['create_pipeline', 'github', 'my_pipeline', '--use-workspace-pipeline'],
             )
 
         assert result.exit_code != 0
@@ -241,7 +241,8 @@ class TestCreatePipelineCommand:
 
         result = runner.invoke(
             main,
-            ['create_pipeline', 'github', 'my_pipeline', '-n', 'my_conn'],
+            ['create_pipeline', 'github', 'my_pipeline', '-n', 'my_conn',
+             '--use-workspace-pipeline'],
         )
 
         # Should succeed (or at least pass the validation)
@@ -283,6 +284,7 @@ class TestCreatePipelineCommand:
                 [
                     'create_pipeline', 'github', 'my_pipeline',
                     '-n', 'my_conn', '--package', temp_pkg.name,
+                    '--use-workspace-pipeline',
                 ],
             )
 
@@ -338,7 +340,7 @@ class TestCreatePipelineCommand:
                 main,
                 [
                     'create_pipeline', 'github', 'my_pipeline', '-n', 'my_conn',
-                    '-p', pkg1.name, '-p', pkg2.name,
+                    '-p', pkg1.name, '-p', pkg2.name, '--use-workspace-pipeline',
                 ],
             )
 
@@ -380,7 +382,8 @@ class TestCreatePipelineCommand:
 
             result = runner.invoke(
                 main,
-                ['create_pipeline', 'github', 'my_pipeline', '-n', 'my_conn', '-p', temp_pkg.name],
+                ['create_pipeline', 'github', 'my_pipeline', '-n', 'my_conn', '-p', temp_pkg.name,
+                 '--use-workspace-pipeline'],
             )
 
             assert result.exit_code == 0, f"Exit code: {result.exit_code}\nOutput: {result.output}"
@@ -509,7 +512,8 @@ class TestCreatePipelineUseLocalSource:
 
         result = runner.invoke(
             main,
-            ['create_pipeline', 'github', 'my_pipeline', '-n', 'my_conn', '--use-local-source'],
+            ['create_pipeline', 'github', 'my_pipeline', '-n', 'my_conn', '--use-local-source',
+             '--use-workspace-pipeline'],
         )
 
         assert result.exit_code == 0, f"Exit code: {result.exit_code}\nOutput: {result.output}"
@@ -549,7 +553,8 @@ class TestCreatePipelineUseLocalSource:
 
         result = runner.invoke(
             main,
-            ['create_pipeline', 'github', 'my_pipeline', '-n', 'my_conn'],
+            ['create_pipeline', 'github', 'my_pipeline', '-n', 'my_conn',
+             '--use-workspace-pipeline'],
         )
 
         assert result.exit_code == 0, f"Exit code: {result.exit_code}\nOutput: {result.output}"
@@ -592,7 +597,7 @@ class TestCreatePipelineUseLocalSource:
                 main,
                 [
                     'create_pipeline', 'github', 'my_pipeline', '-n', 'my_conn',
-                    '-p', temp_pkg.name, '--use-local-source',
+                    '-p', temp_pkg.name, '--use-local-source', '--use-workspace-pipeline',
                 ],
             )
 
@@ -2146,7 +2151,7 @@ class TestUpdatePipelineCommand:
         with patch("databricks.labs.community_connector_cli.cli.WorkspaceClient"):
             result = runner.invoke(
                 main,
-                ["update_pipeline", "my_pipeline"],
+                ["update_pipeline", "my_pipeline", "--use-workspace-pipeline"],
             )
 
         assert result.exit_code != 0
@@ -2223,6 +2228,7 @@ class TestUpdatePipelineCommand:
                 "my_pipeline",
                 "-ps",
                 '{"connection_name": "my_conn", "objects": [{"table": {"source_table": "users"}}]}',
+                "--use-workspace-pipeline",
             ],
         )
 
@@ -2285,7 +2291,8 @@ class TestUpdatePipelineCommand:
                     '{"connection_name": "my_conn", '
                     '"objects": [{"table": {"source_table": "users"}}]}',
                     "--package",
-                    temp_pkg.name
+                    temp_pkg.name,
+                    "--use-workspace-pipeline",
                 ],
             )
 
@@ -2326,7 +2333,8 @@ class TestUpdatePipelineCommand:
 
             result = runner.invoke(
                 main,
-                ["update_pipeline", "my_pipeline", "-p", temp_pkg.name],
+                ["update_pipeline", "my_pipeline", "-p", temp_pkg.name,
+                 "--use-workspace-pipeline"],
             )
 
         assert result.exit_code == 0, f"Exit code: {result.exit_code}\nOutput: {result.output}"
@@ -2369,7 +2377,8 @@ class TestUpdatePipelineCommand:
 
             result = runner.invoke(
                 main,
-                ["update_pipeline", "my_pipeline", "-p", pkg1.name, "-p", pkg2.name],
+                ["update_pipeline", "my_pipeline", "-p", pkg1.name, "-p", pkg2.name,
+                 "--use-workspace-pipeline"],
             )
 
         assert result.exit_code == 0, f"Exit code: {result.exit_code}\nOutput: {result.output}"
@@ -2403,7 +2412,8 @@ class TestUpdatePipelineCommand:
                 "update_pipeline",
                 "my_pipeline",
                 "-ps",
-                '{"connection_name": "conn", "objects": []}',
+                '{"connection_name": "conn", "objects": [{"table": {"source_table": "t"}}]}',
+                "--use-workspace-pipeline",
             ],
         )
 
@@ -2443,7 +2453,8 @@ class TestUpdatePipelineCommand:
                 "update_pipeline",
                 "my_pipeline",
                 "-ps",
-                '{"connection_name": "conn", "objects": []}',
+                '{"connection_name": "conn", "objects": [{"table": {"source_table": "t"}}]}',
+                "--use-workspace-pipeline",
             ],
         )
 
@@ -2481,6 +2492,116 @@ objects:
                 assert "not found" in result.output
         finally:
             os.unlink(temp_path)
+
+
+class TestManagedCreatePipeline:
+    """Tests for the default (managed ingestion) create_pipeline mode."""
+
+    def _bare_spec(self):
+        return (
+            '{"connection_name": "my_conn", '
+            '"objects": [{"table": {"source_table": "commits"}}]}'
+        )
+
+    @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
+    @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_managed_create_bare_spec(
+        self, mock_ws_client, mock_dest_dir, mock_build_upload
+    ):
+        runner = CliRunner()
+        mock_ws = MagicMock()
+        mock_ws_client.return_value = mock_ws
+        mock_ws.config.host = "https://test.databricks.com"
+        mock_ws.api_client.do.return_value = {"pipeline_id": "pl-123"}
+        mock_dest_dir.return_value = "/Volumes/main/default/community_connector/packages"
+        mock_build_upload.return_value = ["/Volumes/main/default/community_connector/packages/w.whl"]
+
+        result = runner.invoke(
+            main,
+            ["create_pipeline", "github", "my_pipeline", "-ps", self._bare_spec(),
+             "-c", "cat", "-t", "sch"],
+        )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Pipeline created!" in result.output
+        # POST to the pipelines endpoint with a managed body.
+        args, kwargs = mock_ws.api_client.do.call_args
+        assert args[0] == "POST"
+        assert args[1] == "/api/2.0/pipelines"
+        body = kwargs["body"]
+        assert body["ingestion_definition"]["source_type"] == "COMMUNITY"
+        assert body["ingestion_definition"]["connection_name"] == "my_conn"
+        assert body["catalog"] == "cat"
+        assert body["configuration"][
+            "pipelines.managedIngestion.registerPythonDataSource"] == "true"
+        assert body["environment"]["dependencies"]
+
+    def test_managed_create_requires_spec(self):
+        runner = CliRunner()
+        with patch("databricks.labs.community_connector_cli.cli.WorkspaceClient"):
+            result = runner.invoke(
+                main, ["create_pipeline", "github", "my_pipeline", "-n", "conn"]
+            )
+        assert result.exit_code != 0
+        assert "--pipeline-spec is required" in result.output
+
+    @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
+    @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_managed_create_full_spec_with_environment_skips_upload(
+        self, mock_ws_client, mock_dest_dir, mock_build_upload
+    ):
+        runner = CliRunner()
+        mock_ws = MagicMock()
+        mock_ws_client.return_value = mock_ws
+        mock_ws.config.host = "https://test.databricks.com"
+        mock_ws.api_client.do.return_value = {"pipeline_id": "pl-9"}
+
+        full_spec = (
+            '{"name": "p", "catalog": "cat", "schema": "sch", '
+            '"ingestion_definition": {"connection_name": "c", '
+            '"objects": [{"table": {"source_table": "t", '
+            '"destination_catalog": "cat", "destination_schema": "sch"}}]}, '
+            '"environment": {"dependencies": ["/Volumes/x/y/z/pre.whl"]}}'
+        )
+        result = runner.invoke(
+            main, ["create_pipeline", "github", "my_pipeline", "-ps", full_spec]
+        )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        mock_build_upload.assert_not_called()
+        mock_dest_dir.assert_not_called()
+        body = mock_ws.api_client.do.call_args.kwargs["body"]
+        assert body["environment"]["dependencies"] == ["/Volumes/x/y/z/pre.whl"]
+
+    @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
+    @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_managed_update_uses_put(
+        self, mock_ws_client, mock_dest_dir, mock_build_upload
+    ):
+        runner = CliRunner()
+        mock_ws = MagicMock()
+        mock_ws_client.return_value = mock_ws
+        mock_ws.config.host = "https://test.databricks.com"
+        mock_pipeline_obj = MagicMock()
+        mock_pipeline_obj.pipeline_id = "pl-77"
+        mock_ws.pipelines.list_pipelines.return_value = [mock_pipeline_obj]
+        mock_dest_dir.return_value = "/Volumes/cat/sch/community_connector/packages"
+        mock_build_upload.return_value = ["/Volumes/cat/sch/community_connector/packages/w.whl"]
+
+        result = runner.invoke(
+            main,
+            ["update_pipeline", "my_pipeline", "-ps", self._bare_spec(),
+             "-s", "github", "-c", "cat", "-t", "sch"],
+        )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        args, kwargs = mock_ws.api_client.do.call_args
+        assert args[0] == "PUT"
+        assert args[1] == "/api/2.0/pipelines/pl-77"
+        assert kwargs["body"]["id"] == "pl-77"
 
 
 def _make_fake_wheel(path: Path, source_name: str) -> Path:

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -2636,6 +2636,13 @@ class TestManagedCreatePipeline:
         assert call.args[2] == "spec_cat"
         assert call.args[3] == "spec_sch"
 
+    @staticmethod
+    def _mock_get_with_spec(mock_ws, spec_dict):
+        """Wire pipelines.get(...) to return a spec whose as_dict() == spec_dict."""
+        mock_info = MagicMock()
+        mock_info.spec.as_dict.return_value = spec_dict
+        mock_ws.pipelines.get.return_value = mock_info
+
     @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
     @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
     @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
@@ -2649,6 +2656,7 @@ class TestManagedCreatePipeline:
         mock_pipeline_obj = MagicMock()
         mock_pipeline_obj.pipeline_id = "pl-77"
         mock_ws.pipelines.list_pipelines.return_value = [mock_pipeline_obj]
+        self._mock_get_with_spec(mock_ws, {"name": "my_pipeline", "catalog": "cat"})
         mock_dest_dir.return_value = "/Volumes/cat/sch/community_connector/packages"
         mock_build_upload.return_value = ["/Volumes/cat/sch/community_connector/packages/w.whl"]
 
@@ -2681,9 +2689,10 @@ class TestManagedCreatePipeline:
 
         # Existing pipeline already points at wheels on a volume.
         existing = ["/Volumes/cat/sch/community_connector/packages/existing.whl"]
-        mock_info = MagicMock()
-        mock_info.spec.environment.dependencies = existing
-        mock_ws.pipelines.get.return_value = mock_info
+        self._mock_get_with_spec(mock_ws, {
+            "catalog": "cat", "schema": "sch",
+            "environment": {"dependencies": existing},
+        })
 
         result = runner.invoke(
             main,
@@ -2697,6 +2706,70 @@ class TestManagedCreatePipeline:
         # Existing dependencies are carried into the new body.
         body = mock_ws.api_client.do.call_args.kwargs["body"]
         assert body["environment"]["dependencies"] == existing
+
+    @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
+    @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_managed_update_bare_spec_preserves_existing_settings(
+        self, mock_ws_client, mock_dest_dir, mock_build_upload
+    ):
+        """A bare-spec update must merge onto the existing spec (full-replace PUT).
+
+        Unmanaged fields (tags, notifications, channel, serverless) and
+        catalog/schema must survive even when the CLI options omit them.
+        """
+        runner = CliRunner()
+        mock_ws = MagicMock()
+        mock_ws_client.return_value = mock_ws
+        mock_ws.config.host = "https://test.databricks.com"
+        mock_pipeline_obj = MagicMock()
+        mock_pipeline_obj.pipeline_id = "pl-99"
+        mock_ws.pipelines.list_pipelines.return_value = [mock_pipeline_obj]
+        mock_dest_dir.return_value = "/Volumes/livecat/livesch/community_connector/packages"
+        mock_build_upload.return_value = ["/Volumes/livecat/livesch/community_connector/packages/w.whl"]
+
+        # Live pipeline has settings the CLI does not manage plus CURRENT channel.
+        self._mock_get_with_spec(mock_ws, {
+            "name": "my_pipeline",
+            "catalog": "livecat",
+            "schema": "livesch",
+            "channel": "CURRENT",
+            "serverless": False,
+            "tags": {"team": "data"},
+            "notifications": [{"email_recipients": ["a@b.com"]}],
+            "budget_policy_id": "bp-1",
+            "environment": {"dependencies": ["/Volumes/old/old/old/old.whl"]},
+        })
+
+        # Rebuild wheels (-s) but omit -c/-t, channel, serverless.
+        result = runner.invoke(
+            main,
+            ["update_pipeline", "my_pipeline", "-ps", self._bare_spec(), "-s", "github"],
+        )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        body = mock_ws.api_client.do.call_args.kwargs["body"]
+        # Unmanaged fields preserved.
+        assert body["tags"] == {"team": "data"}
+        assert body["notifications"] == [{"email_recipients": ["a@b.com"]}]
+        assert body["budget_policy_id"] == "bp-1"
+        # Existing channel/serverless not overridden by managed defaults.
+        assert body["channel"] == "CURRENT"
+        assert body["serverless"] is False
+        # catalog/schema fall back to the live pipeline's values.
+        assert body["catalog"] == "livecat"
+        assert body["schema"] == "livesch"
+        # Managed additions still applied.
+        assert body["configuration"][
+            "pipelines.managedIngestion.registerPythonDataSource"] == "true"
+        assert body["ingestion_definition"]["source_type"] == "COMMUNITY"
+        # Rebuilt wheels replace the old dependencies.
+        assert body["environment"]["dependencies"] == [
+            "/Volumes/livecat/livesch/community_connector/packages/w.whl"]
+        # Per-table destinations backfilled from the live catalog/schema.
+        table = body["ingestion_definition"]["objects"][0]["table"]
+        assert table["destination_catalog"] == "livecat"
+        assert table["destination_schema"] == "livesch"
 
 
 def _make_fake_wheel(path: Path, source_name: str) -> Path:

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -2515,7 +2515,8 @@ class TestManagedCreatePipeline:
         mock_ws.config.host = "https://test.databricks.com"
         mock_ws.api_client.do.return_value = {"pipeline_id": "pl-123"}
         mock_dest_dir.return_value = "/Volumes/main/default/community_connector/packages"
-        mock_build_upload.return_value = ["/Volumes/main/default/community_connector/packages/w.whl"]
+        mock_build_upload.return_value = [
+            "/Volumes/main/default/community_connector/packages/w.whl"]
 
         result = runner.invoke(
             main,
@@ -2617,7 +2618,8 @@ class TestManagedCreatePipeline:
         mock_ws.config.host = "https://test.databricks.com"
         mock_ws.api_client.do.return_value = {"pipeline_id": "pl-1"}
         mock_dest_dir.return_value = "/Volumes/spec_cat/spec_sch/community_connector/packages"
-        mock_build_upload.return_value = ["/Volumes/spec_cat/spec_sch/community_connector/packages/w.whl"]
+        mock_build_upload.return_value = [
+            "/Volumes/spec_cat/spec_sch/community_connector/packages/w.whl"]
 
         full_spec = (
             '{"name": "p", "catalog": "spec_cat", "schema": "spec_sch", '
@@ -2726,7 +2728,8 @@ class TestManagedCreatePipeline:
         mock_pipeline_obj.pipeline_id = "pl-99"
         mock_ws.pipelines.list_pipelines.return_value = [mock_pipeline_obj]
         mock_dest_dir.return_value = "/Volumes/livecat/livesch/community_connector/packages"
-        mock_build_upload.return_value = ["/Volumes/livecat/livesch/community_connector/packages/w.whl"]
+        mock_build_upload.return_value = [
+            "/Volumes/livecat/livesch/community_connector/packages/w.whl"]
 
         # Live pipeline has settings the CLI does not manage plus CURRENT channel.
         self._mock_get_with_spec(mock_ws, {

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -2635,6 +2635,40 @@ class TestManagedCreatePipeline:
         assert args[1] == "/api/2.0/pipelines/pl-77"
         assert kwargs["body"]["id"] == "pl-77"
 
+    @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
+    @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_managed_update_no_source_reuses_existing_deps(
+        self, mock_ws_client, mock_dest_dir, mock_build_upload
+    ):
+        """Update without -s/--package must not rebuild; it reuses existing deps."""
+        runner = CliRunner()
+        mock_ws = MagicMock()
+        mock_ws_client.return_value = mock_ws
+        mock_ws.config.host = "https://test.databricks.com"
+        mock_pipeline_obj = MagicMock()
+        mock_pipeline_obj.pipeline_id = "pl-88"
+        mock_ws.pipelines.list_pipelines.return_value = [mock_pipeline_obj]
+
+        # Existing pipeline already points at wheels on a volume.
+        existing = ["/Volumes/cat/sch/community_connector/packages/existing.whl"]
+        mock_info = MagicMock()
+        mock_info.spec.environment.dependencies = existing
+        mock_ws.pipelines.get.return_value = mock_info
+
+        result = runner.invoke(
+            main,
+            ["update_pipeline", "my_pipeline", "-ps", self._bare_spec()],
+        )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        # No build/upload and no volume resolution.
+        mock_build_upload.assert_not_called()
+        mock_dest_dir.assert_not_called()
+        # Existing dependencies are carried into the new body.
+        body = mock_ws.api_client.do.call_args.kwargs["body"]
+        assert body["environment"]["dependencies"] == existing
+
 
 def _make_fake_wheel(path: Path, source_name: str) -> Path:
     """Build a minimal in-process zip that looks like a connector wheel.

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -2537,14 +2537,43 @@ class TestManagedCreatePipeline:
             "pipelines.managedIngestion.registerPythonDataSource"] == "true"
         assert body["environment"]["dependencies"]
 
-    def test_managed_create_requires_spec(self):
+    def test_managed_create_requires_spec_or_connection(self):
         runner = CliRunner()
         with patch("databricks.labs.community_connector_cli.cli.WorkspaceClient"):
             result = runner.invoke(
-                main, ["create_pipeline", "github", "my_pipeline", "-n", "conn"]
+                main, ["create_pipeline", "github", "my_pipeline"]
             )
         assert result.exit_code != 0
-        assert "--pipeline-spec is required" in result.output
+        assert "Either --pipeline-spec or --connection-name" in result.output
+
+    @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
+    @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    def test_managed_create_empty_pipeline_from_connection(
+        self, mock_ws_client, mock_dest_dir, mock_build_upload
+    ):
+        """No --pipeline-spec: create an empty pipeline (no objects) from -n."""
+        runner = CliRunner()
+        mock_ws = MagicMock()
+        mock_ws_client.return_value = mock_ws
+        mock_ws.config.host = "https://test.databricks.com"
+        mock_ws.api_client.do.return_value = {"pipeline_id": "pl-empty"}
+        mock_dest_dir.return_value = "/Volumes/cat/sch/community_connector/packages"
+        mock_build_upload.return_value = ["/Volumes/cat/sch/community_connector/packages/w.whl"]
+
+        result = runner.invoke(
+            main,
+            ["create_pipeline", "github", "my_pipeline", "-n", "my_conn",
+             "-c", "cat", "-t", "sch"],
+        )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "empty pipeline" in result.output
+        body = mock_ws.api_client.do.call_args.kwargs["body"]
+        assert body["ingestion_definition"]["connection_name"] == "my_conn"
+        assert body["ingestion_definition"]["objects"] == []
+        assert body["ingestion_definition"]["source_type"] == "COMMUNITY"
+        assert body["catalog"] == "cat"
 
     @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
     @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")

--- a/tools/community_connector/tests/test_managed_pipeline.py
+++ b/tools/community_connector/tests/test_managed_pipeline.py
@@ -128,6 +128,39 @@ class TestBuildBarePipelineBody:
         assert "environment" not in body
         assert "catalog" not in body
 
+    def test_merge_onto_base_preserves_unmanaged_fields(self):
+        base = {
+            "name": "p",
+            "catalog": "cat",
+            "schema": "sch",
+            "channel": "CURRENT",
+            "serverless": False,
+            "tags": {"team": "data"},
+            "environment": {"dependencies": ["/old.whl"]},
+        }
+        body = build_bare_pipeline_body(
+            {"objects": [{"table": {"source_table": "t"}}]},
+            pipeline_name="p", connection_name="c",
+            catalog=None, schema=None, dependencies=["/new.whl"],
+            channel=None, serverless=None, base=base,
+        )
+        # Unmanaged fields survive; channel/serverless not overridden.
+        assert body["tags"] == {"team": "data"}
+        assert body["channel"] == "CURRENT"
+        assert body["serverless"] is False
+        # Managed additions applied; deps replaced.
+        assert body["configuration"][REGISTER_PYTHON_DATA_SOURCE_KEY] == "true"
+        assert body["environment"]["dependencies"] == ["/new.whl"]
+        assert body["ingestion_definition"]["source_type"] == SOURCE_TYPE_COMMUNITY
+
+    def test_merge_does_not_mutate_base(self):
+        base = {"name": "p", "tags": {"t": "v"}, "configuration": {}}
+        build_bare_pipeline_body(
+            {"objects": []}, pipeline_name="p", connection_name="c",
+            catalog=None, schema=None, dependencies=None, base=base,
+        )
+        assert base == {"name": "p", "tags": {"t": "v"}, "configuration": {}}
+
 
 class TestAugmentFullPipelineBody:
     def _spec(self, **extra):

--- a/tools/community_connector/tests/test_managed_pipeline.py
+++ b/tools/community_connector/tests/test_managed_pipeline.py
@@ -31,13 +31,16 @@ class TestValidateIngestionDefinition:
     def test_valid_schema_object(self):
         validate_ingestion_definition({"objects": [{"schema": {"source_schema": "s"}}]})
 
-    def test_missing_objects(self):
-        with pytest.raises(ManagedPipelineSpecError):
-            validate_ingestion_definition({"connection_name": "c"})
+    def test_missing_objects_allowed(self):
+        # An empty pipeline (connection only, no tables) is valid.
+        validate_ingestion_definition({"connection_name": "c"})
 
-    def test_empty_objects(self):
+    def test_empty_objects_allowed(self):
+        validate_ingestion_definition({"objects": []})
+
+    def test_objects_wrong_type(self):
         with pytest.raises(ManagedPipelineSpecError):
-            validate_ingestion_definition({"objects": []})
+            validate_ingestion_definition({"objects": "not-a-list"})
 
     def test_object_without_selector(self):
         with pytest.raises(ManagedPipelineSpecError):

--- a/tools/community_connector/tests/test_managed_pipeline.py
+++ b/tools/community_connector/tests/test_managed_pipeline.py
@@ -1,0 +1,179 @@
+"""Unit tests for the managed ingestion pipeline body builders."""
+
+import pytest
+
+from databricks.labs.community_connector_cli.managed_pipeline import (
+    ManagedPipelineSpecError,
+    REGISTER_PYTHON_DATA_SOURCE_KEY,
+    SOURCE_TYPE_COMMUNITY,
+    augment_full_pipeline_body,
+    build_bare_pipeline_body,
+    build_ingestion_definition,
+    is_full_pipeline_spec,
+    validate_ingestion_definition,
+)
+
+
+class TestIsFullPipelineSpec:
+    def test_bare_spec_is_not_full(self):
+        assert not is_full_pipeline_spec(
+            {"connection_name": "c", "objects": [{"table": {"source_table": "t"}}]}
+        )
+
+    def test_full_spec_detected(self):
+        assert is_full_pipeline_spec({"name": "p", "ingestion_definition": {"objects": []}})
+
+
+class TestValidateIngestionDefinition:
+    def test_valid_table(self):
+        validate_ingestion_definition({"objects": [{"table": {"source_table": "t"}}]})
+
+    def test_valid_schema_object(self):
+        validate_ingestion_definition({"objects": [{"schema": {"source_schema": "s"}}]})
+
+    def test_missing_objects(self):
+        with pytest.raises(ManagedPipelineSpecError):
+            validate_ingestion_definition({"connection_name": "c"})
+
+    def test_empty_objects(self):
+        with pytest.raises(ManagedPipelineSpecError):
+            validate_ingestion_definition({"objects": []})
+
+    def test_object_without_selector(self):
+        with pytest.raises(ManagedPipelineSpecError):
+            validate_ingestion_definition({"objects": [{"foo": "bar"}]})
+
+
+class TestBuildIngestionDefinition:
+    def test_injects_source_type_and_connection(self):
+        result = build_ingestion_definition(
+            {"objects": [{"table": {"source_table": "commits"}}]},
+            connection_name="my_conn", catalog="cat", schema="sch",
+        )
+        assert result["source_type"] == SOURCE_TYPE_COMMUNITY
+        assert result["connection_name"] == "my_conn"
+
+    def test_spec_connection_name_wins(self):
+        result = build_ingestion_definition(
+            {"connection_name": "spec_conn", "objects": [{"table": {"source_table": "t"}}]},
+            connection_name="cli_conn", catalog=None, schema=None,
+        )
+        assert result["connection_name"] == "spec_conn"
+
+    def test_backfills_destinations_and_source_schema(self):
+        result = build_ingestion_definition(
+            {"objects": [{"table": {"source_table": "commits"}}]},
+            connection_name="c", catalog="cat", schema="sch",
+        )
+        table = result["objects"][0]["table"]
+        assert table["destination_catalog"] == "cat"
+        assert table["destination_schema"] == "sch"
+        assert table["source_schema"] == "default"
+
+    def test_per_table_destination_wins(self):
+        result = build_ingestion_definition(
+            {"objects": [{"table": {
+                "source_table": "commits",
+                "destination_catalog": "override_cat",
+                "source_schema": "custom",
+            }}]},
+            connection_name="c", catalog="cat", schema="sch",
+        )
+        table = result["objects"][0]["table"]
+        assert table["destination_catalog"] == "override_cat"
+        assert table["destination_schema"] == "sch"
+        assert table["source_schema"] == "custom"
+
+    def test_does_not_mutate_input(self):
+        spec = {"objects": [{"table": {"source_table": "t"}}]}
+        build_ingestion_definition(spec, "c", "cat", "sch")
+        assert spec == {"objects": [{"table": {"source_table": "t"}}]}
+
+    def test_preserves_connector_options(self):
+        opts = {"community_connector_options": {"options": {"owner": "o", "repo": "r"}}}
+        result = build_ingestion_definition(
+            {"objects": [{"table": {"source_table": "commits", "connector_options": opts}}]},
+            connection_name="c", catalog="cat", schema="sch",
+        )
+        assert result["objects"][0]["table"]["connector_options"] == opts
+
+
+class TestBuildBarePipelineBody:
+    def test_full_body_shape(self):
+        body = build_bare_pipeline_body(
+            {"connection_name": "c", "objects": [{"table": {"source_table": "t"}}]},
+            pipeline_name="my_pipeline", connection_name=None,
+            catalog="cat", schema="sch",
+            dependencies=["/Volumes/a/b/v/w.whl"],
+            channel="PREVIEW", serverless=True,
+        )
+        assert body["name"] == "my_pipeline"
+        assert body["catalog"] == "cat"
+        assert body["schema"] == "sch"
+        assert body["channel"] == "PREVIEW"
+        assert body["serverless"] is True
+        assert body["configuration"][REGISTER_PYTHON_DATA_SOURCE_KEY] == "true"
+        assert body["environment"]["dependencies"] == ["/Volumes/a/b/v/w.whl"]
+        assert body["ingestion_definition"]["source_type"] == SOURCE_TYPE_COMMUNITY
+
+    def test_no_dependencies_omits_environment(self):
+        body = build_bare_pipeline_body(
+            {"objects": [{"table": {"source_table": "t"}}]},
+            pipeline_name="p", connection_name="c",
+            catalog=None, schema=None, dependencies=None,
+        )
+        assert "environment" not in body
+        assert "catalog" not in body
+
+
+class TestAugmentFullPipelineBody:
+    def _spec(self, **extra):
+        base = {
+            "name": "p",
+            "catalog": "cat",
+            "schema": "sch",
+            "ingestion_definition": {
+                "connection_name": "c",
+                "objects": [{"table": {"source_table": "t"}}],
+            },
+        }
+        base.update(extra)
+        return base
+
+    def test_adds_config_flag_and_source_type(self):
+        body = augment_full_pipeline_body(self._spec(), dependencies=["/v/w.whl"])
+        assert body["configuration"][REGISTER_PYTHON_DATA_SOURCE_KEY] == "true"
+        assert body["ingestion_definition"]["source_type"] == SOURCE_TYPE_COMMUNITY
+        assert body["environment"]["dependencies"] == ["/v/w.whl"]
+
+    def test_existing_environment_preserved_no_deps_added(self):
+        spec = self._spec(environment={"dependencies": ["/existing/w.whl"]})
+        body = augment_full_pipeline_body(spec, dependencies=["/new/w.whl"])
+        assert body["environment"]["dependencies"] == ["/existing/w.whl"]
+
+    def test_existing_config_flag_preserved(self):
+        spec = self._spec(configuration={REGISTER_PYTHON_DATA_SOURCE_KEY: "false", "x": "y"})
+        body = augment_full_pipeline_body(spec, dependencies=None)
+        assert body["configuration"][REGISTER_PYTHON_DATA_SOURCE_KEY] == "false"
+        assert body["configuration"]["x"] == "y"
+
+    def test_cli_options_applied_when_provided(self):
+        body = augment_full_pipeline_body(
+            self._spec(), pipeline_name="override", catalog="newcat",
+            connection_name="newconn", dependencies=None,
+        )
+        assert body["name"] == "override"
+        assert body["catalog"] == "newcat"
+        assert body["ingestion_definition"]["connection_name"] == "newconn"
+
+    def test_cli_options_omitted_leaves_spec(self):
+        body = augment_full_pipeline_body(self._spec(), dependencies=None)
+        assert body["name"] == "p"
+        assert body["catalog"] == "cat"
+        assert body["ingestion_definition"]["connection_name"] == "c"
+
+    def test_does_not_mutate_input(self):
+        spec = self._spec()
+        augment_full_pipeline_body(spec, dependencies=["/v/w.whl"])
+        assert "environment" not in spec
+        assert REGISTER_PYTHON_DATA_SOURCE_KEY not in spec.get("configuration", {})


### PR DESCRIPTION
## What

Adds **managed ingestion pipeline** support to the `community-connector` CLI and makes it the **default** mode for `create_pipeline` and `update_pipeline`. The legacy workspace-pipeline flow (clone the repo into the workspace, run `ingest.py`) is preserved behind `--use-workspace-pipeline`.

In managed mode the CLI builds and uploads the connector's Python wheels to a UC Volume and creates a pipeline whose `ingestion_definition` is set from `--pipeline-spec` — no repo clone. The table configuration lives under `connector_options.community_connector_options`, and `pipelines.managedIngestion.registerPythonDataSource: "true"` plus `environment.dependencies` are wired automatically.

## How

- New `managed_pipeline.py` module (pure, no I/O) builds the pipeline request body from either:
  - a **bare** ingestion definition (`connection_name` + `objects`) — the CLI wraps it, injects `source_type: COMMUNITY`, backfills per-table `destination_catalog`/`destination_schema`/`source_schema` from `-c`/`-t`, and sets the config flag + `environment.dependencies`; or
  - a **full** pipeline spec (containing an `ingestion_definition` block) — treated as authoritative; the CLI only adds the config flag, `source_type`, CLI-provided options, and (if absent) `environment`. A full spec that already declares an `environment` skips wheel build/upload entirely.
- Bodies are sent as **raw dicts** to `POST`/`PUT /api/2.0/pipelines` via `api_client.do()`, because the installed `databricks-sdk` cannot model `source_type: COMMUNITY` or `community_connector_options`.
- `--volume-path` is optional, defaulting to `/Volumes/<catalog>/<schema>/community_connector/packages`.
- Reuses the existing `upload` command's wheel build/upload helpers; `--package` supplies pre-built wheels instead of building.
- Updates the `deploy-connector` skill to generate a full managed pipeline spec and drops the legacy workspace flow.

## Testing

- New `tests/test_managed_pipeline.py` (21 tests) covering the body builders.
- New `TestManagedCreatePipeline` in `tests/test_cli.py` (managed create/update, bare + full spec, environment-present skip, PUT on update).
- Existing legacy-path tests updated to pass `--use-workspace-pipeline`.
- Full suite: 264 passed.

This pull request and its description were written by Isaac.