### PR TITLE
feat(cli): add `publish` command to save a connector as a workspace asset

### DIFF
--- a/tools/community_connector/README.md
+++ b/tools/community_connector/README.md
@@ -344,6 +344,30 @@ community-connector publish github -d "My GitHub" --overwrite
 | `--schema` | `-t` | Schema for the wheel volume. |
 | `--overwrite` | | Overwrite an existing connector saved at the same path. |
 
+### `unpublish`
+
+Remove a previously published connector from your workspace — the inverse of
+`publish`. Deletes the `.connector.json` file at
+`/Users/<you>/.community-connectors/<display_name>.connector.json`, so the
+connector no longer appears as a **Custom** tile in Add Data. The display name is
+resolved the same way as `publish`; the command errors if no matching connector
+is found, and prompts for confirmation unless `--yes` is passed.
+
+```bash
+# Resolve the display name from the spec / source name, confirm, then delete
+community-connector unpublish github
+
+# Explicit display name, no prompt (works without repo access)
+community-connector unpublish github -d "My GitHub" --yes
+```
+
+**Options:**
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--display-name` | `-d` | User-facing name of the connector to remove. Defaults to the spec's `display_name`, then the source name — must match what was used at publish time. |
+| `--spec` | `-s` | Local path to `connector_spec.yaml`, or a GitHub repo URL. Only used to resolve the display name when `--display-name` is not given. |
+| `--yes` | `-y` | Skip the confirmation prompt. |
+
 ## Pipeline Spec Format
 
 The pipeline spec defines which tables to ingest and how:

--- a/tools/community_connector/README.md
+++ b/tools/community_connector/README.md
@@ -307,6 +307,43 @@ in order.
 | `--source-dir` | | Override the connector source directory (default: locate `sources/<source_name>/`). |
 | `--keep-wheel` | | After upload, copy any wheels built in this run into this local directory. User-supplied wheels are not copied. |
 
+### `publish`
+
+Publish a connector to your workspace as a `.connector.json` asset. The file is
+written to `/Users/<you>/.community-connectors/<display_name>.connector.json`;
+the workspace server infers the `CommunityConnector` asset type from the
+`.connector.json` extension, and the saved connector then appears as a **Custom**
+tile in the "Add Data" page (under Community connectors).
+
+The manifest's `connectionSpec` is read from the connector's
+`connector_spec.yaml` (resolved the same way as `create_connection --spec`: local
+source dir, a `--spec` file, a repo URL, or the default repo). By default the
+framework + connector wheels are built from the local source and uploaded to a UC
+Volume, and their paths are recorded in the manifest's `dependencies`. Pass
+`--package` / `--volume-path` to reuse pre-built wheels instead of building.
+
+```bash
+# Build wheels from source and publish (display name from the spec / source name)
+community-connector publish github
+
+# Custom display name + a pre-built connector wheel (skips building)
+community-connector publish github -d "My GitHub" -p ./dist/connector.whl
+
+# Replace an already-published connector at the same path
+community-connector publish github -d "My GitHub" --overwrite
+```
+
+**Options:**
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--display-name` | `-d` | User-facing name (backs the filename and the Add Data tile). Defaults to the spec's `display_name`, then the source name. |
+| `--spec` | `-s` | Local path to `connector_spec.yaml`, or a GitHub repo URL. |
+| `--package` | `-p` | Pre-built connector wheel; skip building. Repeatable. |
+| `--volume-path` | `-v` | UC Volume directory for the wheels. Defaults to `/Volumes/<catalog>/<schema>/community_connector/packages`. |
+| `--catalog` | `-c` | UC catalog for the wheel volume. |
+| `--schema` | `-t` | Schema for the wheel volume. |
+| `--overwrite` | | Overwrite an existing connector saved at the same path. |
+
 ## Pipeline Spec Format
 
 The pipeline spec defines which tables to ingest and how:

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -3016,5 +3016,98 @@ def publish(
     )
 
 
+def _workspace_object_exists(workspace_client, path: str) -> bool:
+    """Return True if a workspace object exists at ``path``."""
+    try:
+        workspace_client.workspace.get_status(path)
+        return True
+    except Exception as e:
+        if "RESOURCE_DOES_NOT_EXIST" in str(e) or "does not exist" in str(e).lower():
+            return False
+        raise click.ClickException(f"Failed to check {path}: {e}")
+
+
+@main.command("unpublish")
+@click.argument("source_name")
+@click.option(
+    "--display-name",
+    "-d",
+    "display_name",
+    default=None,
+    help="User-facing name of the connector to remove (the <name>.connector.json "
+    "filename). Defaults to the spec's display_name, then the source name — must "
+    "match what was used at publish time.",
+)
+@click.option(
+    "--spec",
+    "-s",
+    "spec_path",
+    default=None,
+    help="Optional: local path to connector_spec.yaml, or a GitHub repo URL. Only "
+    "used to resolve the display name when --display-name is not given.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@click.pass_context
+def unpublish(
+    ctx: click.Context,
+    source_name: str,
+    display_name: Optional[str],
+    spec_path: Optional[str],
+    assume_yes: bool,
+):
+    """
+    Remove a published community connector from your workspace.
+
+    SOURCE_NAME is the name of the connector source (e.g., 'github', 'stripe').
+
+    Deletes the ``.connector.json`` file that ``publish`` wrote at
+    ``/Users/<you>/.community-connectors/<display_name>.connector.json``, so the
+    connector no longer appears as a "Custom" tile in Add Data. The display name
+    is resolved the same way as ``publish``; errors if no matching connector is
+    found.
+
+    \b
+    Example:
+        community-connector unpublish github
+        community-connector unpublish github -d "My GitHub" --yes
+    """
+    debug = ctx.obj.get("debug", False)
+
+    # Only load the spec to resolve the display name; skip it when --display-name
+    # is supplied so unpublish works without repo access.
+    connector_spec = None if display_name else _load_connector_spec(source_name, spec_path)
+    resolved_display_name = _resolve_display_name(display_name, connector_spec, source_name)
+
+    workspace_client = _make_workspace_client()
+    current_user = workspace_client.current_user.me()
+    dir_path = f"/Users/{current_user.user_name}/{COMMUNITY_CONNECTORS_DIR_NAME}"
+    file_path = f"{dir_path}/{resolved_display_name}{COMMUNITY_CONNECTOR_EXTENSION}"
+
+    if not _workspace_object_exists(workspace_client, file_path):
+        raise click.ClickException(
+            f"No published connector found at {file_path}. "
+            "Check the display name (use --display-name if it differs from the source name)."
+        )
+
+    if not assume_yes:
+        click.confirm(f"Delete published connector at {file_path}?", abort=True)
+
+    click.echo(f"Removing connector: {file_path}")
+    try:
+        workspace_client.workspace.delete(path=file_path)
+    except Exception as e:
+        if debug:
+            click.echo(f"\n[DEBUG] Full exception: {traceback.format_exc()}", err=True)
+        raise click.ClickException(f"Failed to delete {file_path}: {e}")
+    click.echo("  ✓ Unpublished!")
+
+
 if __name__ == "__main__":
     main()  # pylint: disable=no-value-for-parameter

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -69,16 +69,12 @@ from databricks.labs.community_connector_cli.connector_spec import (
 
 CONNECTION_TYPE = "COMMUNITY"
 
-# Home-dir subdirectory where the webapp saves community connector manifests, and
-# the file extension the workspace import API infers NodeType.CommunityConnector
-# from. Keep in sync with the webapp (workspaceManifestUtils.ts).
+# Workspace location and file extension for saved community connector manifests.
 COMMUNITY_CONNECTORS_DIR_NAME = ".community-connectors"
 COMMUNITY_CONNECTOR_EXTENSION = ".connector.json"
 
-# Filename-safe display names: letters, numbers, spaces, hyphens, underscores.
-# Mirrors the webapp's FILENAME_SAFE_DISPLAY_NAME check — the display name is
-# interpolated straight into the workspace path, so this blocks path traversal
-# and malformed writes.
+# Filename-safe display names. The display name becomes the workspace filename
+# verbatim, so this allowlist blocks path traversal and malformed writes.
 _FILENAME_SAFE_DISPLAY_NAME_RE = re.compile(r"^[a-zA-Z0-9 _-]+$")
 
 
@@ -2975,13 +2971,11 @@ def publish(
 
     click.echo(f"Publishing community connector: {source_name}")
 
+    # `_load_connector_spec` already warns with the reason when it can't load a
+    # spec; only add the consequence here so the message isn't duplicated.
     connector_spec = _load_connector_spec(source_name, spec_path)
     if connector_spec is None:
-        click.echo(
-            f"⚠️  Warning: Could not load connector spec for '{source_name}'. "
-            "Publishing with a null connectionSpec.",
-            err=True,
-        )
+        click.echo("  Publishing with a null connectionSpec.", err=True)
 
     resolved_display_name = _resolve_display_name(
         display_name, connector_spec, source_name

--- a/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
+++ b/tools/community_connector/src/databricks/labs/community_connector_cli/cli.py
@@ -69,6 +69,18 @@ from databricks.labs.community_connector_cli.connector_spec import (
 
 CONNECTION_TYPE = "COMMUNITY"
 
+# Home-dir subdirectory where the webapp saves community connector manifests, and
+# the file extension the workspace import API infers NodeType.CommunityConnector
+# from. Keep in sync with the webapp (workspaceManifestUtils.ts).
+COMMUNITY_CONNECTORS_DIR_NAME = ".community-connectors"
+COMMUNITY_CONNECTOR_EXTENSION = ".connector.json"
+
+# Filename-safe display names: letters, numbers, spaces, hyphens, underscores.
+# Mirrors the webapp's FILENAME_SAFE_DISPLAY_NAME check — the display name is
+# interpolated straight into the workspace path, so this blocks path traversal
+# and malformed writes.
+_FILENAME_SAFE_DISPLAY_NAME_RE = re.compile(r"^[a-zA-Z0-9 _-]+$")
+
 
 def _make_workspace_client() -> WorkspaceClient:
     """Construct a WorkspaceClient, forcing the DEFAULT profile when unset.
@@ -1666,6 +1678,95 @@ def _build_managed_pipeline_body(
 # ---- end managed ingestion helpers -------------------------------------------
 
 
+# ---- Publish (save .connector.json to the workspace) -------------------------
+
+
+def _resolve_display_name(
+    explicit: Optional[str], connector_spec: Optional[dict], source_name: str
+) -> str:
+    """Resolve the connector's user-facing display name.
+
+    Precedence: an explicit ``--display-name`` wins; then the connector spec's
+    ``display_name``; finally the technical ``source_name``. The result backs
+    the ``<displayName>.connector.json`` filename, so it must be filename-safe.
+    """
+    display_name = explicit or (
+        connector_spec.get("display_name") if connector_spec else None
+    ) or source_name
+    display_name = str(display_name).strip()
+    if not _FILENAME_SAFE_DISPLAY_NAME_RE.match(display_name):
+        raise click.ClickException(
+            f"Display name '{display_name}' is not a valid filename. "
+            "Use only letters, numbers, spaces, hyphens, and underscores."
+        )
+    return display_name
+
+
+def _build_community_connector_manifest(
+    source_name: str,
+    display_name: str,
+    connector_spec: Optional[dict],
+    dependencies: Optional[List[str]],
+) -> dict:
+    """Build the ``.connector.json`` manifest body.
+
+    Mirrors the webapp's ``buildCommunityConnectorAuthoringManifest`` shape: the
+    connector spec YAML becomes ``connectionSpec``; ``logo``/``repositoryPath``/
+    ``readmeUrl`` are left empty (the workspace UI does not consume them for
+    saved connectors); the wheel volume paths become ``dependencies``.
+    """
+    manifest: dict = {
+        "id": source_name.upper().replace("-", "_"),
+        "sourceName": source_name,
+        "displayName": display_name,
+        "logo": None,
+        "repositoryPath": "",
+        "readmeUrl": "",
+        "connectionSpec": connector_spec,
+    }
+    if dependencies:
+        manifest["dependencies"] = dependencies
+    return manifest
+
+
+def _write_community_connector_manifest(
+    workspace_client, dir_path: str, file_path: str, manifest: dict, overwrite: bool
+) -> None:
+    """Write the manifest to the workspace as a ``.connector.json`` file.
+
+    Creates the ``.community-connectors`` directory (idempotent) and imports the
+    file with ``format=AUTO`` so the server infers NodeType.CommunityConnector
+    from the ``.connector.json`` extension — the same call the webapp makes.
+    """
+    try:
+        workspace_client.workspace.mkdirs(dir_path)
+    except Exception as e:
+        if "RESOURCE_ALREADY_EXISTS" not in str(e):
+            raise click.ClickException(
+                f"Failed to create workspace directory {dir_path}: {e}"
+            )
+
+    content = json.dumps(manifest, indent=2) + "\n"
+    content_base64 = base64.b64encode(content.encode("utf-8")).decode("utf-8")
+    try:
+        workspace_client.workspace.import_(
+            path=file_path,
+            content=content_base64,
+            format=ImportFormat.AUTO,
+            overwrite=overwrite,
+        )
+    except Exception as e:
+        if not overwrite and "RESOURCE_ALREADY_EXISTS" in str(e):
+            raise click.ClickException(
+                f"A connector already exists at {file_path}. "
+                "Re-run with --overwrite to replace it."
+            )
+        raise click.ClickException(f"Failed to write {file_path}: {e}")
+
+
+# ---- end publish helpers -----------------------------------------------------
+
+
 @click.group(cls=OrderedGroup)
 @click.option("--debug", is_flag=True, help="Enable debug output")
 @click.pass_context
@@ -2788,6 +2889,137 @@ def upload(
     finally:
         if cleanup_dir and cleanup_dir.exists():
             shutil.rmtree(cleanup_dir, ignore_errors=True)
+
+
+@main.command("publish")
+@click.argument("source_name")
+@click.option(
+    "--display-name",
+    "-d",
+    "display_name",
+    default=None,
+    help="User-facing name for the connector (backs the <name>.connector.json "
+    "filename and the Add Data tile). Defaults to the spec's display_name, "
+    "then the source name.",
+)
+@click.option(
+    "--spec",
+    "-s",
+    "spec_path",
+    default=None,
+    help="Optional: local path to connector_spec.yaml, or a GitHub repo URL. "
+    "If a URL, the spec is fetched from sources/{source_name}/connector_spec.yaml.",
+)
+@click.option(
+    "--package",
+    "-p",
+    "package_paths",
+    type=click.Path(exists=True, dir_okay=False),
+    multiple=True,
+    help="Path to a pre-built connector wheel. Can be given multiple times. "
+    "When provided, wheels are uploaded as-is instead of being built from source.",
+)
+@click.option(
+    "--volume-path",
+    "-v",
+    "volume_path",
+    default=None,
+    help="UC Volume directory for the connector wheels. Defaults to "
+    "/Volumes/<catalog>/<schema>/community_connector/packages.",
+)
+@click.option("--catalog", "-c", default=None, help="UC catalog for the wheel volume.")
+@click.option("--schema", "-t", default=None, help="Schema for the wheel volume.")
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Overwrite an existing connector saved at the same path.",
+)
+@click.pass_context
+# pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+def publish(
+    ctx: click.Context,
+    source_name: str,
+    display_name: Optional[str],
+    spec_path: Optional[str],
+    package_paths: tuple,
+    volume_path: Optional[str],
+    catalog: Optional[str],
+    schema: Optional[str],
+    overwrite: bool,
+):
+    """
+    Publish a community connector to your workspace as a `.connector.json` asset.
+
+    SOURCE_NAME is the name of the connector source (e.g., 'github', 'stripe').
+
+    Writes a workspace file at
+    ``/Users/<you>/.community-connectors/<display_name>.connector.json``. The
+    server infers the CommunityConnector asset type from the `.connector.json`
+    extension, and the saved connector appears as a "Custom" tile in Add Data.
+
+    The manifest's ``connectionSpec`` is read from the connector's
+    ``connector_spec.yaml``. By default the framework + connector wheels are
+    built from the local source, uploaded to a UC Volume, and recorded in
+    ``dependencies``; pass --package (pre-built wheels) and/or --volume-path to
+    reuse pre-built wheels instead of building from source.
+
+    \b
+    Example:
+        # Build wheels from source and publish:
+        community-connector publish github
+        # Use a pre-built wheel, custom display name:
+        community-connector publish github -d "My GitHub" -p ./connector.whl
+    """
+    debug = ctx.obj.get("debug", False)
+
+    click.echo(f"Publishing community connector: {source_name}")
+
+    connector_spec = _load_connector_spec(source_name, spec_path)
+    if connector_spec is None:
+        click.echo(
+            f"⚠️  Warning: Could not load connector spec for '{source_name}'. "
+            "Publishing with a null connectionSpec.",
+            err=True,
+        )
+
+    resolved_display_name = _resolve_display_name(
+        display_name, connector_spec, source_name
+    )
+    click.echo(f"Display name: {resolved_display_name}")
+
+    workspace_client = _make_workspace_client()
+
+    dest_dir = _resolve_managed_dest_dir(
+        workspace_client, volume_path, catalog, schema, debug
+    )
+    dependencies = _build_and_upload_managed_wheels(
+        workspace_client, source_name, dest_dir, package_paths, debug
+    )
+
+    manifest = _build_community_connector_manifest(
+        source_name, resolved_display_name, connector_spec, dependencies
+    )
+    if debug:
+        click.echo(f"[DEBUG] Manifest:\n{json.dumps(manifest, indent=2)}")
+
+    current_user = workspace_client.current_user.me()
+    dir_path = f"/Users/{current_user.user_name}/{COMMUNITY_CONNECTORS_DIR_NAME}"
+    file_path = f"{dir_path}/{resolved_display_name}{COMMUNITY_CONNECTOR_EXTENSION}"
+
+    click.echo(f"\nWriting connector to: {file_path}")
+    _write_community_connector_manifest(
+        workspace_client, dir_path, file_path, manifest, overwrite
+    )
+    click.echo("  ✓ Published!")
+    click.echo(f"\n{'=' * 60}")
+    click.echo(f"Connector: {resolved_display_name}")
+    click.echo(f"Path:      {file_path}")
+    click.echo(f"{'=' * 60}")
+    click.echo(
+        "\nThe connector now appears as a 'Custom' tile in Add Data "
+        "(under Community connectors)."
+    )
 
 
 if __name__ == "__main__":

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -3583,7 +3583,9 @@ class TestPublishCommand:
         mock_load_spec.return_value = {"connection": {}}
         dest = "/Volumes/main/default/community_connector/packages"
         mock_dest_dir.return_value = dest
-        mock_upload_wheel.side_effect = lambda _ws, wheel_path, _dest: f"{dest}/{Path(wheel_path).name}"
+        mock_upload_wheel.side_effect = (
+            lambda _ws, wheel_path, _dest: f"{dest}/{Path(wheel_path).name}"
+        )
         wheel = tmp_path / "conn.whl"
         wheel.write_text("x")
         mock_ws = MagicMock()

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -41,6 +41,9 @@ from databricks.labs.community_connector_cli.cli import (
     _validate_framework_wheel,
     _find_repo_root,
     _interpolate_oauth_placeholders,
+    _resolve_display_name,
+    _build_community_connector_manifest,
+    _write_community_connector_manifest,
 )
 from databricks.labs.community_connector_cli.connector_spec import (
     ParsedConnectorSpec,
@@ -3373,3 +3376,185 @@ class TestInterpolateOauthPlaceholders:
     def test_no_placeholders_is_noop(self):
         conn = {"token_endpoint": "https://example.com/token"}
         assert _interpolate_oauth_placeholders(conn, {}) == conn
+
+
+class TestResolveDisplayName:
+    """Tests for _resolve_display_name."""
+
+    def test_explicit_wins(self):
+        assert _resolve_display_name("My Name", {"display_name": "GitHub"}, "github") == "My Name"
+
+    def test_falls_back_to_spec_display_name(self):
+        assert _resolve_display_name(None, {"display_name": "GitHub"}, "github") == "GitHub"
+
+    def test_falls_back_to_source_name(self):
+        assert _resolve_display_name(None, {}, "github") == "github"
+        assert _resolve_display_name(None, None, "github") == "github"
+
+    def test_rejects_unsafe_filename(self):
+        with pytest.raises(click.ClickException, match="not a valid filename"):
+            _resolve_display_name("../evil", None, "github")
+        with pytest.raises(click.ClickException, match="not a valid filename"):
+            _resolve_display_name(None, {"display_name": "a/b"}, "github")
+
+
+class TestBuildCommunityConnectorManifest:
+    """Tests for _build_community_connector_manifest."""
+
+    def test_field_derivation_and_null_logo(self):
+        spec = {"connection": {"parameters": []}}
+        manifest = _build_community_connector_manifest(
+            "azure-devops", "Azure DevOps", spec, None
+        )
+        assert manifest["id"] == "AZURE_DEVOPS"
+        assert manifest["sourceName"] == "azure-devops"
+        assert manifest["displayName"] == "Azure DevOps"
+        assert manifest["logo"] is None
+        assert manifest["repositoryPath"] == ""
+        assert manifest["readmeUrl"] == ""
+        assert manifest["connectionSpec"] == spec
+        # No dependencies key when none supplied.
+        assert "dependencies" not in manifest
+
+    def test_includes_dependencies_when_present(self):
+        manifest = _build_community_connector_manifest(
+            "github", "GitHub", None, ["/Volumes/main/default/community_connector/x.whl"]
+        )
+        assert manifest["connectionSpec"] is None
+        assert manifest["dependencies"] == [
+            "/Volumes/main/default/community_connector/x.whl"
+        ]
+
+
+class TestWriteCommunityConnectorManifest:
+    """Tests for _write_community_connector_manifest."""
+
+    def test_mkdirs_and_import_called(self):
+        mock_ws = MagicMock()
+        _write_community_connector_manifest(
+            mock_ws,
+            "/Users/me/.community-connectors",
+            "/Users/me/.community-connectors/GitHub.connector.json",
+            {"id": "GITHUB"},
+            overwrite=True,
+        )
+        mock_ws.workspace.mkdirs.assert_called_once_with(
+            "/Users/me/.community-connectors"
+        )
+        assert mock_ws.workspace.import_.call_count == 1
+        _, kwargs = mock_ws.workspace.import_.call_args
+        assert kwargs["path"] == "/Users/me/.community-connectors/GitHub.connector.json"
+        assert kwargs["overwrite"] is True
+        # Content is base64 of the JSON manifest.
+        decoded = base64.b64decode(kwargs["content"]).decode("utf-8")
+        assert json.loads(decoded) == {"id": "GITHUB"}
+
+    def test_existing_dir_is_tolerated(self):
+        mock_ws = MagicMock()
+        mock_ws.workspace.mkdirs.side_effect = Exception("RESOURCE_ALREADY_EXISTS")
+        _write_community_connector_manifest(
+            mock_ws, "/Users/me/.community-connectors",
+            "/Users/me/.community-connectors/x.connector.json", {"id": "X"},
+            overwrite=True,
+        )
+        assert mock_ws.workspace.import_.call_count == 1
+
+    def test_existing_file_without_overwrite_raises_hint(self):
+        mock_ws = MagicMock()
+        mock_ws.workspace.import_.side_effect = Exception("RESOURCE_ALREADY_EXISTS")
+        with pytest.raises(click.ClickException, match="--overwrite"):
+            _write_community_connector_manifest(
+                mock_ws, "/Users/me/.community-connectors",
+                "/Users/me/.community-connectors/x.connector.json", {"id": "X"},
+                overwrite=False,
+            )
+
+
+class TestPublishCommand:
+    """Tests for the `publish` command."""
+
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
+    @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    def test_publish_builds_wheels_and_writes_manifest(
+        self, mock_load_spec, mock_dest_dir, mock_build_wheels, mock_ws_cls
+    ):
+        runner = CliRunner()
+        mock_load_spec.return_value = {"display_name": "GitHub", "connection": {}}
+        mock_dest_dir.return_value = "/Volumes/main/default/community_connector/packages"
+        mock_build_wheels.return_value = [
+            "/Volumes/main/default/community_connector/packages/fw.whl",
+            "/Volumes/main/default/community_connector/packages/conn.whl",
+        ]
+        mock_ws = MagicMock()
+        mock_ws_cls.return_value = mock_ws
+        mock_ws.current_user.me.return_value.user_name = "me@example.com"
+
+        result = runner.invoke(main, ["publish", "github"])
+
+        assert result.exit_code == 0, result.output
+        mock_build_wheels.assert_called_once()
+        # Wrote the manifest to the user's .community-connectors dir.
+        _, kwargs = mock_ws.workspace.import_.call_args
+        assert kwargs["path"] == (
+            "/Users/me@example.com/.community-connectors/GitHub.connector.json"
+        )
+        decoded = base64.b64decode(kwargs["content"]).decode("utf-8")
+        manifest = json.loads(decoded)
+        assert manifest["id"] == "GITHUB"
+        assert manifest["displayName"] == "GitHub"
+        assert manifest["logo"] is None
+        assert manifest["dependencies"] == mock_build_wheels.return_value
+
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
+    @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    def test_publish_uses_custom_display_name_in_path(
+        self, mock_load_spec, mock_dest_dir, mock_build_wheels, mock_ws_cls
+    ):
+        runner = CliRunner()
+        mock_load_spec.return_value = {"connection": {}}
+        mock_dest_dir.return_value = "/Volumes/main/default/community_connector/packages"
+        mock_build_wheels.return_value = []
+        mock_ws = MagicMock()
+        mock_ws_cls.return_value = mock_ws
+        mock_ws.current_user.me.return_value.user_name = "me@example.com"
+
+        result = runner.invoke(main, ["publish", "github", "-d", "My GitHub"])
+
+        assert result.exit_code == 0, result.output
+        _, kwargs = mock_ws.workspace.import_.call_args
+        assert kwargs["path"] == (
+            "/Users/me@example.com/.community-connectors/My GitHub.connector.json"
+        )
+
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
+    @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    def test_publish_with_package_bypasses_build(
+        self, mock_load_spec, mock_dest_dir, mock_build_wheels, mock_ws_cls, tmp_path
+    ):
+        runner = CliRunner()
+        mock_load_spec.return_value = {"connection": {}}
+        mock_dest_dir.return_value = "/Volumes/main/default/community_connector/packages"
+        wheel = tmp_path / "conn.whl"
+        wheel.write_text("x")
+        mock_build_wheels.return_value = [
+            "/Volumes/main/default/community_connector/packages/conn.whl"
+        ]
+        mock_ws = MagicMock()
+        mock_ws_cls.return_value = mock_ws
+        mock_ws.current_user.me.return_value.user_name = "me@example.com"
+
+        result = runner.invoke(
+            main, ["publish", "github", "-p", str(wheel)]
+        )
+
+        assert result.exit_code == 0, result.output
+        # Pre-built package path is forwarded to the upload helper as a tuple.
+        _, kwargs = mock_build_wheels.call_args
+        passed_packages = mock_build_wheels.call_args[0][3]
+        assert passed_packages == (str(wheel),)

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -3642,3 +3642,97 @@ class TestPublishCommand:
 
         assert result.exit_code == 0, result.output
         assert mock_ws.workspace.import_.call_args.kwargs["overwrite"] is True
+
+
+class TestUnpublishCommand:
+    """Tests for the `unpublish` command."""
+
+    @staticmethod
+    def _existing_ws(user="me@example.com"):
+        """A WorkspaceClient mock whose get_status succeeds (object exists)."""
+        mock_ws = MagicMock()
+        mock_ws.current_user.me.return_value.user_name = user
+        return mock_ws
+
+    @staticmethod
+    def _missing_ws(user="me@example.com"):
+        """A WorkspaceClient mock whose get_status raises RESOURCE_DOES_NOT_EXIST."""
+        mock_ws = MagicMock()
+        mock_ws.current_user.me.return_value.user_name = user
+        mock_ws.workspace.get_status.side_effect = Exception("RESOURCE_DOES_NOT_EXIST")
+        return mock_ws
+
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    def test_unpublish_deletes_after_confirmation(self, mock_load_spec, mock_ws_cls):
+        runner = CliRunner()
+        mock_load_spec.return_value = {"display_name": "GitHub", "connection": {}}
+        mock_ws = self._existing_ws()
+        mock_ws_cls.return_value = mock_ws
+
+        # Confirm the prompt with "y".
+        result = runner.invoke(main, ["unpublish", "github"], input="y\n")
+
+        assert result.exit_code == 0, result.output
+        mock_ws.workspace.delete.assert_called_once_with(
+            path="/Users/me@example.com/.community-connectors/GitHub.connector.json"
+        )
+
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    def test_unpublish_yes_skips_prompt(self, mock_load_spec, mock_ws_cls):
+        runner = CliRunner()
+        mock_load_spec.return_value = {"connection": {}}
+        mock_ws = self._existing_ws()
+        mock_ws_cls.return_value = mock_ws
+
+        result = runner.invoke(main, ["unpublish", "github", "--yes"])
+
+        assert result.exit_code == 0, result.output
+        mock_ws.workspace.delete.assert_called_once_with(
+            path="/Users/me@example.com/.community-connectors/github.connector.json"
+        )
+
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    def test_unpublish_uses_display_name_without_loading_spec(self, mock_load_spec, mock_ws_cls):
+        runner = CliRunner()
+        mock_ws = self._existing_ws()
+        mock_ws_cls.return_value = mock_ws
+
+        result = runner.invoke(main, ["unpublish", "github", "-d", "My GitHub", "--yes"])
+
+        assert result.exit_code == 0, result.output
+        # --display-name provided → the spec is not loaded at all.
+        mock_load_spec.assert_not_called()
+        mock_ws.workspace.delete.assert_called_once_with(
+            path="/Users/me@example.com/.community-connectors/My GitHub.connector.json"
+        )
+
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    def test_unpublish_errors_when_not_found(self, mock_load_spec, mock_ws_cls):
+        runner = CliRunner()
+        mock_load_spec.return_value = {"connection": {}}
+        mock_ws = self._missing_ws()
+        mock_ws_cls.return_value = mock_ws
+
+        result = runner.invoke(main, ["unpublish", "github", "--yes"])
+
+        assert result.exit_code != 0
+        assert "No published connector found" in result.output
+        mock_ws.workspace.delete.assert_not_called()
+
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    def test_unpublish_aborts_when_declined(self, mock_load_spec, mock_ws_cls):
+        runner = CliRunner()
+        mock_load_spec.return_value = {"connection": {}}
+        mock_ws = self._existing_ws()
+        mock_ws_cls.return_value = mock_ws
+
+        # Decline the confirmation prompt with "n".
+        result = runner.invoke(main, ["unpublish", "github"], input="n\n")
+
+        assert result.exit_code != 0
+        mock_ws.workspace.delete.assert_not_called()

--- a/tools/community_connector/tests/test_cli.py
+++ b/tools/community_connector/tests/test_cli.py
@@ -3469,6 +3469,17 @@ class TestWriteCommunityConnectorManifest:
                 overwrite=False,
             )
 
+    def test_mkdirs_error_other_than_already_exists_raises(self):
+        mock_ws = MagicMock()
+        mock_ws.workspace.mkdirs.side_effect = Exception("PERMISSION_DENIED")
+        with pytest.raises(click.ClickException, match="Failed to create workspace directory"):
+            _write_community_connector_manifest(
+                mock_ws, "/Users/me/.community-connectors",
+                "/Users/me/.community-connectors/x.connector.json", {"id": "X"},
+                overwrite=True,
+            )
+        assert mock_ws.workspace.import_.call_count == 0
+
 
 class TestPublishCommand:
     """Tests for the `publish` command."""
@@ -3558,3 +3569,76 @@ class TestPublishCommand:
         _, kwargs = mock_build_wheels.call_args
         passed_packages = mock_build_wheels.call_args[0][3]
         assert passed_packages == (str(wheel),)
+
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    @patch("databricks.labs.community_connector_cli.cli._upload_wheel")
+    @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    def test_publish_package_bypass_uploads_without_building(
+        self, mock_load_spec, mock_dest_dir, mock_upload_wheel, mock_ws_cls, tmp_path
+    ):
+        """--package uploads pre-built wheels as-is, exercising the real bypass
+        branch of _build_and_upload_managed_wheels (no build step)."""
+        runner = CliRunner()
+        mock_load_spec.return_value = {"connection": {}}
+        dest = "/Volumes/main/default/community_connector/packages"
+        mock_dest_dir.return_value = dest
+        mock_upload_wheel.side_effect = lambda _ws, wheel_path, _dest: f"{dest}/{Path(wheel_path).name}"
+        wheel = tmp_path / "conn.whl"
+        wheel.write_text("x")
+        mock_ws = MagicMock()
+        mock_ws_cls.return_value = mock_ws
+        mock_ws.current_user.me.return_value.user_name = "me@example.com"
+
+        result = runner.invoke(main, ["publish", "github", "-p", str(wheel)])
+
+        assert result.exit_code == 0, result.output
+        mock_upload_wheel.assert_called_once()
+        manifest = json.loads(
+            base64.b64decode(mock_ws.workspace.import_.call_args.kwargs["content"]).decode("utf-8")
+        )
+        assert manifest["dependencies"] == [f"{dest}/conn.whl"]
+
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
+    @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    def test_publish_null_spec_writes_null_connection_spec_with_warning(
+        self, mock_load_spec, mock_dest_dir, mock_build_wheels, mock_ws_cls
+    ):
+        runner = CliRunner()
+        mock_load_spec.return_value = None
+        mock_dest_dir.return_value = "/Volumes/main/default/community_connector/packages"
+        mock_build_wheels.return_value = []
+        mock_ws = MagicMock()
+        mock_ws_cls.return_value = mock_ws
+        mock_ws.current_user.me.return_value.user_name = "me@example.com"
+
+        result = runner.invoke(main, ["publish", "github"])
+
+        assert result.exit_code == 0, result.output
+        assert "null connectionSpec" in result.output
+        manifest = json.loads(
+            base64.b64decode(mock_ws.workspace.import_.call_args.kwargs["content"]).decode("utf-8")
+        )
+        assert manifest["connectionSpec"] is None
+
+    @patch("databricks.labs.community_connector_cli.cli.WorkspaceClient")
+    @patch("databricks.labs.community_connector_cli.cli._build_and_upload_managed_wheels")
+    @patch("databricks.labs.community_connector_cli.cli._resolve_managed_dest_dir")
+    @patch("databricks.labs.community_connector_cli.cli._load_connector_spec")
+    def test_publish_forwards_overwrite_flag(
+        self, mock_load_spec, mock_dest_dir, mock_build_wheels, mock_ws_cls
+    ):
+        runner = CliRunner()
+        mock_load_spec.return_value = {"connection": {}}
+        mock_dest_dir.return_value = "/Volumes/main/default/community_connector/packages"
+        mock_build_wheels.return_value = []
+        mock_ws = MagicMock()
+        mock_ws_cls.return_value = mock_ws
+        mock_ws.current_user.me.return_value.user_name = "me@example.com"
+
+        result = runner.invoke(main, ["publish", "github", "--overwrite"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_ws.workspace.import_.call_args.kwargs["overwrite"] is True


### PR DESCRIPTION
## What

Adds a `publish` subcommand to the community-connector CLI that saves a connector to the user's Databricks workspace as a `.connector.json` asset, at:

```
/Users/<you>/.community-connectors/<display_name>.connector.json
```

The workspace server infers the `CommunityConnector` asset type from the `.connector.json` extension (via `workspace.import_(format=AUTO)`), and the saved connector then surfaces as a **Custom** tile on the Add Data page. This is the CLI counterpart to the webapp's "save community connector to workspace" flow.

## How it works

The manifest mirrors the webapp's own producer shape:

- `id` = `SOURCE_NAME.upper()`, `sourceName`, `displayName`
- `connectionSpec` — read from the connector's `connector_spec.yaml` (resolved the same way as `create_connection --spec`: local source dir, a `--spec` file, a repo URL, or the default repo)
- `logo: null`, empty `repositoryPath` / `readmeUrl` (the workspace UI does not consume these for saved connectors)
- `dependencies` — the connector's `.whl` volume paths

By default the framework + connector wheels are built from the local source and uploaded to a UC Volume (reusing the managed-ingestion `upload` helpers), and their paths are recorded in `dependencies`. Pass `--package` / `--volume-path` to reuse pre-built wheels instead of building.

```bash
# Build wheels from source and publish (display name from the spec / source name)
community-connector publish github

# Custom display name + a pre-built connector wheel (skips building)
community-connector publish github -d "My GitHub" -p ./dist/connector.whl

# Replace an already-published connector at the same path
community-connector publish github -d "My GitHub" --overwrite
```

## Tests

- Display-name resolution (explicit → spec `display_name` → source name; filename-safety validation).
- Manifest field derivation (`logo: null`, dependency inclusion / omission).
- Workspace `mkdirs` + `import_` behavior, including the `--overwrite` collision hint.
- Build-from-source vs `--package` bypass paths.

Full CLI test suite passes (163 in `test_cli.py`); `cli.py` is pylint-clean (10.00/10) under the repo's CI flags. Added a `publish` section to the CLI README.

This pull request and its description were written by Isaac.