### PR TITLE
Fix fork-PR CI: opt in to allow-unsafe-pr-checkout on actions/checkout v7.0.1

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -76,6 +76,13 @@ jobs:
         # to lint the PR's actual code. For push/same-repo events the empty
         # fallback resolves to the workflow ref.
         ref: ${{ github.event.pull_request.head.sha }}
+        # actions/checkout >= v6.0.3 refuses a fork-head checkout from a
+        # pull_request_target workflow unless this opt-in is set. We do want
+        # the fork's code on disk (that is the point of the head-SHA ref
+        # above), so the opt-in is deliberate. What mitigates the pwn-request
+        # risk is the `safe-to-test` gate in the Authorize step above, which
+        # runs before any fork-controlled code reaches the runner.
+        allow-unsafe-pr-checkout: true
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          # Opt-in required by actions/checkout >= v6.0.3 to check out a fork
+          # head from pull_request_target. See the rationale on the checkout
+          # step in .github/workflows/pylint.yml.
+          allow-unsafe-pr-checkout: true
       - name: Check changed paths
         id: check
         run: |
@@ -213,6 +217,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Opt-in required by actions/checkout >= v6.0.3 to check out a fork
+          # head from pull_request_target. See the rationale on the checkout
+          # step in .github/workflows/pylint.yml.
+          allow-unsafe-pr-checkout: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
@@ -246,6 +254,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Opt-in required by actions/checkout >= v6.0.3 to check out a fork
+          # head from pull_request_target. See the rationale on the checkout
+          # step in .github/workflows/pylint.yml.
+          allow-unsafe-pr-checkout: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
@@ -279,6 +291,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Opt-in required by actions/checkout >= v6.0.3 to check out a fork
+          # head from pull_request_target. See the rationale on the checkout
+          # step in .github/workflows/pylint.yml.
+          allow-unsafe-pr-checkout: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
@@ -312,6 +328,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Opt-in required by actions/checkout >= v6.0.3 to check out a fork
+          # head from pull_request_target. See the rationale on the checkout
+          # step in .github/workflows/pylint.yml.
+          allow-unsafe-pr-checkout: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
@@ -347,6 +367,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Opt-in required by actions/checkout >= v6.0.3 to check out a fork
+          # head from pull_request_target. See the rationale on the checkout
+          # step in .github/workflows/pylint.yml.
+          allow-unsafe-pr-checkout: true
       - name: Set up Python 3.10
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:

--- a/.github/workflows/verify-locks.yml
+++ b/.github/workflows/verify-locks.yml
@@ -64,6 +64,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Opt-in required by actions/checkout >= v6.0.3 to check out a fork
+          # head from pull_request_target. See the rationale on the checkout
+          # step in .github/workflows/pylint.yml.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0


### PR DESCRIPTION
## Problem

CI is broken for every external **fork** pull request (e.g. #258). The `changes`, `build`, and `verify` jobs fail within seconds at the checkout step with:

> `##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. ... To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.`

`Tests / summary` then fails with "Required jobs did not pass", blocking the PR.

## Root cause

Dependabot PR #260 ("Bump actions/checkout from 6.0.2 to 7.0.1", merged in `3fefbea7`) bumped **every** `actions/checkout` pin in the repo — including the three `pull_request_target` workflows that #238 had **deliberately pinned back to v6.0.2** one month earlier. #260 silently reverted #238.

`actions/checkout` >= v6.0.3 added a guard that refuses to check out fork PR code from a `pull_request_target` (or `workflow_run`) workflow unless `allow-unsafe-pr-checkout: true` is set. All three workflows check out the fork head via `ref: ${{ github.event.pull_request.head.sha }}`, so the guard fires on every fork PR.

The run history on #258 shows the cutover precisely: runs at `01:11:39Z` (before #260 merged) were green; every run from `01:21:24Z` onward fails at checkout.

#260's own CI passed because it was a same-repo branch, so the guard never fired — the same blind spot #238 flagged.

## Fix

Stay on v7.0.1 and set `allow-unsafe-pr-checkout: true` on the 8 fork-PR checkout steps:

- `tests.yml` — 6 steps (`changes`, `test-libs`, `test-pipeline`, `test-example`, `test-community-connector`, `test-source`)
- `pylint.yml` — 1 step
- `verify-locks.yml` — 1 step

This is the follow-up #238 recommended, chosen over re-pinning to v6.0.2 so Dependabot can keep the action current and the fix can't be silently undone by the next bump. Diff is 35 added lines, no deletions, nothing outside those `with:` blocks.

`strip-safe-to-test.yml` also uses `pull_request_target` but has no checkout step, so it needs no change. `connector-self-review.yml` and `generate-merged-source-file.yml` use `pull_request` and are unaffected.

## Security posture

Unchanged. The opt-in only makes explicit what pinning to the pre-guard v6.0.2 was doing implicitly — we *do* want the fork's code on disk, since exercising the PR's actual code is the whole point of the head-SHA checkout.

What mitigates the pwn-request risk is the **`safe-to-test` label gate** in each workflow's `Authorize` step: fork PRs run CI only when a maintainer applies the label, and only on the exact labeled SHA (a later `synchronize` does not pass). That step runs before any fork-controlled code reaches the runner. Each opt-in carries a comment pointing at the canonical rationale in `pylint.yml`, so the next reader sees why it's there.

## Why this PR is a same-repo branch (not a fork)

`pull_request_target` runs the workflow definition from the **base branch**, so a fork PR carrying this fix would still execute master's broken workflow and fail its own CI. Pushing to the base repo makes the checkout a non-fork ref, so the guard does not fire and this PR's CI can pass.

## Verification

- All 6 workflow files parse as valid YAML.
- Structural check via `yaml.safe_load` confirms all 8 checkout steps resolve `allow-unsafe-pr-checkout: True` as a `with:` input (not merely a textual match).
- `allow-unsafe-pr-checkout` confirmed present as a declared input in `action.yml` at the pinned SHA `3d3c42e5` (v7.0.1).
- This PR's own CI is a same-repo run, so it does not exercise the fork path. Real validation is re-running CI on #258 after merge.

This pull request and its description were written by Isaac.