### PR TITLE
feat(framework): reusable resumable-CDC helper + shared-lib inlining

### DIFF
--- a/.github/workflows/generate-merged-source-file.yml
+++ b/.github/workflows/generate-merged-source-file.yml
@@ -73,7 +73,7 @@ jobs:
           # Mirror the path filters previously enforced by
           # tj-actions/changed-files: source/library/interface/registration .py
           # files, excluding generated outputs and test directories.
-          all_changed=$(echo "$DIFF" | grep -E '^src/databricks/labs/community_connector/(sources/.+\.py|libs/utils\.py|interface/lakeflow_connect\.py|sparkpds/lakeflow_datasource\.py)$' \
+          all_changed=$(echo "$DIFF" | grep -E '^src/databricks/labs/community_connector/(sources/.+\.py|libs/utils\.py|libs/resumable\.py|interface/lakeflow_connect\.py|sparkpds/lakeflow_datasource\.py)$' \
               | grep -vE '/sources/.*/_generated_.*\.py$' \
               | grep -vE '/sources/.*/test/' || true)
 
@@ -109,6 +109,7 @@ jobs:
           SHARED_CHANGED="false"
           for file in $ALL_CHANGED_FILES; do
             if [[ "$file" == "src/databricks/labs/community_connector/libs/utils.py" ]] || \
+               [[ "$file" == "src/databricks/labs/community_connector/libs/resumable.py" ]] || \
                [[ "$file" == "src/databricks/labs/community_connector/interface/lakeflow_connect.py" ]] || \
                [[ "$file" == "src/databricks/labs/community_connector/sparkpds/lakeflow_datasource.py" ]]; then
               SHARED_CHANGED="true"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@ Tests run against live source environments (no mocks):
 - **Unit tests** — For complex connector-specific logic
 - **Write-back testing** *(recommended)* — Write data, read it back, verify incremental reads and deletes
 
+## Reusable incremental-read helpers
+
+A connector that pages a keyset- or continuation-paginated endpoint while filtering incrementally on a modified-since cursor can reuse the **resumable CDC** helper in [`libs/resumable.py`](src/databricks/labs/community_connector/libs/resumable.py) instead of hand-rolling the offset state machine. A run killed partway through a long scan (commonly an m2m OAuth token expiring) then **resumes** from the last page on the next run instead of restarting.
+
+```python
+from databricks.labs.community_connector.libs.resumable import resumable_cdc_read
+
+records, end_offset = resumable_cdc_read(
+    start_offset=start_offset,   # framework-checkpointed offset (may be None)
+    snapshot_ts=self._init_ts,   # frozen upper bound so the microbatch terminates
+    paginate=lambda token: ...,  # token -> Iterator[(batch, next_token)]
+    cursor_of=lambda raw: ...,   # raw -> comparable cursor (or None)
+    shape=self._shape_row,       # raw -> output row
+    max_records=...,             # page-granular batch cap, or None
+)
+```
+
+The watermark advances **only after a provably complete pass**, so truncation never skips a record and a fresh pass's strict `> watermark` filter can't miss one. Cursor values are compared with plain ordering, so any consistent, JSON-serialisable type works (int epoch ms, ISO-8601 strings, …). See the Collibra `assets` reader for a reference use.
+
+Because SDP forbids imports, a shared lib is *inlined* into the merged source at build time. To add one: create `libs/<name>.py`, list `<name>` in `OPTIONAL_SHARED_LIBS` in [`tools/scripts/merge_python_source.py`](tools/scripts/merge_python_source.py), and add `libs/<name>.py` to the shared-file triggers in `.github/workflows/generate-merged-source-file.yml`. It is then inlined only into connectors that import it (`libs/utils.py` is the exception — always inlined).
+
 ## Develop a New Connector
 
 Build connectors with AI-assisted workflows using [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Cursor](https://www.cursor.com/). All commands and skills are defined under `.claude/` and auto-discovered by both tools.

--- a/src/databricks/labs/community_connector/libs/resumable.py
+++ b/src/databricks/labs/community_connector/libs/resumable.py
@@ -1,0 +1,141 @@
+"""Reusable resumable-CDC read helper for community connectors.
+
+Many sources expose a keyset- or continuation-paginated list endpoint that is
+*sorted by a stable key* (an id, or an opaque page token) but filtered
+*incrementally on a different field* (a ``lastModified`` cursor). Those are two
+independent dimensions, so a run killed partway through a scan — commonly an
+m2m OAuth token expiring on a long full-load — cannot simply advance the
+modified-since watermark: a partial slice has an arbitrary max cursor, and
+advancing the watermark to it would silently drop not-yet-seen records.
+
+``resumable_cdc_read`` implements that resumable state machine once, so a
+connector supplies only the source-specific pieces:
+
+  * ``paginate``  — a page iterator yielding ``(batch, next_token)`` per page,
+                    resumable from an opaque token (``""`` = first page,
+                    ``next_token is None`` marks the last page).
+  * ``cursor_of`` — extract the incremental cursor from a raw record.
+  * ``shape``     — transform a raw record into an output row.
+
+The framework already checkpoints the returned offset dict across runs and
+re-supplies it as ``start_offset`` (see ``interface/lakeflow_connect.py`` and
+``sparkpds/lakeflow_datasource.py``): this helper persists nothing itself. It
+only decides *what* to put in the offset so that
+
+  * within a pass, progress is by the stable page key, so truncation never
+    skips a record;
+  * the modified-since watermark advances ONLY after a provably complete pass,
+    so the next fresh pass's strict ``> watermark`` filter cannot skip an
+    un-emitted record; and
+  * ``max_records`` caps the batch at a *page* boundary and persists the page
+    token, so the next run resumes there instead of restarting.
+
+Offset schema (generic keys; a pre-existing connector may translate to its own
+persisted keys — see the Collibra ``assets`` reader):
+
+  * ``watermark``    — committed modified-since floor (advances on completion)
+  * ``resume_token`` — opaque page token to resume an in-progress pass
+  * ``snapshot_ts``  — upper bound frozen at pass start, kept across resumes
+
+Cursor values are compared with the standard ordering operators, so any
+consistently ordered, JSON-serialisable type works (int epoch ms, ISO-8601 UTC
+strings, ...). ``cursor_of`` and ``snapshot_ts`` must yield the same type.
+"""
+
+from typing import Any, Callable, Iterator, Optional
+
+WATERMARK = "watermark"
+RESUME_TOKEN = "resume_token"
+SNAPSHOT_TS = "snapshot_ts"
+
+# A page iterator yields (batch, next_token) per page; next_token is None on the
+# last page (no resume point after it).
+PageIterator = Iterator[tuple[list[dict[str, Any]], Optional[str]]]
+
+
+def resumable_cdc_read(
+    *,
+    start_offset: Optional[dict],
+    snapshot_ts: Any,
+    paginate: Callable[[str], PageIterator],
+    cursor_of: Callable[[dict], Any],
+    shape: Callable[[dict], dict],
+    max_records: Optional[int],
+) -> tuple[Iterator[dict], dict]:
+    """Run one resumable incremental batch over a keyset/continuation source.
+
+    Args:
+        start_offset: The checkpointed offset from the previous call (``None``/
+            empty on the first ever call). Uses the ``watermark`` /
+            ``resume_token`` / ``snapshot_ts`` keys.
+        snapshot_ts: Upper bound for a *fresh* pass — the connector's init-time
+            timestamp, so a Trigger.AvailableNow microbatch only drains data
+            that existed when the connector started and therefore terminates.
+        paginate: ``resume_token -> Iterator[(batch, next_token)]``. Begins
+            paging from ``resume_token`` (``""`` = first page).
+        cursor_of: ``raw -> cursor`` (or ``None`` when a record has no
+            comparable cursor; such records are always emitted and never move
+            the watermark).
+        shape: ``raw -> output row``.
+        max_records: Page-granular batch cap, or ``None`` to drain the whole
+            pass in one batch.
+
+    Returns:
+        ``(records, end_offset)``. On a completed pass the offset carries only
+        the advanced ``watermark``; mid-pass it carries the held watermark plus
+        the ``resume_token`` and frozen ``snapshot_ts``. When already caught up,
+        ``end_offset`` echoes the committed watermark so the trigger converges.
+    """
+    start_offset = start_offset or {}
+    watermark = start_offset.get(WATERMARK)
+    resume_token = start_offset.get(RESUME_TOKEN) or ""
+    pass_ts = start_offset.get(SNAPSHOT_TS)
+
+    # Fresh pass whenever no pass is in flight (no resume token, or no frozen
+    # snapshot bound to resume under). Freeze the bound at the pass start.
+    if not resume_token or pass_ts is None:
+        resume_token = ""
+        pass_ts = snapshot_ts
+
+    # Already caught up: the floor reached the snapshot bound and no pass is in
+    # flight — nothing new can be emitted, so converge (echo the watermark).
+    if not resume_token and watermark is not None and watermark >= pass_ts:
+        return iter([]), {WATERMARK: watermark}
+
+    records: list[dict[str, Any]] = []
+    next_resume: Optional[str] = None
+    pass_complete = True
+    for batch, next_token in paginate(resume_token):
+        for raw in batch:
+            cursor = cursor_of(raw)
+            # Incremental window: (watermark, snapshot_ts].
+            if watermark is not None and cursor is not None and cursor <= watermark:
+                continue
+            if cursor is not None and cursor > pass_ts:
+                continue
+            records.append(shape(raw))
+
+        # Page-granular cap: stop at this boundary and resume here next run.
+        # Only a page with a real next_token is a resume point; next_token None
+        # means this was the last page, so the pass has actually completed.
+        if (
+            max_records is not None
+            and len(records) >= max_records
+            and next_token is not None
+        ):
+            next_resume = next_token
+            pass_complete = False
+            break
+
+    if pass_complete:
+        # Whole key-space scanned under one snapshot: advance the committed
+        # watermark to the snapshot bound and clear the pass state.
+        new_watermark = pass_ts if watermark is None else max(watermark, pass_ts)
+        return iter(records), {WATERMARK: new_watermark}
+
+    # Mid-pass: hold the watermark, persist the resume point + frozen bound.
+    return iter(records), {
+        WATERMARK: watermark,
+        RESUME_TOKEN: next_resume,
+        SNAPSHOT_TS: pass_ts,
+    }

--- a/src/databricks/labs/community_connector/sources/collibra/_generated_collibra_python_source.py
+++ b/src/databricks/labs/community_connector/sources/collibra/_generated_collibra_python_source.py
@@ -8,7 +8,13 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, Iterator, Sequence
+from typing import (
+    Any,
+    Callable,
+    Iterator,
+    Optional,
+    Sequence,
+)
 import json
 import time
 
@@ -233,6 +239,107 @@ def register_lakeflow_source(spark):
             raise TypeError(f"Unsupported field type: {field_type}")
         except (ValueError, TypeError) as e:
             raise ValueError(f"Error converting '{value}' ({type(value)}) to {field_type}: {str(e)}")
+
+
+    ########################################################
+    # src/databricks/labs/community_connector/libs/resumable.py
+    ########################################################
+
+    WATERMARK = "watermark"
+    RESUME_TOKEN = "resume_token"
+    SNAPSHOT_TS = "snapshot_ts"
+
+    # A page iterator yields (batch, next_token) per page; next_token is None on the
+    # last page (no resume point after it).
+    PageIterator = Iterator[tuple[list[dict[str, Any]], Optional[str]]]
+
+
+    def resumable_cdc_read(
+        *,
+        start_offset: Optional[dict],
+        snapshot_ts: Any,
+        paginate: Callable[[str], PageIterator],
+        cursor_of: Callable[[dict], Any],
+        shape: Callable[[dict], dict],
+        max_records: Optional[int],
+    ) -> tuple[Iterator[dict], dict]:
+        """Run one resumable incremental batch over a keyset/continuation source.
+
+        Args:
+            start_offset: The checkpointed offset from the previous call (``None``/
+                empty on the first ever call). Uses the ``watermark`` /
+                ``resume_token`` / ``snapshot_ts`` keys.
+            snapshot_ts: Upper bound for a *fresh* pass — the connector's init-time
+                timestamp, so a Trigger.AvailableNow microbatch only drains data
+                that existed when the connector started and therefore terminates.
+            paginate: ``resume_token -> Iterator[(batch, next_token)]``. Begins
+                paging from ``resume_token`` (``""`` = first page).
+            cursor_of: ``raw -> cursor`` (or ``None`` when a record has no
+                comparable cursor; such records are always emitted and never move
+                the watermark).
+            shape: ``raw -> output row``.
+            max_records: Page-granular batch cap, or ``None`` to drain the whole
+                pass in one batch.
+
+        Returns:
+            ``(records, end_offset)``. On a completed pass the offset carries only
+            the advanced ``watermark``; mid-pass it carries the held watermark plus
+            the ``resume_token`` and frozen ``snapshot_ts``. When already caught up,
+            ``end_offset`` echoes the committed watermark so the trigger converges.
+        """
+        start_offset = start_offset or {}
+        watermark = start_offset.get(WATERMARK)
+        resume_token = start_offset.get(RESUME_TOKEN) or ""
+        pass_ts = start_offset.get(SNAPSHOT_TS)
+
+        # Fresh pass whenever no pass is in flight (no resume token, or no frozen
+        # snapshot bound to resume under). Freeze the bound at the pass start.
+        if not resume_token or pass_ts is None:
+            resume_token = ""
+            pass_ts = snapshot_ts
+
+        # Already caught up: the floor reached the snapshot bound and no pass is in
+        # flight — nothing new can be emitted, so converge (echo the watermark).
+        if not resume_token and watermark is not None and watermark >= pass_ts:
+            return iter([]), {WATERMARK: watermark}
+
+        records: list[dict[str, Any]] = []
+        next_resume: Optional[str] = None
+        pass_complete = True
+        for batch, next_token in paginate(resume_token):
+            for raw in batch:
+                cursor = cursor_of(raw)
+                # Incremental window: (watermark, snapshot_ts].
+                if watermark is not None and cursor is not None and cursor <= watermark:
+                    continue
+                if cursor is not None and cursor > pass_ts:
+                    continue
+                records.append(shape(raw))
+
+            # Page-granular cap: stop at this boundary and resume here next run.
+            # Only a page with a real next_token is a resume point; next_token None
+            # means this was the last page, so the pass has actually completed.
+            if (
+                max_records is not None
+                and len(records) >= max_records
+                and next_token is not None
+            ):
+                next_resume = next_token
+                pass_complete = False
+                break
+
+        if pass_complete:
+            # Whole key-space scanned under one snapshot: advance the committed
+            # watermark to the snapshot bound and clear the pass state.
+            new_watermark = pass_ts if watermark is None else max(watermark, pass_ts)
+            return iter(records), {WATERMARK: new_watermark}
+
+        # Mid-pass: hold the watermark, persist the resume point + frozen bound.
+        return iter(records), {
+            WATERMARK: watermark,
+            RESUME_TOKEN: next_resume,
+            SNAPSHOT_TS: pass_ts,
+        }
 
 
     ########################################################
@@ -1273,98 +1380,63 @@ def register_lakeflow_source(spark):
             """Resumable incremental read for the ID-sorted ``assets`` path.
 
             ``/assets`` is keyset-paginated by ``id`` (its opaque ``nextCursor`` is
-            an ``AFTER:id:<id>`` token), but filtered incrementally on
-            ``lastModifiedOn``. Those are two independent dimensions, so we track
-            them separately in the offset:
+            an ``AFTER:id:<id>`` token) but filtered incrementally on
+            ``lastModifiedOn``. The generic resumable state machine — page by the
+            stable key, advance the watermark only on a provably complete pass, cap
+            at a page boundary and persist the resume token — lives in
+            :func:`resumable.resumable_cdc_read`. This method only adapts Collibra's
+            specifics to it:
 
-              * ``cursor``     — the committed ``lastModifiedOn`` watermark (floor).
-                                 Only advances when a full id-pass completes.
-              * ``page_token`` — the opaque nextCursor to resume an in-progress
-                                 id-pass. Absent ⇒ start a fresh pass.
-              * ``pass_ts``    — ``_init_ts`` frozen at the start of a pass, kept
-                                 across resumes so the pass sees one consistent
-                                 snapshot upper bound.
+              * the persisted offset keeps Collibra's historical keys
+                (``cursor`` / ``page_token`` / ``pass_ts``) rather than the helper's
+                generic ones, so offsets checkpointed by earlier runs keep resuming;
+              * ``lastModifiedOn`` cursors are int64 epoch ms (via ``_as_cursor``),
+                with ``0`` as the "no committed floor yet" sentinel.
 
-            Per run we page by id from ``page_token`` (or the start), emitting rows
-            where ``cursor < lastModifiedOn <= pass_ts``. ``max_records_per_batch``
-            is a page-granular cap: once reached we stop at the page boundary and
-            persist ``page_token`` = that page's nextCursor, leaving the committed
-            watermark UNCHANGED (we haven't proven we've seen everything ≤ any given
-            lastModifiedOn yet). When pagination is exhausted the pass is complete —
-            we advance the committed watermark to ``pass_ts`` and clear
-            ``page_token``/``pass_ts`` so the next run starts a fresh pass from the
-            new floor. A run killed mid-pass (e.g. m2m token expiry) resumes from
-            the last committed ``page_token`` instead of restarting.
-
-            Progress within a pass is by id (the true sort key), so truncation never
-            skips a record; the watermark only moves after a provably complete pass,
-            so the next fresh pass's strict ``> committed`` filter can't skip an
-            un-emitted record.
+            A run killed mid-pass (e.g. m2m token expiry) resumes from the persisted
+            ``page_token`` instead of restarting.
             """
             start_offset = start_offset or {}
+            # Adapt Collibra's persisted offset -> the helper's generic schema,
+            # coercing the epoch-ms cursor and frozen snapshot bound to int.
+            generic_start: dict[str, Any] = {}
             committed = self._as_cursor(start_offset.get("cursor"))
-            page_token = start_offset.get("page_token") or ""
-            # Freeze the snapshot boundary at pass start; keep it across resumes.
-            pass_ts = start_offset.get("pass_ts")
-            if not page_token or pass_ts is None:
-                # Fresh pass.
-                page_token = ""
-                pass_ts = self._init_ts
-            pass_ts = int(pass_ts)
+            if committed is not None:
+                generic_start[WATERMARK] = committed
+            if start_offset.get("page_token"):
+                generic_start[RESUME_TOKEN] = start_offset["page_token"]
+            if start_offset.get("pass_ts") is not None:
+                generic_start[SNAPSHOT_TS] = int(start_offset["pass_ts"])
 
-            # Already caught up: committed floor has reached the snapshot boundary
-            # and no pass is in flight — nothing new to emit, converge.
-            if not page_token and committed is not None and committed >= pass_ts:
-                return iter([]), {"cursor": committed}
-
-            max_records = self._parse_max_records(table_options)
             url = f"{self.base_url}/assets"
+            records, end_offset = resumable_cdc_read(
+                start_offset=generic_start,
+                snapshot_ts=self._init_ts,
+                paginate=lambda token: cursor_paginate_pages(
+                    self._session, url, base_params, "assets", start_cursor=token
+                ),
+                cursor_of=lambda raw: self._as_cursor(raw.get("lastModifiedOn")),
+                shape=self._shape_asset,
+                max_records=self._parse_max_records(table_options),
+            )
+            return records, self._to_collibra_offset(end_offset)
 
-            records: list[dict[str, Any]] = []
-            next_page_token: str | None = None
-            pass_complete = True
-            for batch, next_cursor in cursor_paginate_pages(
-                self._session, url, base_params, "assets", start_cursor=page_token
-            ):
-                for raw in batch:
-                    cursor = self._as_cursor(raw.get("lastModifiedOn"))
-                    # Incremental window: (committed, pass_ts].
-                    if committed is not None and cursor is not None and cursor <= committed:
-                        continue
-                    if cursor is not None and cursor > pass_ts:
-                        continue
-                    records.append(self._shape_asset(raw))
+        @staticmethod
+        def _to_collibra_offset(end_offset: dict) -> dict:
+            """Translate the generic resumable offset back to Collibra's keys.
 
-                # Page-granular cap: stop at this boundary, resume here next run.
-                # Only a page that has a real nextCursor can be a resume point; if
-                # next_cursor is None this was the last page (pass completes).
-                if (
-                    max_records is not None
-                    and len(records) >= max_records
-                    and next_cursor is not None
-                ):
-                    next_page_token = next_cursor
-                    pass_complete = False
-                    break
-            else:
-                # Iterator exhausted without hitting the cap ⇒ pass complete.
-                pass_complete = True
-
-            if pass_complete:
-                # Whole id-space scanned under one snapshot: safe to advance the
-                # committed watermark to the snapshot boundary and clear pass state.
-                new_committed = pass_ts if committed is None else max(committed, pass_ts)
-                end_offset = {"cursor": new_committed}
-            else:
-                # Mid-pass: hold the watermark, persist the id resume point + the
-                # frozen snapshot boundary.
-                end_offset = {
-                    "cursor": committed if committed is not None else 0,
-                    "page_token": next_page_token,
-                    "pass_ts": pass_ts,
+            Mid-pass (``resume_token`` present) → ``{cursor, page_token, pass_ts}``,
+            with ``cursor`` defaulting to ``0`` when no floor has been committed yet.
+            Pass-complete / caught-up → ``{cursor}``.
+            """
+            if RESUME_TOKEN in end_offset:
+                watermark = end_offset.get(WATERMARK)
+                return {
+                    "cursor": watermark if watermark is not None else 0,
+                    "page_token": end_offset[RESUME_TOKEN],
+                    "pass_ts": end_offset[SNAPSHOT_TS],
                 }
-
-            return iter(records), end_offset
+            return {"cursor": end_offset[WATERMARK]}
 
         # ------------------------------------------------------------------ #
         # Record shaping

--- a/src/databricks/labs/community_connector/sources/collibra/_generated_collibra_python_source.py
+++ b/src/databricks/labs/community_connector/sources/collibra/_generated_collibra_python_source.py
@@ -1155,7 +1155,8 @@ def register_lakeflow_source(spark):
             (400); that value is valid only on ``/responsibilities`` and
             ``/relations``. We therefore default to ``ID`` (stable keyset order),
             and the ``lastModifiedOn`` incremental cursor is applied CLIENT-SIDE
-            (see ``_read_cdc_incremental``) rather than relying on server ordering.
+            (see ``_incremental_from_iter`` / ``_incremental_assets_resumable``)
+            rather than relying on server ordering.
             Overridable via the ``sort_field`` table option (NAME/DISPLAY_NAME/ID).
             """
             sort_field = table_options.get("sort_field", "ID")

--- a/src/databricks/labs/community_connector/sources/collibra/collibra.py
+++ b/src/databricks/labs/community_connector/sources/collibra/collibra.py
@@ -202,7 +202,8 @@ class CollibraLakeflowConnect(LakeflowConnect):
         (400); that value is valid only on ``/responsibilities`` and
         ``/relations``. We therefore default to ``ID`` (stable keyset order),
         and the ``lastModifiedOn`` incremental cursor is applied CLIENT-SIDE
-        (see ``_read_cdc_incremental``) rather than relying on server ordering.
+        (see ``_incremental_from_iter`` / ``_incremental_assets_resumable``)
+        rather than relying on server ordering.
         Overridable via the ``sort_field`` table option (NAME/DISPLAY_NAME/ID).
         """
         sort_field = table_options.get("sort_field", "ID")

--- a/src/databricks/labs/community_connector/sources/collibra/collibra.py
+++ b/src/databricks/labs/community_connector/sources/collibra/collibra.py
@@ -45,6 +45,12 @@ import requests
 from pyspark.sql.types import StructType
 
 from databricks.labs.community_connector.interface import LakeflowConnect
+from databricks.labs.community_connector.libs.resumable import (
+    RESUME_TOKEN,
+    SNAPSHOT_TS,
+    WATERMARK,
+    resumable_cdc_read,
+)
 from databricks.labs.community_connector.sources.collibra.collibra_schemas import (
     DEFAULT_PAGE_SIZE,
     MAX_PAGE_SIZE,
@@ -421,98 +427,63 @@ class CollibraLakeflowConnect(LakeflowConnect):
         """Resumable incremental read for the ID-sorted ``assets`` path.
 
         ``/assets`` is keyset-paginated by ``id`` (its opaque ``nextCursor`` is
-        an ``AFTER:id:<id>`` token), but filtered incrementally on
-        ``lastModifiedOn``. Those are two independent dimensions, so we track
-        them separately in the offset:
+        an ``AFTER:id:<id>`` token) but filtered incrementally on
+        ``lastModifiedOn``. The generic resumable state machine — page by the
+        stable key, advance the watermark only on a provably complete pass, cap
+        at a page boundary and persist the resume token — lives in
+        :func:`resumable.resumable_cdc_read`. This method only adapts Collibra's
+        specifics to it:
 
-          * ``cursor``     — the committed ``lastModifiedOn`` watermark (floor).
-                             Only advances when a full id-pass completes.
-          * ``page_token`` — the opaque nextCursor to resume an in-progress
-                             id-pass. Absent ⇒ start a fresh pass.
-          * ``pass_ts``    — ``_init_ts`` frozen at the start of a pass, kept
-                             across resumes so the pass sees one consistent
-                             snapshot upper bound.
+          * the persisted offset keeps Collibra's historical keys
+            (``cursor`` / ``page_token`` / ``pass_ts``) rather than the helper's
+            generic ones, so offsets checkpointed by earlier runs keep resuming;
+          * ``lastModifiedOn`` cursors are int64 epoch ms (via ``_as_cursor``),
+            with ``0`` as the "no committed floor yet" sentinel.
 
-        Per run we page by id from ``page_token`` (or the start), emitting rows
-        where ``cursor < lastModifiedOn <= pass_ts``. ``max_records_per_batch``
-        is a page-granular cap: once reached we stop at the page boundary and
-        persist ``page_token`` = that page's nextCursor, leaving the committed
-        watermark UNCHANGED (we haven't proven we've seen everything ≤ any given
-        lastModifiedOn yet). When pagination is exhausted the pass is complete —
-        we advance the committed watermark to ``pass_ts`` and clear
-        ``page_token``/``pass_ts`` so the next run starts a fresh pass from the
-        new floor. A run killed mid-pass (e.g. m2m token expiry) resumes from
-        the last committed ``page_token`` instead of restarting.
-
-        Progress within a pass is by id (the true sort key), so truncation never
-        skips a record; the watermark only moves after a provably complete pass,
-        so the next fresh pass's strict ``> committed`` filter can't skip an
-        un-emitted record.
+        A run killed mid-pass (e.g. m2m token expiry) resumes from the persisted
+        ``page_token`` instead of restarting.
         """
         start_offset = start_offset or {}
+        # Adapt Collibra's persisted offset -> the helper's generic schema,
+        # coercing the epoch-ms cursor and frozen snapshot bound to int.
+        generic_start: dict[str, Any] = {}
         committed = self._as_cursor(start_offset.get("cursor"))
-        page_token = start_offset.get("page_token") or ""
-        # Freeze the snapshot boundary at pass start; keep it across resumes.
-        pass_ts = start_offset.get("pass_ts")
-        if not page_token or pass_ts is None:
-            # Fresh pass.
-            page_token = ""
-            pass_ts = self._init_ts
-        pass_ts = int(pass_ts)
+        if committed is not None:
+            generic_start[WATERMARK] = committed
+        if start_offset.get("page_token"):
+            generic_start[RESUME_TOKEN] = start_offset["page_token"]
+        if start_offset.get("pass_ts") is not None:
+            generic_start[SNAPSHOT_TS] = int(start_offset["pass_ts"])
 
-        # Already caught up: committed floor has reached the snapshot boundary
-        # and no pass is in flight — nothing new to emit, converge.
-        if not page_token and committed is not None and committed >= pass_ts:
-            return iter([]), {"cursor": committed}
-
-        max_records = self._parse_max_records(table_options)
         url = f"{self.base_url}/assets"
+        records, end_offset = resumable_cdc_read(
+            start_offset=generic_start,
+            snapshot_ts=self._init_ts,
+            paginate=lambda token: cursor_paginate_pages(
+                self._session, url, base_params, "assets", start_cursor=token
+            ),
+            cursor_of=lambda raw: self._as_cursor(raw.get("lastModifiedOn")),
+            shape=self._shape_asset,
+            max_records=self._parse_max_records(table_options),
+        )
+        return records, self._to_collibra_offset(end_offset)
 
-        records: list[dict[str, Any]] = []
-        next_page_token: str | None = None
-        pass_complete = True
-        for batch, next_cursor in cursor_paginate_pages(
-            self._session, url, base_params, "assets", start_cursor=page_token
-        ):
-            for raw in batch:
-                cursor = self._as_cursor(raw.get("lastModifiedOn"))
-                # Incremental window: (committed, pass_ts].
-                if committed is not None and cursor is not None and cursor <= committed:
-                    continue
-                if cursor is not None and cursor > pass_ts:
-                    continue
-                records.append(self._shape_asset(raw))
+    @staticmethod
+    def _to_collibra_offset(end_offset: dict) -> dict:
+        """Translate the generic resumable offset back to Collibra's keys.
 
-            # Page-granular cap: stop at this boundary, resume here next run.
-            # Only a page that has a real nextCursor can be a resume point; if
-            # next_cursor is None this was the last page (pass completes).
-            if (
-                max_records is not None
-                and len(records) >= max_records
-                and next_cursor is not None
-            ):
-                next_page_token = next_cursor
-                pass_complete = False
-                break
-        else:
-            # Iterator exhausted without hitting the cap ⇒ pass complete.
-            pass_complete = True
-
-        if pass_complete:
-            # Whole id-space scanned under one snapshot: safe to advance the
-            # committed watermark to the snapshot boundary and clear pass state.
-            new_committed = pass_ts if committed is None else max(committed, pass_ts)
-            end_offset = {"cursor": new_committed}
-        else:
-            # Mid-pass: hold the watermark, persist the id resume point + the
-            # frozen snapshot boundary.
-            end_offset = {
-                "cursor": committed if committed is not None else 0,
-                "page_token": next_page_token,
-                "pass_ts": pass_ts,
+        Mid-pass (``resume_token`` present) → ``{cursor, page_token, pass_ts}``,
+        with ``cursor`` defaulting to ``0`` when no floor has been committed yet.
+        Pass-complete / caught-up → ``{cursor}``.
+        """
+        if RESUME_TOKEN in end_offset:
+            watermark = end_offset.get(WATERMARK)
+            return {
+                "cursor": watermark if watermark is not None else 0,
+                "page_token": end_offset[RESUME_TOKEN],
+                "pass_ts": end_offset[SNAPSHOT_TS],
             }
-
-        return iter(records), end_offset
+        return {"cursor": end_offset[WATERMARK]}
 
     # ------------------------------------------------------------------ #
     # Record shaping

--- a/tests/unit/libs/test_resumable.py
+++ b/tests/unit/libs/test_resumable.py
@@ -1,0 +1,199 @@
+"""Unit tests for the reusable resumable-CDC helper (``libs.resumable``).
+
+Exercise the state machine directly, independent of any connector: fresh-pass
+drain, page-granular cap + resume, watermark-advances-only-on-completion, a
+frozen snapshot bound across resumes, convergence when caught up, and the
+incremental window. Cursors are compared with plain ordering, so the helper is
+type-agnostic — covered here with both int and ISO-string cursors.
+"""
+
+from databricks.labs.community_connector.libs.resumable import (
+    RESUME_TOKEN,
+    SNAPSHOT_TS,
+    WATERMARK,
+    resumable_cdc_read,
+)
+
+
+def _paginator(pages):
+    """Build a ``paginate(resume_token)`` over ``pages``.
+
+    ``pages`` is a list of ``(batch, next_token)``; ``next_token`` is the token
+    to resume *after* that page (``None`` on the last page). ``paginate`` starts
+    at the page whose incoming token matches ``resume_token`` (``""`` = first),
+    and records the tokens it was called with on ``paginate.calls``.
+    """
+    incoming = [""]
+    for _, next_token in pages[:-1]:
+        incoming.append(next_token)
+    calls = []
+
+    def paginate(resume_token):
+        calls.append(resume_token)
+        start = incoming.index(resume_token) if resume_token in incoming else 0
+        for i in range(start, len(pages)):
+            yield pages[i]
+
+    paginate.calls = calls
+    return paginate
+
+
+def _rec(rec_id, ts):
+    return {"id": rec_id, "ts": ts}
+
+
+def _run(paginate, start_offset, snapshot_ts, max_records):
+    records, end_offset = resumable_cdc_read(
+        start_offset=start_offset,
+        snapshot_ts=snapshot_ts,
+        paginate=paginate,
+        cursor_of=lambda r: r.get("ts"),
+        shape=lambda r: r,
+        max_records=max_records,
+    )
+    return [r["id"] for r in records], end_offset
+
+
+# --------------------------------------------------------------------------- #
+# Fresh pass
+# --------------------------------------------------------------------------- #
+
+
+def test_fresh_pass_no_cap_drains_all_and_advances_watermark():
+    pages = [
+        ([_rec("a", 10), _rec("b", 20)], "t1"),
+        ([_rec("c", 30)], None),
+    ]
+    ids, off = _run(_paginator(pages), None, snapshot_ts=100, max_records=None)
+    assert ids == ["a", "b", "c"]
+    # Whole space scanned under one snapshot -> watermark jumps to the bound.
+    assert off == {WATERMARK: 100}
+
+
+def test_empty_source_completes_and_advances_to_snapshot():
+    ids, off = _run(_paginator([([], None)]), None, snapshot_ts=100, max_records=None)
+    assert ids == []
+    assert off == {WATERMARK: 100}
+
+
+# --------------------------------------------------------------------------- #
+# Page-granular cap + resume
+# --------------------------------------------------------------------------- #
+
+
+def test_cap_stops_mid_pass_and_persists_resume_token():
+    pages = [
+        ([_rec("a", 10), _rec("b", 10)], "t1"),
+        ([_rec("c", 10), _rec("d", 10)], "t2"),
+        ([_rec("e", 10), _rec("f", 10)], None),
+    ]
+    paginate = _paginator(pages)
+
+    ids1, off1 = _run(paginate, None, snapshot_ts=100, max_records=2)
+    assert ids1 == ["a", "b"]
+    assert off1[RESUME_TOKEN] == "t1"
+    assert off1[SNAPSHOT_TS] == 100
+    # Watermark not advanced mid-pass (nothing proven complete yet).
+    assert off1.get(WATERMARK) is None
+
+    ids2, off2 = _run(paginate, off1, snapshot_ts=999, max_records=2)
+    assert ids2 == ["c", "d"]
+    assert off2[RESUME_TOKEN] == "t2"
+
+    ids3, off3 = _run(paginate, off2, snapshot_ts=999, max_records=2)
+    assert ids3 == ["e", "f"]
+    # Last page's cap hit but next_token is None -> pass completes, token cleared.
+    assert RESUME_TOKEN not in off3
+    assert off3 == {WATERMARK: 100}
+
+    allids = ids1 + ids2 + ids3
+    assert allids == ["a", "b", "c", "d", "e", "f"]
+    assert len(allids) == len(set(allids))
+
+
+def test_snapshot_ts_frozen_across_resume():
+    """Once a pass starts, its snapshot bound is kept across resumes even if the
+    connector's live snapshot_ts moves on."""
+    pages = [
+        ([_rec("a", 10), _rec("b", 10)], "t1"),
+        ([_rec("c", 10)], None),
+    ]
+    paginate = _paginator(pages)
+    _, off1 = _run(paginate, None, snapshot_ts=100, max_records=2)
+    assert off1[SNAPSHOT_TS] == 100
+    # Resume with a *different* live snapshot_ts; the frozen 100 must win.
+    _, off2 = _run(paginate, off1, snapshot_ts=555, max_records=2)
+    assert off2 == {WATERMARK: 100}
+
+
+def test_cap_on_last_page_completes_without_false_resume():
+    pages = [([_rec("a", 10), _rec("b", 10), _rec("c", 10)], None)]
+    ids, off = _run(_paginator(pages), None, snapshot_ts=100, max_records=2)
+    assert ids == ["a", "b", "c"]  # last page drained despite cap
+    assert off == {WATERMARK: 100}
+
+
+# --------------------------------------------------------------------------- #
+# Incremental window + convergence
+# --------------------------------------------------------------------------- #
+
+
+def test_incremental_window_excludes_committed_and_future():
+    pages = [
+        (
+            [
+                _rec("old", 50),  # <= watermark -> excluded
+                _rec("keep1", 150),
+                _rec("future", 250),  # > snapshot_ts -> excluded
+                _rec("keep2", 200),
+            ],
+            None,
+        )
+    ]
+    ids, off = _run(
+        _paginator(pages), {WATERMARK: 100}, snapshot_ts=200, max_records=None
+    )
+    assert ids == ["keep1", "keep2"]
+    assert off == {WATERMARK: 200}
+
+
+def test_caught_up_converges_without_paging():
+    paginate = _paginator([([_rec("a", 10)], None)])
+    ids, off = _run(paginate, {WATERMARK: 100}, snapshot_ts=100, max_records=None)
+    assert ids == []
+    assert off == {WATERMARK: 100}
+    # Already caught up: the source must not be paged at all.
+    assert paginate.calls == []
+
+
+def test_record_without_cursor_is_emitted_and_does_not_move_watermark():
+    pages = [([_rec("a", 20), {"id": "nocursor"}], None)]
+    ids, off = _run(_paginator(pages), None, snapshot_ts=100, max_records=None)
+    assert set(ids) == {"a", "nocursor"}
+    # Pass completed -> watermark advances to the snapshot bound regardless.
+    assert off == {WATERMARK: 100}
+
+
+# --------------------------------------------------------------------------- #
+# Type-agnostic: ISO-8601 string cursors (Purview-style)
+# --------------------------------------------------------------------------- #
+
+
+def test_iso_string_cursors_are_supported():
+    pages = [
+        (
+            [
+                _rec("a", "2026-01-01T00:00:00+00:00"),  # <= watermark -> excluded
+                _rec("b", "2026-05-01T00:00:00+00:00"),
+            ],
+            None,
+        )
+    ]
+    ids, off = _run(
+        _paginator(pages),
+        {WATERMARK: "2026-01-01T00:00:00+00:00"},
+        snapshot_ts="2026-12-31T23:59:59+00:00",
+        max_records=None,
+    )
+    assert ids == ["b"]
+    assert off == {WATERMARK: "2026-12-31T23:59:59+00:00"}

--- a/tools/scripts/merge_python_source.py
+++ b/tools/scripts/merge_python_source.py
@@ -46,18 +46,35 @@ OPTIONAL_SHARED_LIBS = ("resumable",)
 
 
 def get_referenced_shared_libs(file_contents: List[str]) -> List[str]:
-    """Return the OPTIONAL_SHARED_LIBS a source imports (in declared order).
+    """Return the OPTIONAL_SHARED_LIBS a source (transitively) imports.
 
     Scans the given file contents (the main source plus its library files) for
-    ``from ...libs.<name> import`` of any optional shared lib, so only libs a
-    source actually uses get inlined into its merged file.
+    ``from ...libs.<name> import`` of any optional shared lib, then follows
+    shared-lib -> shared-lib imports so that a lib which itself imports another
+    shared lib pulls that dependency in too (otherwise the dependency's code
+    would be referenced but never inlined -> NameError at SDP runtime). Only
+    libs a source actually uses get inlined into its merged file.
+
+    The result is ordered by OPTIONAL_SHARED_LIBS declaration order, so declare
+    a shared lib before any other that depends on it to keep the inlined
+    definitions in dependency order.
     """
-    referenced = []
-    for lib in OPTIONAL_SHARED_LIBS:
-        needle = f"from databricks.labs.community_connector.libs.{lib} import"
-        if any(needle in content for content in file_contents):
-            referenced.append(lib)
-    return referenced
+    libs_dir = PROJECT_ROOT / "src" / "databricks" / "labs" / "community_connector" / "libs"
+    referenced = set()
+    pending = list(file_contents)
+    while pending:
+        content = pending.pop()
+        for lib in OPTIONAL_SHARED_LIBS:
+            if lib in referenced:
+                continue
+            needle = f"from databricks.labs.community_connector.libs.{lib} import"
+            if needle in content:
+                referenced.add(lib)
+                # Follow this lib's own imports to catch transitive shared libs.
+                lib_path = libs_dir / f"{lib}.py"
+                if lib_path.exists():
+                    pending.append(read_file_content(lib_path))
+    return [lib for lib in OPTIONAL_SHARED_LIBS if lib in referenced]
 
 
 def load_exclude_config() -> Dict:

--- a/tools/scripts/merge_python_source.py
+++ b/tools/scripts/merge_python_source.py
@@ -37,6 +37,28 @@ SCRIPT_DIR = Path(__file__).parent
 PROJECT_ROOT = SCRIPT_DIR.parent.parent
 EXCLUDE_CONFIG_PATH = SCRIPT_DIR / "merge_exclude_config.json"
 
+# Reusable framework helpers under libs/ that are inlined ONLY into sources that
+# import them (unlike libs/utils.py, which is always inlined). Lets connectors
+# share framework code despite SDP's no-import limitation, without bloating the
+# merged file of every source that doesn't use it. Each name maps to
+# src/databricks/labs/community_connector/libs/<name>.py.
+OPTIONAL_SHARED_LIBS = ("resumable",)
+
+
+def get_referenced_shared_libs(file_contents: List[str]) -> List[str]:
+    """Return the OPTIONAL_SHARED_LIBS a source imports (in declared order).
+
+    Scans the given file contents (the main source plus its library files) for
+    ``from ...libs.<name> import`` of any optional shared lib, so only libs a
+    source actually uses get inlined into its merged file.
+    """
+    referenced = []
+    for lib in OPTIONAL_SHARED_LIBS:
+        needle = f"from databricks.labs.community_connector.libs.{lib} import"
+        if any(needle in content for content in file_contents):
+            referenced.append(lib)
+    return referenced
+
 
 def load_exclude_config() -> Dict:
     """
@@ -440,6 +462,11 @@ def deduplicate_imports(
         "from databricks.labs.community_connector.sparkpds.lakeflow_datasource import",
         "from databricks.labs.community_connector.sources.",
         "from databricks.labs.community_connector.interface",
+    ] + [
+        # Optional shared libs are inlined when a source imports them, so their
+        # imports must be stripped like the always-inlined libs.utils above.
+        f"from databricks.labs.community_connector.libs.{lib} import"
+        for lib in OPTIONAL_SHARED_LIBS
     ]
 
     # Track 'from X import Y' style imports to merge them
@@ -646,6 +673,16 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
         lib_contents = []
         for lib_file in lib_files:
             lib_contents.append((lib_file, read_file_content(lib_file)))
+
+        # Detect and read optional shared libs (libs/<name>.py) imported by the
+        # source or its library files. Only imported ones are inlined.
+        shared_lib_names = get_referenced_shared_libs(
+            [source_content] + [content for _, content in lib_contents]
+        )
+        shared_lib_contents = [
+            (name, read_file_content(src_base / "libs" / f"{name}.py"))
+            for name in shared_lib_names
+        ]
     except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -679,6 +716,12 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
     for lib_file, content in lib_contents:
         lib_imports, lib_code = extract_imports_and_code(content)
         lib_imports_and_code.append((lib_file, lib_imports, lib_code))
+
+    # Extract imports and code from optional shared libs.
+    shared_lib_imports_and_code = []
+    for name, content in shared_lib_contents:
+        shared_imports, shared_code = extract_imports_and_code(content)
+        shared_lib_imports_and_code.append((name, shared_imports, shared_code))
 
     # Replace the LakeflowConnectImpl alias with the actual implementation class.
     # The placeholder line in lakeflow_datasource.py is:
@@ -720,6 +763,8 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
 
     # Deduplicate and organize all imports
     all_import_lists = [utils_imports, interface_imports, partition_imports, namespaces_imports]
+    for _, shared_imports, _ in shared_lib_imports_and_code:
+        all_import_lists.append(shared_imports)
     for _, lib_imports, _ in lib_imports_and_code:
         all_import_lists.append(lib_imports)
     all_import_lists.extend([source_imports, lakeflow_imports])
@@ -766,6 +811,23 @@ def merge_files(source_name: str, output_path: Optional[Path] = None) -> str:
             merged_lines.append("")
     merged_lines.append("")
     merged_lines.append("")
+
+    # Section 1b: optional shared libs (inlined only when the source imports
+    # them). Placed after utils.py so their top-level names are defined before
+    # the source code that references them.
+    for name, _, shared_code in shared_lib_imports_and_code:
+        rel_path = f"src/databricks/labs/community_connector/libs/{name}.py"
+        merged_lines.append("    " + "#" * 56)
+        merged_lines.append(f"    # {rel_path}")
+        merged_lines.append("    " + "#" * 56)
+        merged_lines.append("")
+        for line in shared_code.strip().split("\n"):
+            if line.strip():
+                merged_lines.append("    " + line)
+            else:
+                merged_lines.append("")
+        merged_lines.append("")
+        merged_lines.append("")
 
     # Section 2: src/databricks/labs/community_connector/interface/lakeflow_connect.py code
     merged_lines.append("    " + "#" * 56)


### PR DESCRIPTION
## Motivation

Long full-loads on m2m-OAuth connectors can outlive the ~1h token and die partway through a scan; today each connector that cares has to hand-roll a resumable offset. Collibra #267 shipped that state machine for its `assets` path. Per the community-connector office hours, @rahulkhanna-dbl greenlit generalizing it into the framework so the ~8 token-death connectors can reuse it.

**Key framing:** the framework *already* checkpoints the offset dict across runs (Spark `SimpleDataSourceStreamReader`; see `interface/lakeflow_connect.py` — "on subsequent runs the framework resumes from the last checkpointed offset"). So this is **not new persistence** — it's a reusable helper + offset convention so connectors stop re-implementing the tricky part.

## What's here

- **`libs/resumable.py`** — `resumable_cdc_read()`. Pages a keyset/continuation-paginated source while filtering on a modified-since cursor. It advances the watermark **only after a provably complete pass** (so truncation never skips a record), caps at a **page** boundary and persists the resume token, and freezes the snapshot upper bound across resumes. Cursor-type-agnostic (int epoch ms, ISO-8601 strings, …). Generic offset keys: `watermark` / `resume_token` / `snapshot_ts`.
- **Collibra migration (reference)** — the `assets` reader now delegates to the helper via a thin adapter that keeps Collibra's historical offset keys (`cursor`/`page_token`/`pass_ts`) and int-cursor quirks, so **existing checkpoints keep resuming**. The 7 resumable + 3 incremental-regression tests pass **unchanged**.
- **`tools/scripts/merge_python_source.py`** — SDP forbids imports, so a shared lib must be inlined into the merged source. Added `OPTIONAL_SHARED_LIBS`: libs inlined **only into sources that import them** (unlike the always-inlined `libs/utils.py`). Regenerating all 29 sources changes **only Collibra's** `_generated` file — a true no-op elsewhere.
- **`generate-merged-source-file.yml`** — track `libs/resumable.py` as a shared trigger so a future change to it regenerates dependents (mirrors how `libs/utils.py` is handled).
- **README** — documents the helper and how to add a shared lib.
- **`tests/unit/libs/test_resumable.py`** — 9 unit tests for the helper directly.

## Design decisions (flagging for review)

1. **Free helper, not a base class/mixin** — avoids MRO friction with `SupportsPartition` etc.; strictly opt-in.
2. **Generic offset keys are the default for new connectors**; Collibra keeps its own keys via the adapter, because the "tests pass unchanged" gate + live checkpoint format require it.
3. **Conditional inlining** (vs always-inline like `utils.py`) to keep the diff to exactly what changed. Happy to switch to another mechanism if you have one planned for shared libs.

## Verification

- Suites: `libs` + `sparkpds` + `collibra` + `microsoft_purview` + `example` = **337 passed / 4 skipped**.
- Collibra's 17 tests pass unchanged (behavior-preserving migration).
- `pylint` 10/10 on the helper + Collibra; `ruff` clean on new files (no new findings elsewhere).
- Merged source regenerated and validated; regenerating all 29 sources touches only Collibra.

## Follow-ups (not in this PR)

- Migrate other token-death connectors (per-source token-survival check on their pagination — Rahul's list of 8).
- Optional ready-made `paginate` builders (keyset / opaque-token / offset).
